### PR TITLE
Proper ASN.1 Tagging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,24 @@
 # Changelog
 
-## 3.0
+## 4.0
 
-### NEXT
+### 4.0.0 (Supreme 0.3.0) Breaking Changes Ahead!
+* Completely revamped ASN.1 Tag Handling
+  * Properly handle multi-byte tags
+  * Introduce a new data structure `TLV.Tag` with an accompanying `TagClass` enum and a `constructed` flag to accurately represent arbitrary tags up to `ULong.MAX_VALUE`
+  * Make all `tag` parameters `ULong` to reflect support for multi-byte tags
+  * Remove `DERTags`
+  * Revamp implicit tagging (there is still work to be done, but at least it supports CONSTRUCTED ASN.1 elements)
+* Refactor `Int.Companion.decodeFromDer` -> `Int.Companion.decodeFromDerValue`
+* Refactor `Long.Companion.decodeFromDer` -> `Long.Companion.decodeFromDerValue`
+* Introduce `ULong.Companion.decodeFromDer` which can handle overlong inputs, as long as they start with a valid ULong encoding
 * Changed return type of `Verifier::verify` from `KmmResult<Unit>` to `KmmResult<Success>`. Usage is unchanged.
 * Add `ConfirmationClaim` to represent [Proof-of-Possesion Key Semantics for JWTs](https://datatracker.ietf.org/doc/html/rfc7800)
 * Add claims to `JsonWebToken` to implement [Demonstrating Proof of Possession](https://datatracker.ietf.org/doc/html/rfc9449)
 * Replace `JsonWebToken.confirmationKey` by `JsonWebToken.confirmationClaim`, the implementation was wrong
+
+
+## 3.0
 
 ### 3.7.0 (Supreme 0.2.0)
 * Remove Swift verifier logic to obtain a general speed-up

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,24 @@
   * Make all `tag` parameters `ULong` to reflect support for multi-byte tags
   * Remove `DERTags`
   * Revamp implicit tagging (there is still work to be done, but at least it supports CONSTRUCTED ASN.1 elements)
-* Refactor `Int.Companion.decodeFromDer` -> `Int.Companion.decodeFromDerValue`
-* Refactor `Long.Companion.decodeFromDer` -> `Long.Companion.decodeFromDerValue`
+* Refactor `Int.Companion.decodeFromDer` -> `Int.Companion.decodeFromDerValue()`
+* Refactor `Long.Companion.decodeFromDer` -> `Long.Companion.decodeFromDerValue()`
 * Introduce `ULong.Companion.decodeFromDer` which can handle overlong inputs, as long as they start with a valid ULong encoding
 * Changed return type of `Verifier::verify` from `KmmResult<Unit>` to `KmmResult<Success>`. Usage is unchanged.
 * Add `ConfirmationClaim` to represent [Proof-of-Possesion Key Semantics for JWTs](https://datatracker.ietf.org/doc/html/rfc7800)
 * Add claims to `JsonWebToken` to implement [Demonstrating Proof of Possession](https://datatracker.ietf.org/doc/html/rfc9449)
 * Replace `JsonWebToken.confirmationKey` by `JsonWebToken.confirmationClaim`, the implementation was wrong
-
+* Introduce `ULong.toAsn1VarInt()` to encode ULongs into ASN.1 unsigned VarInts (**not to be confused with
+  multi^2_base's`UVarInt`!**)
+* Introduce `decodeAsn1VarULong()` and `decodeAsn1VarUInt()` which can handle overlong inputs, as long as they start with a valid unsigned number encoding.
+    * Comes in three ULong flavours:
+        * `Iterator<Byte>.decodeAsn1VarULong()`
+        * `Iterable<Byte>.decodeAsn1VarULong()`
+        * `ByteArray.decodeAsn1VarULong()`
+    * and three UInt flavours:
+        * `Iterator<Byte>.decodeAsn1VarUInt()`
+        * `Iterable<Byte>.decodeAsn1VarUInt()`
+        * `ByteArray.decodeAsn1VarUInt()`
 
 ## 3.0
 

--- a/README.md
+++ b/README.md
@@ -433,7 +433,7 @@ DSL, which returns an `Asn1Structure`:
 ```kotlin
 Asn1.Sequence {
     +Tagged(1uL) {
-        +Asn1Primitive(BERTags.BOOLEAN.toUlong(), byteArrayOf(0x00))
+        +Asn1Primitive(Asn1Element.Tag.BOOL, byteArrayOf(0x00)) //or +Asn1.Bool(false)
     }
     +Asn1.Set {
         +Asn1.Sequence {

--- a/README.md
+++ b/README.md
@@ -432,8 +432,8 @@ DSL, which returns an `Asn1Structure`:
 
 ```kotlin
 Asn1.Sequence {
-    +Tagged(1u) {
-        +Asn1Primitive(BERTags.BOOLEAN, byteArrayOf(0x00))
+    +Tagged(1uL) {
+        +Asn1Primitive(BERTags.BOOLEAN.toUlong(), byteArrayOf(0x00))
     }
     +Asn1.Set {
         +Asn1.Sequence {

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,8 +2,8 @@ kotlin.code.style=official
 kotlin.js.compiler=ir
 org.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8
 
-artifactVersion=3.7.1-SNAPSHOT
-supremeVersion=0.2.1-SNAPSHOT
+artifactVersion=4.0.0-SNAPSHOT
+supremeVersion=0.3.0-SNAPSHOT
 
 # This is not a well-defined property, the ASP convention plugin respects it, though
 jdk.version=17

--- a/indispensable-cosef/src/commonMain/kotlin/at/asitplus/signum/indispensable/cosef/CoseKey.kt
+++ b/indispensable-cosef/src/commonMain/kotlin/at/asitplus/signum/indispensable/cosef/CoseKey.kt
@@ -6,7 +6,6 @@ import at.asitplus.catching
 import at.asitplus.signum.indispensable.CryptoPublicKey
 import at.asitplus.signum.indispensable.SignatureAlgorithm
 import at.asitplus.signum.indispensable.SpecializedCryptoPublicKey
-import at.asitplus.signum.indispensable.asn1.encodeToByteArray
 import at.asitplus.signum.indispensable.cosef.CoseKey.Companion.deserialize
 import at.asitplus.signum.indispensable.cosef.CoseKeySerializer.CompressedCompoundCoseKeySerialContainer
 import at.asitplus.signum.indispensable.cosef.CoseKeySerializer.UncompressedCompoundCoseKeySerialContainer
@@ -187,7 +186,7 @@ fun CryptoPublicKey.toCoseKey(algorithm: CoseAlgorithm? = null, keyId: ByteArray
                 CoseKey(
                     keyParams = CoseKeyParams.RsaParams(
                         n = n,
-                        e = e.encodeToByteArray()
+                        e = e.encodeToTwosComplementByteArray()
                     ),
                     type = CoseKeyType.RSA,
                     keyId = didEncoded.encodeToByteArray(),

--- a/indispensable-cosef/src/commonMain/kotlin/at/asitplus/signum/indispensable/cosef/CoseKey.kt
+++ b/indispensable-cosef/src/commonMain/kotlin/at/asitplus/signum/indispensable/cosef/CoseKey.kt
@@ -6,6 +6,7 @@ import at.asitplus.catching
 import at.asitplus.signum.indispensable.CryptoPublicKey
 import at.asitplus.signum.indispensable.SignatureAlgorithm
 import at.asitplus.signum.indispensable.SpecializedCryptoPublicKey
+import at.asitplus.signum.indispensable.asn1.toTwosComplementByteArray
 import at.asitplus.signum.indispensable.cosef.CoseKey.Companion.deserialize
 import at.asitplus.signum.indispensable.cosef.CoseKeySerializer.CompressedCompoundCoseKeySerialContainer
 import at.asitplus.signum.indispensable.cosef.CoseKeySerializer.UncompressedCompoundCoseKeySerialContainer
@@ -186,7 +187,7 @@ fun CryptoPublicKey.toCoseKey(algorithm: CoseAlgorithm? = null, keyId: ByteArray
                 CoseKey(
                     keyParams = CoseKeyParams.RsaParams(
                         n = n,
-                        e = e.encodeToTwosComplementByteArray()
+                        e = e.toTwosComplementByteArray()
                     ),
                     type = CoseKeyType.RSA,
                     keyId = didEncoded.encodeToByteArray(),

--- a/indispensable-cosef/src/commonMain/kotlin/at/asitplus/signum/indispensable/cosef/CoseKeyParams.kt
+++ b/indispensable-cosef/src/commonMain/kotlin/at/asitplus/signum/indispensable/cosef/CoseKeyParams.kt
@@ -5,7 +5,7 @@ import at.asitplus.KmmResult.Companion.failure
 import at.asitplus.catching
 import at.asitplus.signum.indispensable.CryptoPublicKey
 import at.asitplus.signum.indispensable.SpecializedCryptoPublicKey
-import at.asitplus.signum.indispensable.asn1.decodeFromDer
+import at.asitplus.signum.indispensable.asn1.decodeFromDerValue
 
 /**
  * Wrapper to handle parameters for different COSE public key types.
@@ -164,7 +164,7 @@ sealed class CoseKeyParams : SpecializedCryptoPublicKey {
         override fun toCryptoPublicKey(): KmmResult<CryptoPublicKey> = catching {
             CryptoPublicKey.Rsa(
                 n = n ?: throw IllegalArgumentException("Missing modulus n"),
-                e = Int.decodeFromDer(e ?:
+                e = Int.decodeFromDerValue(e ?:
                     throw IllegalArgumentException("Missing or invalid exponent e"))
             )
         }

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JsonWebKey.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JsonWebKey.kt
@@ -8,7 +8,7 @@ import at.asitplus.signum.indispensable.CryptoPublicKey
 import at.asitplus.signum.indispensable.CryptoPublicKey.EC.Companion.fromUncompressed
 import at.asitplus.signum.indispensable.ECCurve
 import at.asitplus.signum.indispensable.SpecializedCryptoPublicKey
-import at.asitplus.signum.indispensable.asn1.decodeFromDer
+import at.asitplus.signum.indispensable.asn1.decodeFromDerValue
 import at.asitplus.signum.indispensable.asn1.encodeToByteArray
 import at.asitplus.signum.indispensable.io.Base64UrlStrict
 import at.asitplus.signum.indispensable.io.ByteArrayBase64UrlSerializer
@@ -303,7 +303,7 @@ data class JsonWebKey(
             JwkType.RSA -> {
                 CryptoPublicKey.Rsa(
                     n = n ?: throw IllegalArgumentException("Missing modulus n"),
-                    e = e?.let { bytes -> Int.decodeFromDer(bytes) }
+                    e = e?.let { bytes -> Int.decodeFromDerValue(bytes) }
                         ?: throw IllegalArgumentException("Missing or invalid exponent e")
                 ).apply { jwkId = keyId }
             }

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JsonWebKey.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JsonWebKey.kt
@@ -9,6 +9,7 @@ import at.asitplus.signum.indispensable.CryptoPublicKey.EC.Companion.fromUncompr
 import at.asitplus.signum.indispensable.ECCurve
 import at.asitplus.signum.indispensable.SpecializedCryptoPublicKey
 import at.asitplus.signum.indispensable.asn1.decodeFromDerValue
+import at.asitplus.signum.indispensable.asn1.toTwosComplementByteArray
 import at.asitplus.signum.indispensable.io.Base64UrlStrict
 import at.asitplus.signum.indispensable.io.ByteArrayBase64UrlSerializer
 import at.asitplus.signum.indispensable.josef.io.JwsCertificateSerializer
@@ -362,7 +363,7 @@ fun CryptoPublicKey.toJsonWebKey(keyId: String? = this.jwkId): JsonWebKey =
                 type = JwkType.RSA,
                 keyId = keyId,
                 n = n,
-                e = e.encodeToTwosComplementByteArray()
+                e = e.toTwosComplementByteArray()
             )
     }
 

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JsonWebKey.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JsonWebKey.kt
@@ -9,7 +9,6 @@ import at.asitplus.signum.indispensable.CryptoPublicKey.EC.Companion.fromUncompr
 import at.asitplus.signum.indispensable.ECCurve
 import at.asitplus.signum.indispensable.SpecializedCryptoPublicKey
 import at.asitplus.signum.indispensable.asn1.decodeFromDerValue
-import at.asitplus.signum.indispensable.asn1.encodeToByteArray
 import at.asitplus.signum.indispensable.io.Base64UrlStrict
 import at.asitplus.signum.indispensable.io.ByteArrayBase64UrlSerializer
 import at.asitplus.signum.indispensable.josef.io.JwsCertificateSerializer
@@ -363,7 +362,7 @@ fun CryptoPublicKey.toJsonWebKey(keyId: String? = this.jwkId): JsonWebKey =
                 type = JwkType.RSA,
                 keyId = keyId,
                 n = n,
-                e = e.encodeToByteArray()
+                e = e.encodeToTwosComplementByteArray()
             )
     }
 

--- a/indispensable-josef/src/jvmTest/kotlin/at/asitplus/signum/indispensable/josef/JsonWebKeyJvmTest.kt
+++ b/indispensable-josef/src/jvmTest/kotlin/at/asitplus/signum/indispensable/josef/JsonWebKeyJvmTest.kt
@@ -4,6 +4,7 @@ import at.asitplus.signum.indispensable.CryptoPublicKey
 import at.asitplus.signum.indispensable.CryptoPublicKey.EC.Companion.fromUncompressed
 import at.asitplus.signum.indispensable.ECCurve
 import at.asitplus.signum.indispensable.asn1.ensureSize
+import at.asitplus.signum.indispensable.asn1.toTwosComplementByteArray
 import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
@@ -59,7 +60,7 @@ class JsonWebKeyJvmTest : FreeSpec({
 
         jwk.shouldNotBeNull()
         jwk.n shouldBe nFromBc
-        jwk.e shouldBe eFromBc.encodeToTwosComplementByteArray()
+        jwk.e shouldBe eFromBc.toTwosComplementByteArray()
         jwk.keyId.shouldNotBeNull()
 
         "it can be converted back to CryptoPublicKey" {

--- a/indispensable-josef/src/jvmTest/kotlin/at/asitplus/signum/indispensable/josef/JsonWebKeyJvmTest.kt
+++ b/indispensable-josef/src/jvmTest/kotlin/at/asitplus/signum/indispensable/josef/JsonWebKeyJvmTest.kt
@@ -3,7 +3,6 @@ package at.asitplus.signum.indispensable.josef
 import at.asitplus.signum.indispensable.CryptoPublicKey
 import at.asitplus.signum.indispensable.CryptoPublicKey.EC.Companion.fromUncompressed
 import at.asitplus.signum.indispensable.ECCurve
-import at.asitplus.signum.indispensable.asn1.encodeToByteArray
 import at.asitplus.signum.indispensable.asn1.ensureSize
 import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.nulls.shouldNotBeNull
@@ -60,7 +59,7 @@ class JsonWebKeyJvmTest : FreeSpec({
 
         jwk.shouldNotBeNull()
         jwk.n shouldBe nFromBc
-        jwk.e shouldBe eFromBc.encodeToByteArray()
+        jwk.e shouldBe eFromBc.encodeToTwosComplementByteArray()
         jwk.keyId.shouldNotBeNull()
 
         "it can be converted back to CryptoPublicKey" {

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/CryptoPublicKey.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/CryptoPublicKey.kt
@@ -128,7 +128,7 @@ sealed class CryptoPublicKey : Asn1Encodable<Asn1Sequence>, Identifiable {
                     (keyInfo.nextChild() as Asn1Primitive).readNull()
                     val bitString = (src.nextChild() as Asn1Primitive).readBitString()
                     val rsaSequence = Asn1Element.parse(bitString.rawBytes) as Asn1Sequence
-                    val n = (rsaSequence.nextChild() as Asn1Primitive).decode(BERTags.INTEGER.toULong()) { it }
+                    val n = (rsaSequence.nextChild() as Asn1Primitive).decode(Asn1Element.Tag.INT) { it }
                     val e = (rsaSequence.nextChild() as Asn1Primitive).readInt()
                     if (rsaSequence.hasMoreChildren()) throw Asn1StructuralException("Superfluous data in SPKI!")
                     return Rsa(n, e)
@@ -156,6 +156,7 @@ sealed class CryptoPublicKey : Asn1Encodable<Asn1Sequence>, Identifiable {
                     EC.fromAnsiX963Bytes(curve, it)
                 }
 
+                //TODO: this could be nicer, maybe?
                 (BERTags.SEQUENCE or BERTags.CONSTRUCTED) -> Rsa.fromPKCS1encoded(it)
                 else -> throw IllegalArgumentException("Unsupported Key type")
             }
@@ -246,7 +247,7 @@ sealed class CryptoPublicKey : Asn1Encodable<Asn1Sequence>, Identifiable {
         val pkcsEncoded by lazy {
             Asn1.Sequence {
                 +Asn1Primitive(
-                    BERTags.INTEGER.toULong(),
+                    Asn1Element.Tag.INT,
                     n.ensureSize(bits.number / 8u)
                         .let { if (it.first() == 0x00.toByte()) it else byteArrayOf(0x00, *it) })
 
@@ -280,7 +281,7 @@ sealed class CryptoPublicKey : Asn1Encodable<Asn1Sequence>, Identifiable {
             @Throws(Asn1Exception::class)
             fun fromPKCS1encoded(input: ByteArray): Rsa = runRethrowing {
                 val conv = Asn1Element.parse(input) as Asn1Sequence
-                val n = (conv.nextChild() as Asn1Primitive).decode(BERTags.INTEGER.toULong()) { it }
+                val n = (conv.nextChild() as Asn1Primitive).decode(Asn1Element.Tag.INT) { it }
                 val e = (conv.nextChild() as Asn1Primitive).readInt()
                 if (conv.hasMoreChildren()) throw Asn1StructuralException("Superfluous bytes")
                 return Rsa(Size.of(n), n, e)

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/CryptoPublicKey.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/CryptoPublicKey.kt
@@ -128,7 +128,7 @@ sealed class CryptoPublicKey : Asn1Encodable<Asn1Sequence>, Identifiable {
                     (keyInfo.nextChild() as Asn1Primitive).readNull()
                     val bitString = (src.nextChild() as Asn1Primitive).readBitString()
                     val rsaSequence = Asn1Element.parse(bitString.rawBytes) as Asn1Sequence
-                    val n = (rsaSequence.nextChild() as Asn1Primitive).decode(BERTags.INTEGER.toUInt()) { it }
+                    val n = (rsaSequence.nextChild() as Asn1Primitive).decode(BERTags.INTEGER.toULong()) { it }
                     val e = (rsaSequence.nextChild() as Asn1Primitive).readInt()
                     if (rsaSequence.hasMoreChildren()) throw Asn1StructuralException("Superfluous data in SPKI!")
                     return Rsa(n, e)
@@ -246,7 +246,7 @@ sealed class CryptoPublicKey : Asn1Encodable<Asn1Sequence>, Identifiable {
         val pkcsEncoded by lazy {
             Asn1.Sequence {
                 +Asn1Primitive(
-                    BERTags.INTEGER.toUInt(),
+                    BERTags.INTEGER.toULong(),
                     n.ensureSize(bits.number / 8u)
                         .let { if (it.first() == 0x00.toByte()) it else byteArrayOf(0x00, *it) })
 
@@ -280,7 +280,7 @@ sealed class CryptoPublicKey : Asn1Encodable<Asn1Sequence>, Identifiable {
             @Throws(Asn1Exception::class)
             fun fromPKCS1encoded(input: ByteArray): Rsa = runRethrowing {
                 val conv = Asn1Element.parse(input) as Asn1Sequence
-                val n = (conv.nextChild() as Asn1Primitive).decode(BERTags.INTEGER.toUInt()) { it }
+                val n = (conv.nextChild() as Asn1Primitive).decode(BERTags.INTEGER.toULong()) { it }
                 val e = (conv.nextChild() as Asn1Primitive).readInt()
                 if (conv.hasMoreChildren()) throw Asn1StructuralException("Superfluous bytes")
                 return Rsa(Size.of(n), n, e)

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/CryptoPublicKey.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/CryptoPublicKey.kt
@@ -128,7 +128,7 @@ sealed class CryptoPublicKey : Asn1Encodable<Asn1Sequence>, Identifiable {
                     (keyInfo.nextChild() as Asn1Primitive).readNull()
                     val bitString = (src.nextChild() as Asn1Primitive).readBitString()
                     val rsaSequence = Asn1Element.parse(bitString.rawBytes) as Asn1Sequence
-                    val n = (rsaSequence.nextChild() as Asn1Primitive).decode(BERTags.INTEGER) { it }
+                    val n = (rsaSequence.nextChild() as Asn1Primitive).decode(BERTags.INTEGER.toUInt()) { it }
                     val e = (rsaSequence.nextChild() as Asn1Primitive).readInt()
                     if (rsaSequence.hasMoreChildren()) throw Asn1StructuralException("Superfluous data in SPKI!")
                     return Rsa(n, e)
@@ -156,7 +156,7 @@ sealed class CryptoPublicKey : Asn1Encodable<Asn1Sequence>, Identifiable {
                     EC.fromAnsiX963Bytes(curve, it)
                 }
 
-                DERTags.DER_SEQUENCE -> Rsa.fromPKCS1encoded(it)
+                (BERTags.SEQUENCE or BERTags.CONSTRUCTED) -> Rsa.fromPKCS1encoded(it)
                 else -> throw IllegalArgumentException("Unsupported Key type")
             }
     }
@@ -246,7 +246,7 @@ sealed class CryptoPublicKey : Asn1Encodable<Asn1Sequence>, Identifiable {
         val pkcsEncoded by lazy {
             Asn1.Sequence {
                 +Asn1Primitive(
-                    BERTags.INTEGER,
+                    BERTags.INTEGER.toUInt(),
                     n.ensureSize(bits.number / 8u)
                         .let { if (it.first() == 0x00.toByte()) it else byteArrayOf(0x00, *it) })
 
@@ -280,7 +280,7 @@ sealed class CryptoPublicKey : Asn1Encodable<Asn1Sequence>, Identifiable {
             @Throws(Asn1Exception::class)
             fun fromPKCS1encoded(input: ByteArray): Rsa = runRethrowing {
                 val conv = Asn1Element.parse(input) as Asn1Sequence
-                val n = (conv.nextChild() as Asn1Primitive).decode(BERTags.INTEGER) { it }
+                val n = (conv.nextChild() as Asn1Primitive).decode(BERTags.INTEGER.toUInt()) { it }
                 val e = (conv.nextChild() as Asn1Primitive).readInt()
                 if (conv.hasMoreChildren()) throw Asn1StructuralException("Superfluous bytes")
                 return Rsa(Size.of(n), n, e)

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/CryptoSignature.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/CryptoSignature.kt
@@ -1,7 +1,6 @@
 package at.asitplus.signum.indispensable
 
 import at.asitplus.signum.indispensable.asn1.*
-import at.asitplus.signum.indispensable.asn1.BERTags.BIT_STRING
 import at.asitplus.signum.indispensable.io.Base64Strict
 import at.asitplus.signum.indispensable.misc.BitLength
 import at.asitplus.signum.indispensable.misc.max
@@ -229,9 +228,9 @@ sealed interface CryptoSignature : Asn1Encodable<Asn1Element> {
 
     class RSAorHMAC(input: ByteArray) : CryptoSignature, RawByteEncodable {
 
-        override val signature: Asn1Element = Asn1Primitive(BIT_STRING.toULong(), input)
+        override val signature: Asn1Element = Asn1Primitive(Asn1Element.Tag.BIT_STRING, input)
 
-        override val rawByteArray by lazy { (signature as Asn1Primitive).decode(BIT_STRING.toULong()) { it } }
+        override val rawByteArray by lazy { (signature as Asn1Primitive).decode(Asn1Element.Tag.BIT_STRING) { it } }
         override fun encodeToTlvBitString(): Asn1Element = this.encodeToTlv()
 
         override fun hashCode(): Int = signature.hashCode()
@@ -258,9 +257,9 @@ sealed interface CryptoSignature : Asn1Encodable<Asn1Element> {
     companion object : Asn1Decodable<Asn1Element, CryptoSignature> {
         @Throws(Asn1Exception::class)
         override fun decodeFromTlv(src: Asn1Element): CryptoSignature = runRethrowing {
-            when (src.tag.tagValue) {
-                BIT_STRING.toULong() -> RSAorHMAC((src as Asn1Primitive).decode(BIT_STRING.toULong()) { it })
-                (BERTags.SEQUENCE).toULong() -> EC.decodeFromTlv(src as Asn1Sequence)
+            when (src.tag) {
+                Asn1Element.Tag.BIT_STRING -> RSAorHMAC((src as Asn1Primitive).decode(Asn1Element.Tag.BIT_STRING) { it })
+                Asn1Element.Tag.ASN1_SEQUENCE -> EC.decodeFromTlv(src as Asn1Sequence)
 
                 else -> throw Asn1Exception("Unknown Signature Format")
             }

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/CryptoSignature.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/CryptoSignature.kt
@@ -229,9 +229,9 @@ sealed interface CryptoSignature : Asn1Encodable<Asn1Element> {
 
     class RSAorHMAC(input: ByteArray) : CryptoSignature, RawByteEncodable {
 
-        override val signature: Asn1Element = Asn1Primitive(BIT_STRING.toUInt(), input)
+        override val signature: Asn1Element = Asn1Primitive(BIT_STRING.toULong(), input)
 
-        override val rawByteArray by lazy { (signature as Asn1Primitive).decode(BIT_STRING.toUInt()) { it } }
+        override val rawByteArray by lazy { (signature as Asn1Primitive).decode(BIT_STRING.toULong()) { it } }
         override fun encodeToTlvBitString(): Asn1Element = this.encodeToTlv()
 
         override fun hashCode(): Int = signature.hashCode()
@@ -259,8 +259,8 @@ sealed interface CryptoSignature : Asn1Encodable<Asn1Element> {
         @Throws(Asn1Exception::class)
         override fun decodeFromTlv(src: Asn1Element): CryptoSignature = runRethrowing {
             when (src.tag.tagValue) {
-                BIT_STRING.toUInt() -> RSAorHMAC((src as Asn1Primitive).decode(BIT_STRING.toUInt()) { it })
-                (BERTags.SEQUENCE).toUInt() -> EC.decodeFromTlv(src as Asn1Sequence)
+                BIT_STRING.toULong() -> RSAorHMAC((src as Asn1Primitive).decode(BIT_STRING.toULong()) { it })
+                (BERTags.SEQUENCE).toULong() -> EC.decodeFromTlv(src as Asn1Sequence)
 
                 else -> throw Asn1Exception("Unknown Signature Format")
             }

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/CryptoSignature.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/CryptoSignature.kt
@@ -2,7 +2,6 @@ package at.asitplus.signum.indispensable
 
 import at.asitplus.signum.indispensable.asn1.*
 import at.asitplus.signum.indispensable.asn1.BERTags.BIT_STRING
-import at.asitplus.signum.indispensable.asn1.DERTags.DER_SEQUENCE
 import at.asitplus.signum.indispensable.io.Base64Strict
 import at.asitplus.signum.indispensable.misc.BitLength
 import at.asitplus.signum.indispensable.misc.max
@@ -230,9 +229,9 @@ sealed interface CryptoSignature : Asn1Encodable<Asn1Element> {
 
     class RSAorHMAC(input: ByteArray) : CryptoSignature, RawByteEncodable {
 
-        override val signature: Asn1Element = Asn1Primitive(BIT_STRING, input)
+        override val signature: Asn1Element = Asn1Primitive(BIT_STRING.toUInt(), input)
 
-        override val rawByteArray by lazy { (signature as Asn1Primitive).decode(BIT_STRING) { it } }
+        override val rawByteArray by lazy { (signature as Asn1Primitive).decode(BIT_STRING.toUInt()) { it } }
         override fun encodeToTlvBitString(): Asn1Element = this.encodeToTlv()
 
         override fun hashCode(): Int = signature.hashCode()
@@ -259,9 +258,9 @@ sealed interface CryptoSignature : Asn1Encodable<Asn1Element> {
     companion object : Asn1Decodable<Asn1Element, CryptoSignature> {
         @Throws(Asn1Exception::class)
         override fun decodeFromTlv(src: Asn1Element): CryptoSignature = runRethrowing {
-            when (src.tag) {
-                BIT_STRING -> RSAorHMAC((src as Asn1Primitive).decode(BIT_STRING) { it })
-                DER_SEQUENCE -> EC.decodeFromTlv(src as Asn1Sequence)
+            when (src.tag.tagValue) {
+                BIT_STRING.toUInt() -> RSAorHMAC((src as Asn1Primitive).decode(BIT_STRING.toUInt()) { it })
+                (BERTags.SEQUENCE).toUInt() -> EC.decodeFromTlv(src as Asn1Sequence)
 
                 else -> throw Asn1Exception("Unknown Signature Format")
             }

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/X509SignatureAlgorithm.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/X509SignatureAlgorithm.kt
@@ -119,8 +119,8 @@ enum class X509SignatureAlgorithm(
                 RS256.oid, RS384.oid, RS512.oid,
                 HS256.oid, HS384.oid, HS512.oid -> fromOid(oid).also {
                     val tag = src.nextChild().tag
-                    if (tag.tagValue != BERTags.ASN1_NULL.toULong())
-                        throw Asn1TagMismatchException(TLV.Tag(BERTags.ASN1_NULL.toULong(), constructed = false), tag, "RSA Params not allowed.")
+                    if (tag != Asn1Element.Tag.NULL)
+                        throw Asn1TagMismatchException(Asn1Element.Tag.NULL, tag, "RSA Params not allowed.")
                 }
 
                 PS256.oid, PS384.oid, PS512.oid -> parsePssParams(src)
@@ -135,8 +135,8 @@ enum class X509SignatureAlgorithm(
 
             val sigAlg = (first.nextChild() as Asn1Primitive).readOid()
             val tag = first.nextChild().tag
-            if (tag.tagValue != BERTags.ASN1_NULL.toULong())
-                throw Asn1TagMismatchException(TLV.Tag(BERTags.ASN1_NULL.toULong(), constructed = false), tag, "PSS Params not supported yet")
+            if (tag != Asn1Element.Tag.NULL)
+                throw Asn1TagMismatchException(Asn1Element.Tag.NULL, tag, "PSS Params not supported yet")
 
             val second = (seq.nextChild() as Asn1Tagged).verifyTag(1u).single() as Asn1Sequence
             val mgf = (second.nextChild() as Asn1Primitive).readOid()
@@ -145,7 +145,7 @@ enum class X509SignatureAlgorithm(
             val innerHash = (inner.nextChild() as Asn1Primitive).readOid()
             if (innerHash != sigAlg) throw IllegalArgumentException("HashFunction mismatch! Expected: $sigAlg, is: $innerHash")
 
-            if (inner.nextChild().tag.tagValue != BERTags.ASN1_NULL.toULong()) throw IllegalArgumentException(
+            if (inner.nextChild().tag != Asn1Element.Tag.NULL) throw IllegalArgumentException(
                 "PSS Params not supported yet"
             )
 

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/X509SignatureAlgorithm.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/X509SignatureAlgorithm.kt
@@ -41,14 +41,14 @@ enum class X509SignatureAlgorithm(
     // RSASSA-PKCS1-v1_5 using SHA-1
     RS1(KnownOIDs.sha1WithRSAEncryption);
 
-    private fun encodePSSParams(bits: Int): Asn1Sequence {
-        val shaOid = when (bits) {
+    private fun encodePSSParams(bits: Int): Asn1Sequence =
+        when (bits) {
             256 -> KnownOIDs.sha_256
             384 -> KnownOIDs.sha_384
             512 -> KnownOIDs.sha_512
             else -> TODO()
-        }
-        return Asn1.Sequence {
+        }.let { shaOid ->
+            Asn1.Sequence {
             +oid
             +Asn1.Sequence {
                 +Tagged(0u) {

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/X509SignatureAlgorithm.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/X509SignatureAlgorithm.kt
@@ -119,8 +119,8 @@ enum class X509SignatureAlgorithm(
                 RS256.oid, RS384.oid, RS512.oid,
                 HS256.oid, HS384.oid, HS512.oid -> fromOid(oid).also {
                     val tag = src.nextChild().tag
-                    if (tag.tagValue != BERTags.ASN1_NULL.toUInt())
-                        throw Asn1TagMismatchException(TLV.Tag(BERTags.ASN1_NULL.toUInt(), constructed = false), tag, "RSA Params not allowed.")
+                    if (tag.tagValue != BERTags.ASN1_NULL.toULong())
+                        throw Asn1TagMismatchException(TLV.Tag(BERTags.ASN1_NULL.toULong(), constructed = false), tag, "RSA Params not allowed.")
                 }
 
                 PS256.oid, PS384.oid, PS512.oid -> parsePssParams(src)
@@ -135,8 +135,8 @@ enum class X509SignatureAlgorithm(
 
             val sigAlg = (first.nextChild() as Asn1Primitive).readOid()
             val tag = first.nextChild().tag
-            if (tag.tagValue != BERTags.ASN1_NULL.toUInt())
-                throw Asn1TagMismatchException(TLV.Tag(BERTags.ASN1_NULL.toUInt(), constructed = false), tag, "PSS Params not supported yet")
+            if (tag.tagValue != BERTags.ASN1_NULL.toULong())
+                throw Asn1TagMismatchException(TLV.Tag(BERTags.ASN1_NULL.toULong(), constructed = false), tag, "PSS Params not supported yet")
 
             val second = (seq.nextChild() as Asn1Tagged).verifyTag(1u).single() as Asn1Sequence
             val mgf = (second.nextChild() as Asn1Primitive).readOid()
@@ -145,7 +145,7 @@ enum class X509SignatureAlgorithm(
             val innerHash = (inner.nextChild() as Asn1Primitive).readOid()
             if (innerHash != sigAlg) throw IllegalArgumentException("HashFunction mismatch! Expected: $sigAlg, is: $innerHash")
 
-            if (inner.nextChild().tag.tagValue != BERTags.ASN1_NULL.toUInt()) throw IllegalArgumentException(
+            if (inner.nextChild().tag.tagValue != BERTags.ASN1_NULL.toULong()) throw IllegalArgumentException(
                 "PSS Params not supported yet"
             )
 

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/Asn1BitString.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/Asn1BitString.kt
@@ -82,7 +82,7 @@ class Asn1BitString private constructor(
 
         @Throws(Asn1Exception::class)
         private fun decode(src: Asn1Primitive, tagOverride: TLV.Tag? = null): Asn1BitString {
-            val expected = tagOverride ?: TLV.Tag(BERTags.BIT_STRING.toUInt(), constructed = false)
+            val expected = tagOverride ?: TLV.Tag(BERTags.BIT_STRING.toULong(), constructed = false)
             if (src.tag != expected)
                 throw Asn1TagMismatchException(expected, src.tag)
             if (src.length == 0) return Asn1BitString(0, byteArrayOf())
@@ -97,7 +97,7 @@ class Asn1BitString private constructor(
         override fun decodeFromTlv(src: Asn1Primitive, tagOverride: TLV.Tag?) = decode(src, tagOverride)
     }
 
-    override fun encodeToTlv() = Asn1Primitive(BERTags.BIT_STRING.toUInt(), byteArrayOf(numPaddingBits, *rawBytes))
+    override fun encodeToTlv() = Asn1Primitive(BERTags.BIT_STRING.toULong(), byteArrayOf(numPaddingBits, *rawBytes))
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other == null || this::class != other::class) return false

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/Asn1BitString.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/Asn1BitString.kt
@@ -81,9 +81,10 @@ class Asn1BitString private constructor(
         }
 
         @Throws(Asn1Exception::class)
-        private fun decode(src: Asn1Primitive, tagOverride: UByte? = null): Asn1BitString {
-            if (src.tag != (tagOverride ?: BERTags.BIT_STRING))
-                throw Asn1TagMismatchException(tagOverride ?: BERTags.BIT_STRING, src.tag)
+        private fun decode(src: Asn1Primitive, tagOverride: TLV.Tag? = null): Asn1BitString {
+            val expected = tagOverride ?: TLV.Tag(BERTags.BIT_STRING.toUInt(), constructed = false)
+            if (src.tag != expected)
+                throw Asn1TagMismatchException(expected, src.tag)
             if (src.length == 0) return Asn1BitString(0, byteArrayOf())
             if (src.content.first() > 7) throw Asn1Exception("Number of padding bits < 7")
             return Asn1BitString(src.content[0], src.content.sliceArray(1..<src.content.size))
@@ -93,10 +94,10 @@ class Asn1BitString private constructor(
         override fun decodeFromTlv(src: Asn1Primitive) = decodeFromTlv(src, null)
 
         @Throws(Asn1Exception::class)
-        override fun decodeFromTlv(src: Asn1Primitive, tagOverride: UByte?) = decode(src, tagOverride)
+        override fun decodeFromTlv(src: Asn1Primitive, tagOverride: TLV.Tag?) = decode(src, tagOverride)
     }
 
-    override fun encodeToTlv() = Asn1Primitive(BERTags.BIT_STRING, byteArrayOf(numPaddingBits, *rawBytes))
+    override fun encodeToTlv() = Asn1Primitive(BERTags.BIT_STRING.toUInt(), byteArrayOf(numPaddingBits, *rawBytes))
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other == null || this::class != other::class) return false

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/Asn1BitString.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/Asn1BitString.kt
@@ -81,8 +81,8 @@ class Asn1BitString private constructor(
         }
 
         @Throws(Asn1Exception::class)
-        private fun decode(src: Asn1Primitive, tagOverride: TLV.Tag? = null): Asn1BitString {
-            val expected = tagOverride ?: TLV.Tag(BERTags.BIT_STRING.toULong(), constructed = false)
+        private fun decode(src: Asn1Primitive, tagOverride: Asn1Element.Tag? = null): Asn1BitString {
+            val expected = tagOverride ?: Asn1Element.Tag.BIT_STRING
             if (src.tag != expected)
                 throw Asn1TagMismatchException(expected, src.tag)
             if (src.length == 0) return Asn1BitString(0, byteArrayOf())
@@ -94,10 +94,10 @@ class Asn1BitString private constructor(
         override fun decodeFromTlv(src: Asn1Primitive) = decodeFromTlv(src, null)
 
         @Throws(Asn1Exception::class)
-        override fun decodeFromTlv(src: Asn1Primitive, tagOverride: TLV.Tag?) = decode(src, tagOverride)
+        override fun decodeFromTlv(src: Asn1Primitive, tagOverride: Asn1Element.Tag?) = decode(src, tagOverride)
     }
 
-    override fun encodeToTlv() = Asn1Primitive(BERTags.BIT_STRING.toULong(), byteArrayOf(numPaddingBits, *rawBytes))
+    override fun encodeToTlv() = Asn1Primitive(Asn1Element.Tag.BIT_STRING, byteArrayOf(numPaddingBits, *rawBytes))
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other == null || this::class != other::class) return false

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/Asn1Decoding.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/Asn1Decoding.kt
@@ -215,7 +215,7 @@ fun Asn1Primitive.readNullOrNull() = catching { readNull() }.getOrNull()
  */
 @Throws(Asn1TagMismatchException::class)
 fun Asn1Tagged.verifyTag(tag: UInt): List<Asn1Element> {
-    val explicitTag= TLV.Tag(tag,constructed = true,TagClass.CONTEXT_SPECIFIC)
+    val explicitTag = TLV.Tag(tag, constructed = true, TagClass.CONTEXT_SPECIFIC)
     if (this.tag != explicitTag) throw Asn1TagMismatchException(explicitTag, this.tag)
     return this.children
 }
@@ -332,8 +332,7 @@ private fun ByteArray.readTlv(): TLV = runRethrowing {
             throw IllegalArgumentException("Out of bytes")
         val value = this.drop(offset + 3).take(length).toByteArray()
         return TLV(TLV.Tag(tagBytes), value)
-    }
-    if (firstLength == 0x81.toByte()) {
+    } else if (firstLength == 0x81.toByte()) {
         if (this.size < offset + 2)
             throw IllegalArgumentException("Can't decode length")
         val length = this[offset + 1].toUByte().toInt()
@@ -341,15 +340,14 @@ private fun ByteArray.readTlv(): TLV = runRethrowing {
             throw IllegalArgumentException("Out of bytes")
         val value = this.drop(offset + 2).take(length).toByteArray()
         return TLV(TLV.Tag(tagBytes), value)
+    } else {
+        val length = firstLength.toUByte().toInt()
+        if (this.size < offset + 1 + length)
+            throw IllegalArgumentException("Out of bytes")
+        val value = this.drop(offset + 1).take(length).toByteArray()
+        // TODO end
+        return TLV(TLV.Tag(tagBytes), value)
     }
-    val length = firstLength.toUByte().toInt()
-    if (this.size < offset + 1 + length)
-        throw IllegalArgumentException("Out of bytes")
-
-    val value = this.drop(offset + 1).take(length).toByteArray()
-    // TODO end
-
-    return TLV(TLV.Tag(tagBytes), value)
 }
 
 private infix fun UByte.ushr(bits: Int) = toInt() ushr bits

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/Asn1Decoding.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/Asn1Decoding.kt
@@ -38,7 +38,7 @@ private class Asn1Reader(input: ByteArray) {
         while (rest.isNotEmpty()) {
             val tlv = read()
             if (tlv.isSequence()) result.add(Asn1Sequence(Asn1Reader(tlv.content).doParse()))
-            else if (tlv.isSet()) result.add(Asn1Set(Asn1Reader(tlv.content).doParse(), dontSort = true))
+            else if (tlv.isSet()) result.add(Asn1Set.fromPresorted(Asn1Reader(tlv.content).doParse()))
             else if (tlv.isExplicitlyTagged()) result.add(
                 Asn1Tagged(
                     tlv.tag.tagValue,

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/Asn1Decoding.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/Asn1Decoding.kt
@@ -307,7 +307,8 @@ fun UInt.Companion.decodeFromDerValue(bytes: ByteArray): UInt = runRethrowing { 
 fun ULong.Companion.decodeFromDerValue(bytes: ByteArray): ULong = runRethrowing { fromTwosComplementByteArray(bytes) }
 
 @Throws(Asn1Exception::class)
-fun BigInteger.Companion.decodeFromDerValue(bytes: ByteArray): BigInteger = runRethrowing { fromTwosComplementByteArray(bytes) }
+fun BigInteger.Companion.decodeFromDerValue(bytes: ByteArray): BigInteger =
+    runRethrowing { fromTwosComplementByteArray(bytes) }
 
 
 @Throws(Asn1Exception::class)
@@ -390,8 +391,7 @@ fun Iterator<Byte>.decodeAsn1VarULong(): Pair<ULong, ByteArray> {
     while (hasNext()) {
         val current = next().toUByte()
         accumulator += current.toByte()
-        if (offset == 0) result = (current and 0x7F.toUByte()).toULong()
-        else if (current >= 0x80.toUByte()) {
+        if (current >= 0x80.toUByte()) {
             result = (current and 0x7F.toUByte()).toULong() or (result shl 7)
         } else {
             result = (current and 0x7F.toUByte()).toULong() or (result shl 7)
@@ -437,8 +437,7 @@ fun Iterator<Byte>.decodeAsn1VarUInt(): Pair<UInt, ByteArray> {
     while (hasNext()) {
         val current = next().toUByte()
         accumulator += current.toByte()
-        if (offset == 0) result = (current and 0x7F.toUByte()).toUInt()
-        else if (current >= 0x80.toUByte()) {
+        if (current >= 0x80.toUByte()) {
             result = (current and 0x7F.toUByte()).toUInt() or (result shl 7)
         } else {
             result = (current and 0x7F.toUByte()).toUInt() or (result shl 7)

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/Asn1Decoding.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/Asn1Decoding.kt
@@ -46,7 +46,7 @@ private class Asn1Reader(input: ByteArray) {
                 )
             )
             else if (tlv.tag == Asn1Element.Tag.OCTET_STRING) {
-               catching{
+                catching {
                     result.add(Asn1EncapsulatingOctetString(Asn1Reader(tlv.content).doParse()))
                 }.getOrElse {
                     result.add(Asn1PrimitiveOctetString(tlv.content))
@@ -234,17 +234,19 @@ fun Asn1Tagged.verifyTagOrNull(tag: ULong) = catching { verifyTag(tag) }.getOrNu
 @Throws(Asn1Exception::class)
 inline fun <reified T> Asn1Primitive.decode(tag: ULong, transform: (content: ByteArray) -> T): T =
     decode(Asn1Element.Tag(tag, constructed = false), transform)
+
 /**
  * Generic decoding function. Verifies that this [Asn1Primitive]'s tag matches [tag]
  * and transforms its content as per [transform]
  * @throws Asn1Exception all sorts of exceptions on invalid input
  */
 @Throws(Asn1Exception::class)
-inline fun <reified T> Asn1Primitive.decode(tag: Asn1Element.Tag, transform: (content: ByteArray) -> T) = runRethrowing {
-    if(tag.isConstructed) throw IllegalArgumentException("A primitive cannot have a CONSTRUCTED tag")
-    if (tag != this.tag) throw Asn1TagMismatchException(tag, this.tag)
-    transform(content)
-}
+inline fun <reified T> Asn1Primitive.decode(tag: Asn1Element.Tag, transform: (content: ByteArray) -> T) =
+    runRethrowing {
+        if (tag.isConstructed) throw IllegalArgumentException("A primitive cannot have a CONSTRUCTED tag")
+        if (tag != this.tag) throw Asn1TagMismatchException(tag, this.tag)
+        transform(content)
+    }
 
 /**
  * Exception-free version of [decode]

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/Asn1Decoding.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/Asn1Decoding.kt
@@ -1,8 +1,6 @@
 package at.asitplus.signum.indispensable.asn1
 
 import at.asitplus.catching
-import at.asitplus.io.UVarInt
-import at.asitplus.io.varIntDecode
 import at.asitplus.signum.indispensable.asn1.BERTags.ASN1_NULL
 import at.asitplus.signum.indispensable.asn1.BERTags.BMP_STRING
 import at.asitplus.signum.indispensable.asn1.BERTags.BOOLEAN
@@ -52,7 +50,7 @@ private class Asn1Reader(input: ByteArray) {
                     Asn1Reader(tlv.content).doParse()
                 )
             )
-            else if (tlv.tag.tagValue == OCTET_STRING.toUInt()) {
+            else if (tlv.tag.tagValue == OCTET_STRING.toULong()) {
                 kotlin.runCatching { //TODO: make catching again, not runCatching
                     result.add(Asn1EncapsulatingOctetString(Asn1Reader(tlv.content).doParse()))
                 }.getOrElse {
@@ -66,8 +64,8 @@ private class Asn1Reader(input: ByteArray) {
         return result
     }
 
-    private fun TLV.isSet() = tag.tagValue == BERTags.SET.toUInt() && tag.isConstructed
-    private fun TLV.isSequence() = tag.tagValue == BERTags.SEQUENCE.toUInt() && tag.isConstructed
+    private fun TLV.isSet() = tag.tagValue == BERTags.SET.toULong() && tag.isConstructed
+    private fun TLV.isSequence() = tag.tagValue == BERTags.SEQUENCE.toULong() && tag.isConstructed
     private fun TLV.isExplicitlyTagged() = tag.isExplicitlyTagged
 
     @Throws(Asn1Exception::class)
@@ -86,7 +84,7 @@ private class Asn1Reader(input: ByteArray) {
  * @throws [Throwable] all sorts of exceptions on invalid input
  */
 @Throws(Asn1Exception::class)
-fun Asn1Primitive.readInt() = runRethrowing { decode(INTEGER.toUInt()) { Int.decodeFromDer(it) } }
+fun Asn1Primitive.readInt() = runRethrowing { decode(INTEGER.toULong()) { Int.decodeFromDer(it) } }
 
 /**
  * decodes this [Asn1Primitive]'s content into an [Boolean]
@@ -95,7 +93,7 @@ fun Asn1Primitive.readInt() = runRethrowing { decode(INTEGER.toUInt()) { Int.dec
  */
 @Throws(Asn1Exception::class)
 fun Asn1Primitive.readBool() = runRethrowing {
-    decode(BOOLEAN.toUInt()) {
+    decode(BOOLEAN.toULong()) {
         if (it.size != 1) throw Asn1Exception("Not a Boolean!")
         when (it.first().toUByte()) {
             0.toUByte() -> false
@@ -110,7 +108,7 @@ fun Asn1Primitive.readBool() = runRethrowing {
  */
 @Throws(Asn1Exception::class)
 fun Asn1Primitive.readBigInteger() =
-    decode(INTEGER.toUInt()) { BigInteger.fromTwosComplementByteArray(it) }
+    decode(INTEGER.toULong()) { BigInteger.fromTwosComplementByteArray(it) }
 
 /**
  * Exception-free version of [readBigInteger]
@@ -130,7 +128,7 @@ fun Asn1Primitive.readIntOrNull() = catching { readInt() }.getOrNull()
  * @throws [Throwable] all sorts of exceptions on invalid input
  */
 @Throws(Asn1Exception::class)
-fun Asn1Primitive.readLong() = runRethrowing { decode(INTEGER.toUInt()) { Long.decodeFromDer(it) } }
+fun Asn1Primitive.readLong() = runRethrowing { decode(INTEGER.toULong()) { Long.decodeFromDer(it) } }
 
 /**
  * Exception-free version of [readLong]
@@ -145,14 +143,14 @@ fun Asn1Primitive.readLongOrNull() = catching { readLong() }.getOrNull()
  */
 @Throws(Throwable::class)
 fun Asn1Primitive.readString(): Asn1String = runRethrowing {
-    if (tag.tagValue == UTF8_STRING.toUInt()) Asn1String.UTF8(content.decodeToString())
-    else if (tag.tagValue == UNIVERSAL_STRING.toUInt()) Asn1String.Universal(content.decodeToString())
-    else if (tag.tagValue == IA5_STRING.toUInt()) Asn1String.IA5(content.decodeToString())
-    else if (tag.tagValue == BMP_STRING.toUInt()) Asn1String.BMP(content.decodeToString())
-    else if (tag.tagValue == T61_STRING.toUInt()) Asn1String.Teletex(content.decodeToString())
-    else if (tag.tagValue == PRINTABLE_STRING.toUInt()) Asn1String.Printable(content.decodeToString())
-    else if (tag.tagValue == NUMERIC_STRING.toUInt()) Asn1String.Numeric(content.decodeToString())
-    else if (tag.tagValue == VISIBLE_STRING.toUInt()) Asn1String.Visible(content.decodeToString())
+    if (tag.tagValue == UTF8_STRING.toULong()) Asn1String.UTF8(content.decodeToString())
+    else if (tag.tagValue == UNIVERSAL_STRING.toULong()) Asn1String.Universal(content.decodeToString())
+    else if (tag.tagValue == IA5_STRING.toULong()) Asn1String.IA5(content.decodeToString())
+    else if (tag.tagValue == BMP_STRING.toULong()) Asn1String.BMP(content.decodeToString())
+    else if (tag.tagValue == T61_STRING.toULong()) Asn1String.Teletex(content.decodeToString())
+    else if (tag.tagValue == PRINTABLE_STRING.toULong()) Asn1String.Printable(content.decodeToString())
+    else if (tag.tagValue == NUMERIC_STRING.toULong()) Asn1String.Numeric(content.decodeToString())
+    else if (tag.tagValue == VISIBLE_STRING.toULong()) Asn1String.Visible(content.decodeToString())
     else TODO("Support other string tag $tag")
 }
 
@@ -169,9 +167,9 @@ fun Asn1Primitive.readStringOrNull() = catching { readString() }.getOrNull()
  */
 @Throws(Asn1Exception::class)
 fun Asn1Primitive.readInstant() =
-    if (tag.tagValue == UTC_TIME.toUInt()) decode(UTC_TIME.toUInt(), Instant.Companion::decodeUtcTimeFromDer)
-    else if (tag.tagValue == GENERALIZED_TIME.toUInt()) decode(
-        GENERALIZED_TIME.toUInt(),
+    if (tag.tagValue == UTC_TIME.toULong()) decode(UTC_TIME.toULong(), Instant.Companion::decodeUtcTimeFromDer)
+    else if (tag.tagValue == GENERALIZED_TIME.toULong()) decode(
+        GENERALIZED_TIME.toULong(),
         Instant.Companion::decodeGeneralizedTimeFromDer
     )
     else TODO("Support time tag $tag")
@@ -202,7 +200,7 @@ fun Asn1Primitive.readBitStringOrNull() = catching { readBitString() }.getOrNull
  * @throws Asn1Exception  on invalid input
  */
 @Throws(Asn1Exception::class)
-fun Asn1Primitive.readNull() = decode(ASN1_NULL.toUInt()) {}
+fun Asn1Primitive.readNull() = decode(ASN1_NULL.toULong()) {}
 
 /**
  * Name seems odd, but this is just an exception-free version of [readNull]
@@ -216,7 +214,7 @@ fun Asn1Primitive.readNullOrNull() = catching { readNull() }.getOrNull()
  * @throws Asn1TagMismatchException if the tag does not match
  */
 @Throws(Asn1TagMismatchException::class)
-fun Asn1Tagged.verifyTag(tag: UInt): List<Asn1Element> {
+fun Asn1Tagged.verifyTag(tag: ULong): List<Asn1Element> {
     val explicitTag = TLV.Tag(tag, constructed = true, TagClass.CONTEXT_SPECIFIC)
     if (this.tag != explicitTag) throw Asn1TagMismatchException(explicitTag, this.tag)
     return this.children
@@ -225,7 +223,7 @@ fun Asn1Tagged.verifyTag(tag: UInt): List<Asn1Element> {
 /**
  * Exception-free version of [verifyTag]
  */
-fun Asn1Tagged.verifyTagOrNull(tag: UInt) = catching { verifyTag(tag) }.getOrNull()
+fun Asn1Tagged.verifyTagOrNull(tag: ULong) = catching { verifyTag(tag) }.getOrNull()
 
 
 /**
@@ -234,7 +232,7 @@ fun Asn1Tagged.verifyTagOrNull(tag: UInt) = catching { verifyTag(tag) }.getOrNul
  * @throws Asn1Exception all sorts of exceptions on invalid input
  */
 @Throws(Asn1Exception::class)
-inline fun <reified T> Asn1Primitive.decode(tag: UInt, transform: (content: ByteArray) -> T) = runRethrowing {
+inline fun <reified T> Asn1Primitive.decode(tag: ULong, transform: (content: ByteArray) -> T) = runRethrowing {
     if (tag != this.tag.tagValue) throw Asn1TagMismatchException(TLV.Tag(tag, constructed = false), this.tag)
     transform(content)
 }
@@ -242,7 +240,7 @@ inline fun <reified T> Asn1Primitive.decode(tag: UInt, transform: (content: Byte
 /**
  * Exception-free version of [decode]
  */
-inline fun <reified T> Asn1Primitive.decodeOrNull(tag: UInt, transform: (content: ByteArray) -> T) =
+inline fun <reified T> Asn1Primitive.decodeOrNull(tag: ULong, transform: (content: ByteArray) -> T) =
     catching { decode(tag, transform) }.getOrNull()
 
 @Throws(Asn1Exception::class)
@@ -301,6 +299,23 @@ fun Long.Companion.decodeFromDer(bytes: ByteArray): Long = runRethrowing {
     return result
 }
 
+@Throws(Asn1Exception::class)
+fun ULong.Companion.decodeFromDer(input: ByteArray): Pair<ULong, ByteArray> = runRethrowing {
+    var last = 0
+    input.iterator().let { while (it.hasNext() && it.next().toUByte() >= 0x80.toUByte()) last++ }
+    val bytes = input.sliceArray(0..last)
+    val input = if (bytes.size == 8) bytes else {
+        if (bytes.size > 9) throw IllegalArgumentException("Absolute value too large!")
+        val padding = 0x00.toByte()
+        ByteArray(9 - bytes.size) { padding } + bytes
+    }
+    var result = 0uL
+    for (i in input.indices) {
+        result = (result shl Byte.SIZE_BITS) or (input[i].toUByte().toULong())
+    }
+    return result to bytes
+}
+
 fun UInt.Companion.decodeFromDer(bytes: ByteArray): UInt = runRethrowing {
     val input = if (bytes.size == 8) bytes else {
         if (bytes.size > 5) throw IllegalArgumentException("Absolute value too large!")
@@ -320,8 +335,8 @@ private fun ByteArray.readTlv(): TLV = runRethrowing {
     if (this.size == 1) return TLV(TLV.Tag(byteArrayOf(this[0])), byteArrayOf())
 
     val decodedTag = decodeTag()
-    val tagLength = decodedTag.encodedTagLength
-    val tagBytes = sliceArray(0..<tagLength)
+    val tagLength = decodedTag.second.size
+    val tagBytes = decodedTag.second
     val value = drop(tagLength).decodeValue()
     return TLV(TLV.Tag(tagBytes), value.toByteArray())
 }
@@ -349,13 +364,11 @@ private infix fun UByte.ushr(bits: Int) = toInt() ushr bits
 
 internal infix fun Byte.byteMask(mask: Int) = (this and mask.toUInt().toByte()).toUByte()
 
-internal fun ByteArray.decodeTag(): UVarInt {
+internal fun ByteArray.decodeTag(): Pair<ULong, ByteArray> {
     val tagNumber = this[0] byteMask 0x1F
     return if (tagNumber <= 30U) {
-        UVarInt(tagNumber.toUInt())
+        tagNumber.toULong() to byteArrayOf(this[0])
     } else {
-        drop(1).toByteArray().varIntDecode()
+        ULong.decodeFromDer(drop(1).toByteArray()).let { (l,b)->l to byteArrayOf(first(),*b) }
     }
 }
-
-internal val UVarInt.encodedTagLength: Int get() = encodeToByteArray().size.let { if (it > 1) 1 + it else 1 }

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/Asn1Decoding.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/Asn1Decoding.kt
@@ -344,14 +344,14 @@ private fun List<Byte>.getInt(i: Int) = this[i].toUByte().toInt()
 
 internal infix fun Byte.byteMask(mask: Int) = (this and mask.toUInt().toByte()).toUByte()
 
-internal fun ByteArray.decodeTag(): Pair<ULong, ByteArray> {
-    val tagNumber = this[0] byteMask 0x1F
-    return if (tagNumber <= 30U) {
-        tagNumber.toULong() to byteArrayOf(this[0])
-    } else {
-        drop(1).decodeAsn1VarULong().let { (l, b) -> l to byteArrayOf(first(), *b) }
+internal fun ByteArray.decodeTag(): Pair<ULong, ByteArray> =
+    (this[0] byteMask 0x1F).let { tagNumber ->
+        if (tagNumber <= 30U) {
+            tagNumber.toULong() to byteArrayOf(this[0])
+        } else {
+            drop(1).decodeAsn1VarULong().let { (l, b) -> l to byteArrayOf(first(), *b) }
+        }
     }
-}
 
 
 /**

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/Asn1Decoding.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/Asn1Decoding.kt
@@ -45,7 +45,7 @@ private class Asn1Reader(input: ByteArray) {
         while (rest.isNotEmpty()) {
             val tlv = read()
             if (tlv.isSequence()) result.add(Asn1Sequence(Asn1Reader(tlv.content).doParse()))
-            else if (tlv.isSet()) result.add(Asn1Set(Asn1Reader(tlv.content).doParse()))
+            else if (tlv.isSet()) result.add(Asn1Set(Asn1Reader(tlv.content).doParse(), dontSort = true))
             else if (tlv.isExplicitlyTagged()) result.add(
                 Asn1Tagged(
                     tlv.tag.tagValue,
@@ -58,6 +58,8 @@ private class Asn1Reader(input: ByteArray) {
                 }.getOrElse {
                     result.add(Asn1PrimitiveOctetString(tlv.content))
                 }
+            } else if (tlv.tag.isConstructed) { //custom tags, we don't know if it is a SET OF, SET, SEQUENCE,… so we default to sequence semantics
+                result.add(Asn1CustomStructure(Asn1Reader(tlv.content).doParse(), tlv.tag.tagValue, tlv.tagClass))
             } else result.add(Asn1Primitive(tlv.tag, tlv.content))
 
         }

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/Asn1Decoding.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/Asn1Decoding.kt
@@ -320,27 +320,30 @@ private fun ByteArray.readTlv(): TLV = runRethrowing {
     val decodedTag = decodeTag()
     val tagLength = decodedTag.encodedTagLength
     val tagBytes = sliceArray(0..<tagLength)
-
-    val value = this.drop(tagLength).decodeLengthAndValue()
+    val value = drop(tagLength).decodeValue()
     return TLV(TLV.Tag(tagBytes), value.toByteArray())
 }
 
 @Throws(IllegalArgumentException::class)
-private fun List<Byte>.decodeLengthAndValue(): List<Byte> {
-    if (this[0] == 0x82.toByte()) {
+private fun List<Byte>.decodeValue() = when {
+    this[0] == 0x82.toByte() -> {
         require(size >= 3) { "Can't decode length" }
         val length = (getInt(1) shl 8) + getInt(2)
         require(size >= 3 + length) { "Out of bytes" }
-        return drop(3).take(length)
-    } else if (this[0] == 0x81.toByte()) {
+        drop(3).take(length)
+    }
+
+    this[0] == 0x81.toByte() -> {
         require(size >= 2) { "Can't decode length" }
         val length = getInt(1)
         require(size >= 2 + length) { "Out of bytes" }
-        return drop(2).take(length)
-    } else {
+        drop(2).take(length)
+    }
+
+    else -> {
         val length = getInt(0)
         require(size >= 1 + length) { "Out of bytes" }
-        return drop(1).take(length)
+        drop(1).take(length)
     }
 }
 

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/Asn1Elements.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/Asn1Elements.kt
@@ -156,16 +156,10 @@ sealed class Asn1Element(
                         )
                     }
 
-                var encoded = derEncoded.first().toUByte()
-                if (constructed) encoded = encoded or BERTags.CONSTRUCTED
-                when (tagClass) {
-                    TagClass.UNIVERSAL -> encoded = encoded or BERTags.UNIVERSAL
-                    TagClass.APPLICATION -> encoded = encoded or BERTags.APPLICATION
-                    TagClass.CONTEXT_SPECIFIC -> encoded = encoded or BERTags.CONTEXT_SPECIFIC
-                    TagClass.PRIVATE -> encoded = encoded or BERTags.PRIVATE
-
-                }
-                derEncoded[0] = encoded.toByte()
+                derEncoded[0] = derEncoded[0].toUByte()
+                    .let { if (constructed) (it or BERTags.CONSTRUCTED) else it }
+                    .let { it or tagClass.berTag }
+                    .toByte()
                 return derEncoded
             }
 

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/Asn1Elements.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/Asn1Elements.kt
@@ -391,12 +391,16 @@ class Asn1PrimitiveOctetString(content: ByteArray) : Asn1Primitive(Tag.OCTET_STR
 
 /**
  * ASN.1 SET 0x31 ([BERTags.SET] OR [BERTags.CONSTRUCTED])
- * @param children the elements to put into this set. will be automatically sorted by tag
  */
-open class Asn1Set internal constructor(children: List<Asn1Element>?, dontSort: Boolean = false) :
+open class Asn1Set private constructor(children: List<Asn1Element>?, dontSort: Boolean) :
     Asn1Structure(
         Tag.SET,
         if (dontSort) children else children?.sortedBy { it.tag.encodedTag.encodeToString(Base16) }) /*TODO this is inefficient*/ {
+
+    /**
+     * @param children the elements to put into this set. will be automatically sorted by tag
+     */
+    internal constructor(children: List<Asn1Element>?) : this(children, false)
 
     init {
         if (!tag.isConstructed) throw IllegalArgumentException("An ASN.1 Structure must have a CONSTRUCTED tag")
@@ -407,6 +411,14 @@ open class Asn1Set internal constructor(children: List<Asn1Element>?, dontSort: 
 
 
     override fun prettyPrint(indent: Int) = (" " * indent) + "Set" + super.prettyPrint(indent + 2)
+
+    companion object {
+        /**
+         * Explicitly discard DER requirements and DON'T sort children. Useful when parsing Structures which might not
+         * conform to DER
+         */
+        internal fun fromPresorted(children: List<Asn1Element>) = Asn1Set(children, true)
+    }
 }
 
 /**

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/Asn1Elements.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/Asn1Elements.kt
@@ -361,7 +361,6 @@ class Asn1CustomStructure private constructor(
 
     companion object {
         /**
-         * **UNTESTED!!!**
          * ASN.1 Structure encoded as an ASN.1 Primitive (similar to OCTET STRING containing a valid ASN.1 Structure) with custom tag
          * @param children the elements to put into this sequence
          * @param tag the custom tag to use

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/Asn1Elements.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/Asn1Elements.kt
@@ -188,7 +188,11 @@ sealed class Asn1Element(
 
         }
 
-        val tagClass by lazy { TagClass.fromByte(encodedTag.first()).getOrThrow() } //yes, this shall crash!!!
+        val tagClass by lazy {
+            checkNotNull(TagClass.fromByte(encodedTag.first()).getOrNull()) {
+                "An Illegal Tag class has been found. This should be impossible!"
+            }
+        }
 
         val isConstructed by lazy { encodedTag.first().toUByte().isConstructed() }
 

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/Asn1Elements.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/Asn1Elements.kt
@@ -471,14 +471,14 @@ interface Asn1OctetString<T : Asn1Element> {
 
 @Throws(IllegalArgumentException::class)
 internal fun Int.encodeLength(): ByteArray {
-    if (this < 128) {
-        return byteArrayOf(this.toByte())
+    require(this >= 0)
+    return when {
+        (this < 0x80) ->  byteArrayOf(this.toByte()) /* short form */
+        else -> { /* long form */
+            val length = this.toUnsignedByteArray()
+            val lengthLength = length.size
+            check(lengthLength < 0x80)
+            byteArrayOf((lengthLength or 0x80).toByte(), *length)
+        }
     }
-    if (this < 0x100) {
-        return byteArrayOf(0x81.toByte(), this.toByte())
-    }
-    if (this < 0x8000) {
-        return byteArrayOf(0x82.toByte(), (this ushr 8).toByte(), this.toByte())
-    }
-    throw IllegalArgumentException("length $this")
 }

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/Asn1Elements.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/Asn1Elements.kt
@@ -128,6 +128,7 @@ sealed class Asn1Element(
     }
 
     @Serializable
+    @ConsistentCopyVisibility
     data class Tag private constructor(
         val tagValue: ULong, val encodedTagLength: Int,
         @Serializable(with = ByteArrayBase64Serializer::class) val encodedTag: ByteArray

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/Asn1Encodable.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/Asn1Encodable.kt
@@ -3,9 +3,8 @@
 package at.asitplus.signum.indispensable.asn1
 
 import at.asitplus.KmmResult
-import at.asitplus.KmmResult.Companion.wrap
 import at.asitplus.catching
-import at.asitplus.signum.indispensable.asn1.DERTags.toImplicitTag
+import at.asitplus.signum.indispensable.asn1.toImplicitTag
 
 /**
  * Interface providing methods to encode to ASN.1
@@ -76,12 +75,12 @@ interface Asn1Decodable<A : Asn1Element, T : Asn1Encodable<A>> {
     fun decodeFromDer(src: ByteArray): T = decodeFromTlv(Asn1Element.parse(src) as A)
 
     /**
-     * Exception-free version of [decodeFromDer]
+     * Exception-free version of [decodeFromDerValue]
      */
     fun decodeFromDerOrNull(src: ByteArray) = catching { decodeFromDer(src) }.getOrNull()
 
     /**
-     * Safe version of [decodeFromDer], wrapping the result into a [KmmResult]
+     * Safe version of [decodeFromDerValue], wrapping the result into a [KmmResult]
      */
     fun decodeFromDerSafe(src: ByteArray) = catching { decodeFromDer(src) }
 }
@@ -119,13 +118,13 @@ interface Asn1TagVerifyingDecodable<T : Asn1Encodable<Asn1Primitive>> :
         decodeFromTlv(Asn1Element.parse(src) as Asn1Primitive, tagOverride)
 
     /**
-     * Exception-free version of [decodeFromDer]
+     * Exception-free version of [decodeFromDerValue]
      */
     fun decodeFromDerOrNull(src: ByteArray, tagOverride: TLV.Tag?) =
         catching { decodeFromDer(src, tagOverride) }.getOrNull()
 
     /**
-     * Safe version of [decodeFromDer], wrapping the result into a [KmmResult]
+     * Safe version of [decodeFromDerValue], wrapping the result into a [KmmResult]
      */
     fun decodeFromDerSafe(src: ByteArray, tagOverride: TLV.Tag?) = catching { decodeFromDer(src, tagOverride) }
 }

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/Asn1Encodable.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/Asn1Encodable.kt
@@ -94,18 +94,18 @@ interface Asn1TagVerifyingDecodable<T : Asn1Encodable<Asn1Primitive>> :
      * @throws Asn1Exception
      */
     @Throws(Asn1Exception::class)
-    fun decodeFromTlv(src: Asn1Primitive, tagOverride: TLV.Tag?): T
+    fun decodeFromTlv(src: Asn1Primitive, tagOverride: Asn1Element.Tag?): T
 
     /**
      * Exception-free version of [decodeFromTlv]
      */
-    fun decodeFromTlvOrNull(src: Asn1Primitive, tagOverride: TLV.Tag?) =
+    fun decodeFromTlvOrNull(src: Asn1Primitive, tagOverride: Asn1Element.Tag?) =
         catching { decodeFromTlv(src, tagOverride) }.getOrNull()
 
     /**
      * Safe version of [decodeFromTlv], wrapping the result into a [KmmResult]
      */
-    fun decodeFromTlvSafe(src: Asn1Primitive, tagOverride: TLV.Tag?) =
+    fun decodeFromTlvSafe(src: Asn1Primitive, tagOverride: Asn1Element.Tag?) =
         catching { decodeFromTlv(src, tagOverride) }
 
 
@@ -114,17 +114,17 @@ interface Asn1TagVerifyingDecodable<T : Asn1Encodable<Asn1Primitive>> :
      * Useful for implicit tagging.
      */
     @Throws(Asn1Exception::class)
-    fun decodeFromDer(src: ByteArray, tagOverride: TLV.Tag?): T =
+    fun decodeFromDer(src: ByteArray, tagOverride: Asn1Element.Tag?): T =
         decodeFromTlv(Asn1Element.parse(src) as Asn1Primitive, tagOverride)
 
     /**
      * Exception-free version of [decodeFromDerValue]
      */
-    fun decodeFromDerOrNull(src: ByteArray, tagOverride: TLV.Tag?) =
+    fun decodeFromDerOrNull(src: ByteArray, tagOverride: Asn1Element.Tag?) =
         catching { decodeFromDer(src, tagOverride) }.getOrNull()
 
     /**
      * Safe version of [decodeFromDerValue], wrapping the result into a [KmmResult]
      */
-    fun decodeFromDerSafe(src: ByteArray, tagOverride: TLV.Tag?) = catching { decodeFromDer(src, tagOverride) }
+    fun decodeFromDerSafe(src: ByteArray, tagOverride: Asn1Element.Tag?) = catching { decodeFromDer(src, tagOverride) }
 }

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/Asn1Encodable.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/Asn1Encodable.kt
@@ -95,18 +95,18 @@ interface Asn1TagVerifyingDecodable<T : Asn1Encodable<Asn1Primitive>> :
      * @throws Asn1Exception
      */
     @Throws(Asn1Exception::class)
-    fun decodeFromTlv(src: Asn1Primitive, tagOverride: UByte?): T
+    fun decodeFromTlv(src: Asn1Primitive, tagOverride: TLV.Tag?): T
 
     /**
      * Exception-free version of [decodeFromTlv]
      */
-    fun decodeFromTlvOrNull(src: Asn1Primitive, tagOverride: UByte?) =
+    fun decodeFromTlvOrNull(src: Asn1Primitive, tagOverride: TLV.Tag?) =
         catching { decodeFromTlv(src, tagOverride) }.getOrNull()
 
     /**
      * Safe version of [decodeFromTlv], wrapping the result into a [KmmResult]
      */
-    fun decodeFromTlvSafe(src: Asn1Primitive, tagOverride: UByte?) =
+    fun decodeFromTlvSafe(src: Asn1Primitive, tagOverride: TLV.Tag?) =
         catching { decodeFromTlv(src, tagOverride) }
 
 
@@ -115,17 +115,17 @@ interface Asn1TagVerifyingDecodable<T : Asn1Encodable<Asn1Primitive>> :
      * Useful for implicit tagging.
      */
     @Throws(Asn1Exception::class)
-    fun decodeFromDer(src: ByteArray, tagOverride: UByte?): T =
+    fun decodeFromDer(src: ByteArray, tagOverride: TLV.Tag?): T =
         decodeFromTlv(Asn1Element.parse(src) as Asn1Primitive, tagOverride)
 
     /**
      * Exception-free version of [decodeFromDer]
      */
-    fun decodeFromDerOrNull(src: ByteArray, tagOverride: UByte?) =
+    fun decodeFromDerOrNull(src: ByteArray, tagOverride: TLV.Tag?) =
         catching { decodeFromDer(src, tagOverride) }.getOrNull()
 
     /**
      * Safe version of [decodeFromDer], wrapping the result into a [KmmResult]
      */
-    fun decodeFromDerSafe(src: ByteArray, tagOverride: UByte?) = catching { decodeFromDer(src, tagOverride) }
+    fun decodeFromDerSafe(src: ByteArray, tagOverride: TLV.Tag?) = catching { decodeFromDer(src, tagOverride) }
 }

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/Asn1Encodable.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/Asn1Encodable.kt
@@ -75,12 +75,12 @@ interface Asn1Decodable<A : Asn1Element, T : Asn1Encodable<A>> {
     fun decodeFromDer(src: ByteArray): T = decodeFromTlv(Asn1Element.parse(src) as A)
 
     /**
-     * Exception-free version of [decodeFromDerValue]
+     * Exception-free version of [decodeFromDer]
      */
     fun decodeFromDerOrNull(src: ByteArray) = catching { decodeFromDer(src) }.getOrNull()
 
     /**
-     * Safe version of [decodeFromDerValue], wrapping the result into a [KmmResult]
+     * Safe version of [decodeFromDer], wrapping the result into a [KmmResult]
      */
     fun decodeFromDerSafe(src: ByteArray) = catching { decodeFromDer(src) }
 }
@@ -118,13 +118,13 @@ interface Asn1TagVerifyingDecodable<T : Asn1Encodable<Asn1Primitive>> :
         decodeFromTlv(Asn1Element.parse(src) as Asn1Primitive, tagOverride)
 
     /**
-     * Exception-free version of [decodeFromDerValue]
+     * Exception-free version of [decodeFromDer]
      */
     fun decodeFromDerOrNull(src: ByteArray, tagOverride: Asn1Element.Tag?) =
         catching { decodeFromDer(src, tagOverride) }.getOrNull()
 
     /**
-     * Safe version of [decodeFromDerValue], wrapping the result into a [KmmResult]
+     * Safe version of [decodeFromDer], wrapping the result into a [KmmResult]
      */
     fun decodeFromDerSafe(src: ByteArray, tagOverride: Asn1Element.Tag?) = catching { decodeFromDer(src, tagOverride) }
 }

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/Asn1Encoding.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/Asn1Encoding.kt
@@ -8,7 +8,6 @@ import at.asitplus.signum.indispensable.asn1.BERTags.BOOLEAN
 import at.asitplus.signum.indispensable.asn1.BERTags.GENERALIZED_TIME
 import at.asitplus.signum.indispensable.asn1.BERTags.INTEGER
 import at.asitplus.signum.indispensable.asn1.BERTags.UTC_TIME
-import at.asitplus.signum.indispensable.asn1.DERTags.toExplicitTag
 import at.asitplus.signum.indispensable.io.BitSet
 import com.ionspin.kotlin.bignum.integer.BigInteger
 import com.ionspin.kotlin.bignum.integer.util.toTwosComplementByteArray
@@ -129,7 +128,7 @@ object Asn1 {
     fun Set(root: Asn1TreeBuilder.() -> Unit): Asn1Set {
         val seq = Asn1TreeBuilder()
         seq.root()
-        return Asn1Set(seq.elements.sortedBy { it.tag })
+        return Asn1Set(seq.elements)
     }
 
     /**
@@ -192,22 +191,22 @@ object Asn1 {
      * }
      *  ```
      */
-    fun Tagged(tag: UByte, root: Asn1TreeBuilder.() -> Unit): Asn1Tagged {
+    fun Tagged(tag: UInt, root: Asn1TreeBuilder.() -> Unit): Asn1Tagged {
         val seq = Asn1TreeBuilder()
         seq.root()
-        return Asn1Tagged(tag.toExplicitTag(), seq.elements)
+        return Asn1Tagged(tag, seq.elements)
     }
 
     /**
      * Exception-free version of [Tagged]
      */
-    fun TaggedOrNull(tag: UByte, root: Asn1TreeBuilder.() -> Unit) =
+    fun TaggedOrNull(tag: UInt, root: Asn1TreeBuilder.() -> Unit) =
         catching { Tagged(tag, root) }.getOrNull()
 
     /**
      * Safe version on [Tagged], wrapping the result into a [KmmResult]
      */
-    fun TaggedSafe(tag: UByte, root: Asn1TreeBuilder.() -> Unit) =
+    fun TaggedSafe(tag: UInt, root: Asn1TreeBuilder.() -> Unit) =
         catching { Tagged(tag, root) }
 
 
@@ -265,7 +264,7 @@ object Asn1 {
     /**
      * Adds a NULL [Asn1Primitive] to this ASN.1 structure
      */
-    fun Null() = Asn1Primitive(ASN1_NULL, byteArrayOf())
+    fun Null() = Asn1Primitive(ASN1_NULL.toUInt(), byteArrayOf())
 
 
     /**
@@ -305,23 +304,23 @@ object Asn1 {
 /**
  * Produces an INTEGER as [Asn1Primitive]
  */
-fun Int.encodeToTlv() = Asn1Primitive(INTEGER, encodeToDer())
+fun Int.encodeToTlv() = Asn1Primitive(INTEGER.toUInt(), encodeToDer())
 
 
 /**
  * Produces a BOOLEAN as [Asn1Primitive]
  */
-fun Boolean.encodeToTlv() = Asn1Primitive(BOOLEAN, byteArrayOf(if (this) 0xff.toByte() else 0))
+fun Boolean.encodeToTlv() = Asn1Primitive(BOOLEAN.toUInt(), byteArrayOf(if (this) 0xff.toByte() else 0))
 
 /**
  * Produces an INTEGER as [Asn1Primitive]
  */
-fun Long.encodeToTlv() = Asn1Primitive(INTEGER, encodeToDer())
+fun Long.encodeToTlv() = Asn1Primitive(INTEGER.toUInt(), encodeToDer())
 
 /**
  * Produces an INTEGER as [Asn1Primitive]
  */
-fun BigInteger.encodeToTlv() = Asn1Primitive(INTEGER, toTwosComplementByteArray())
+fun BigInteger.encodeToTlv() = Asn1Primitive(INTEGER.toUInt(), toTwosComplementByteArray())
 
 /**
  * Produces an OCTET STRING as [Asn1Primitive]
@@ -331,14 +330,14 @@ fun ByteArray.encodeToTlvOctetString() = Asn1PrimitiveOctetString(this)
 /**
  * Produces a BIT STRING as [Asn1Primitive]
  */
-fun ByteArray.encodeToTlvBitString() = Asn1Primitive(BIT_STRING, encodeToBitString())
+fun ByteArray.encodeToTlvBitString() = Asn1Primitive(BIT_STRING.toUInt(), encodeToBitString())
 
 /**
  * Prepends 0x00 to this ByteArray for encoding it into a BIT STRING. Useful for implicit tagging
  */
 fun ByteArray.encodeToBitString() = byteArrayOf(0x00) + this
 
-private fun Int.encodeToDer() = if (this == 0) byteArrayOf(0) else
+internal fun Int.encodeToDer() = if (this == 0) byteArrayOf(0) else
     encodeToByteArray()
 
 private fun Long.encodeToDer() = if (this == 0L) byteArrayOf(0) else
@@ -348,13 +347,13 @@ private fun Long.encodeToDer() = if (this == 0L) byteArrayOf(0) else
  * Produces a UTC TIME as [Asn1Primitive]
  */
 fun Instant.encodeToAsn1UtcTime() =
-    Asn1Primitive(UTC_TIME, encodeToAsn1Time().drop(2).encodeToByteArray())
+    Asn1Primitive(UTC_TIME.toUInt(), encodeToAsn1Time().drop(2).encodeToByteArray())
 
 /**
  * Produces a GENERALIZED TIME as [Asn1Primitive]
  */
 fun Instant.encodeToAsn1GeneralizedTime() =
-    Asn1Primitive(GENERALIZED_TIME, encodeToAsn1Time().encodeToByteArray())
+    Asn1Primitive(GENERALIZED_TIME.toUInt(), encodeToAsn1Time().encodeToByteArray())
 
 private fun Instant.encodeToAsn1Time(): String {
     val value = this.toString()

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/Asn1Encoding.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/Asn1Encoding.kt
@@ -17,8 +17,8 @@ import kotlinx.datetime.Instant
  * Class Providing a DSL for creating arbitrary ASN.1 structures. You will almost certainly never use it directly, but rather use it as follows:
  * ```kotlin
  * Sequence {
- *     +Tagged(1u) {
- *         +Asn1Primitive(BERTags.BOOLEAN, byteArrayOf(0x00))
+ *     +Tagged(1uL) {
+ *         +Asn1Primitive(BERTags.BOOLEAN.toUlong(), byteArrayOf(0x00))
  *     }
  *     +Set {
  *         +Sequence {
@@ -178,8 +178,6 @@ object Asn1 {
 
     /**
      * Creates a new EXPLICITLY TAGGED ASN.1 structure as [Asn1Tagged] using [tag].
-     *
-     * * **NOTE:** automatically calls [at.asitplus.signum.indispensable.asn1.DERTags.toExplicitTag] on [tag]
      *
      * Use as follows:
      *

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/Asn1Encoding.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/Asn1Encoding.kt
@@ -395,7 +395,7 @@ fun Long.encodeTo8Bytes(): ByteArray = byteArrayOf(
 )
 
 /** Encodes a signed Long to a minimum-size twos-complement byte array */
-internal fun Long.toTwosComplementByteArray(): ByteArray {
+fun Long.toTwosComplementByteArray(): ByteArray {
     //fast case
     if (this >= Byte.MIN_VALUE && this <= Byte.MAX_VALUE) return byteArrayOf(this.toByte())
     if (this >= Short.MIN_VALUE && this <= Short.MAX_VALUE) return byteArrayOf(
@@ -451,10 +451,10 @@ internal fun Long.toTwosComplementByteArray(): ByteArray {
 }
 
 /** Encodes a signed Int to a minimum-size twos-complement byte array */
-internal fun Int.toTwosComplementByteArray() = toLong().toTwosComplementByteArray()
+fun Int.toTwosComplementByteArray() = toLong().toTwosComplementByteArray()
 
 /** Encodes an unsigned Long to a minimum-size unsigned byte array */
-internal fun Long.toUnsignedByteArray(): ByteArray {
+fun Long.toUnsignedByteArray(): ByteArray {
     require(this >= 0)
     return this.toTwosComplementByteArray().let {
         if (it[0] == 0.toByte()) it.copyOfRange(1, it.size)
@@ -463,7 +463,7 @@ internal fun Long.toUnsignedByteArray(): ByteArray {
 }
 
 /** Encodes an unsigned Int to a minimum-size unsigned byte array */
-internal fun Int.toUnsignedByteArray() = toLong().toUnsignedByteArray()
+fun Int.toUnsignedByteArray() = toLong().toUnsignedByteArray()
 
 /**
  * Drops bytes at the start, or adds zero bytes at the start, until the [size] is reached

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/Asn1Encoding.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/Asn1Encoding.kt
@@ -496,8 +496,8 @@ fun ULong.toAsn1VarInt(): ByteArray {
         b0 = (this shr offset and 0x7FuL).toByte()
     }
 
-    return ByteArray(result.size){
-        result[result.size-1-it] or  (if (it < result.size-1) 0x80 else 0x00).toByte()
+    return with(result) {
+        ByteArray(size) { fromBack(it) or asn1VarIntByteMask(it) }
     }
 }
 
@@ -519,7 +519,13 @@ fun UInt.toAsn1VarInt(): ByteArray {
         b0 = (this shr offset and 0x7Fu).toByte()
     }
 
-    return ByteArray(result.size){
-        result[result.size-1-it] or  (if (it < result.size-1) 0x80 else 0x00).toByte()
+    return with(result) {
+        ByteArray(size) { fromBack(it) or asn1VarIntByteMask(it) }
     }
 }
+
+private fun MutableList<Byte>.asn1VarIntByteMask(it: Int) = (if (isLastIndex(it)) 0x00 else 0x80).toByte()
+
+private fun MutableList<Byte>.isLastIndex(it: Int) = it == size - 1
+
+private fun MutableList<Byte>.fromBack(it: Int) = this[size - 1 - it]

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/Asn1Encoding.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/Asn1Encoding.kt
@@ -191,7 +191,7 @@ object Asn1 {
      * }
      *  ```
      */
-    fun Tagged(tag: UInt, root: Asn1TreeBuilder.() -> Unit): Asn1Tagged {
+    fun Tagged(tag: ULong, root: Asn1TreeBuilder.() -> Unit): Asn1Tagged {
         val seq = Asn1TreeBuilder()
         seq.root()
         return Asn1Tagged(tag, seq.elements)
@@ -200,13 +200,13 @@ object Asn1 {
     /**
      * Exception-free version of [Tagged]
      */
-    fun TaggedOrNull(tag: UInt, root: Asn1TreeBuilder.() -> Unit) =
+    fun TaggedOrNull(tag: ULong, root: Asn1TreeBuilder.() -> Unit) =
         catching { Tagged(tag, root) }.getOrNull()
 
     /**
      * Safe version on [Tagged], wrapping the result into a [KmmResult]
      */
-    fun TaggedSafe(tag: UInt, root: Asn1TreeBuilder.() -> Unit) =
+    fun TaggedSafe(tag: ULong, root: Asn1TreeBuilder.() -> Unit) =
         catching { Tagged(tag, root) }
 
 
@@ -264,7 +264,7 @@ object Asn1 {
     /**
      * Adds a NULL [Asn1Primitive] to this ASN.1 structure
      */
-    fun Null() = Asn1Primitive(ASN1_NULL.toUInt(), byteArrayOf())
+    fun Null() = Asn1Primitive(ASN1_NULL.toULong(), byteArrayOf())
 
 
     /**
@@ -304,23 +304,23 @@ object Asn1 {
 /**
  * Produces an INTEGER as [Asn1Primitive]
  */
-fun Int.encodeToTlv() = Asn1Primitive(INTEGER.toUInt(), encodeToDer())
+fun Int.encodeToTlv() = Asn1Primitive(INTEGER.toULong(), encodeToDer())
 
 
 /**
  * Produces a BOOLEAN as [Asn1Primitive]
  */
-fun Boolean.encodeToTlv() = Asn1Primitive(BOOLEAN.toUInt(), byteArrayOf(if (this) 0xff.toByte() else 0))
+fun Boolean.encodeToTlv() = Asn1Primitive(BOOLEAN.toULong(), byteArrayOf(if (this) 0xff.toByte() else 0))
 
 /**
  * Produces an INTEGER as [Asn1Primitive]
  */
-fun Long.encodeToTlv() = Asn1Primitive(INTEGER.toUInt(), encodeToDer())
+fun Long.encodeToTlv() = Asn1Primitive(INTEGER.toULong(), encodeToDer())
 
 /**
  * Produces an INTEGER as [Asn1Primitive]
  */
-fun BigInteger.encodeToTlv() = Asn1Primitive(INTEGER.toUInt(), toTwosComplementByteArray())
+fun BigInteger.encodeToTlv() = Asn1Primitive(INTEGER.toULong(), toTwosComplementByteArray())
 
 /**
  * Produces an OCTET STRING as [Asn1Primitive]
@@ -330,7 +330,7 @@ fun ByteArray.encodeToTlvOctetString() = Asn1PrimitiveOctetString(this)
 /**
  * Produces a BIT STRING as [Asn1Primitive]
  */
-fun ByteArray.encodeToTlvBitString() = Asn1Primitive(BIT_STRING.toUInt(), encodeToBitString())
+fun ByteArray.encodeToTlvBitString() = Asn1Primitive(BIT_STRING.toULong(), encodeToBitString())
 
 /**
  * Prepends 0x00 to this ByteArray for encoding it into a BIT STRING. Useful for implicit tagging
@@ -347,13 +347,13 @@ private fun Long.encodeToDer() = if (this == 0L) byteArrayOf(0) else
  * Produces a UTC TIME as [Asn1Primitive]
  */
 fun Instant.encodeToAsn1UtcTime() =
-    Asn1Primitive(UTC_TIME.toUInt(), encodeToAsn1Time().drop(2).encodeToByteArray())
+    Asn1Primitive(UTC_TIME.toULong(), encodeToAsn1Time().drop(2).encodeToByteArray())
 
 /**
  * Produces a GENERALIZED TIME as [Asn1Primitive]
  */
 fun Instant.encodeToAsn1GeneralizedTime() =
-    Asn1Primitive(GENERALIZED_TIME.toUInt(), encodeToAsn1Time().encodeToByteArray())
+    Asn1Primitive(GENERALIZED_TIME.toULong(), encodeToAsn1Time().encodeToByteArray())
 
 private fun Instant.encodeToAsn1Time(): String {
     val value = this.toString()

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/Asn1Encoding.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/Asn1Encoding.kt
@@ -2,12 +2,6 @@ package at.asitplus.signum.indispensable.asn1
 
 import at.asitplus.KmmResult
 import at.asitplus.catching
-import at.asitplus.signum.indispensable.asn1.BERTags.ASN1_NULL
-import at.asitplus.signum.indispensable.asn1.BERTags.BIT_STRING
-import at.asitplus.signum.indispensable.asn1.BERTags.BOOLEAN
-import at.asitplus.signum.indispensable.asn1.BERTags.GENERALIZED_TIME
-import at.asitplus.signum.indispensable.asn1.BERTags.INTEGER
-import at.asitplus.signum.indispensable.asn1.BERTags.UTC_TIME
 import at.asitplus.signum.indispensable.io.BitSet
 import com.ionspin.kotlin.bignum.integer.BigInteger
 import com.ionspin.kotlin.bignum.integer.util.toTwosComplementByteArray
@@ -263,7 +257,7 @@ object Asn1 {
     /**
      * Adds a NULL [Asn1Primitive] to this ASN.1 structure
      */
-    fun Null() = Asn1Primitive(ASN1_NULL.toULong(), byteArrayOf())
+    fun Null() = Asn1Primitive(Asn1Element.Tag.NULL, byteArrayOf())
 
 
     /**
@@ -303,23 +297,23 @@ object Asn1 {
 /**
  * Produces an INTEGER as [Asn1Primitive]
  */
-fun Int.encodeToTlv() = Asn1Primitive(INTEGER.toULong(), encodeToDer())
+fun Int.encodeToTlv() = Asn1Primitive(Asn1Element.Tag.INT, encodeToDer())
 
 
 /**
  * Produces a BOOLEAN as [Asn1Primitive]
  */
-fun Boolean.encodeToTlv() = Asn1Primitive(BOOLEAN.toULong(), byteArrayOf(if (this) 0xff.toByte() else 0))
+fun Boolean.encodeToTlv() = Asn1Primitive(Asn1Element.Tag.BOOL, byteArrayOf(if (this) 0xff.toByte() else 0))
 
 /**
  * Produces an INTEGER as [Asn1Primitive]
  */
-fun Long.encodeToTlv() = Asn1Primitive(INTEGER.toULong(), encodeToDer())
+fun Long.encodeToTlv() = Asn1Primitive(Asn1Element.Tag.INT, encodeToDer())
 
 /**
  * Produces an INTEGER as [Asn1Primitive]
  */
-fun BigInteger.encodeToTlv() = Asn1Primitive(INTEGER.toULong(), toTwosComplementByteArray())
+fun BigInteger.encodeToTlv() = Asn1Primitive(Asn1Element.Tag.INT, toTwosComplementByteArray())
 
 /**
  * Produces an OCTET STRING as [Asn1Primitive]
@@ -329,7 +323,7 @@ fun ByteArray.encodeToTlvOctetString() = Asn1PrimitiveOctetString(this)
 /**
  * Produces a BIT STRING as [Asn1Primitive]
  */
-fun ByteArray.encodeToTlvBitString() = Asn1Primitive(BIT_STRING.toULong(), encodeToBitString())
+fun ByteArray.encodeToTlvBitString() = Asn1Primitive(Asn1Element.Tag.BIT_STRING, encodeToBitString())
 
 /**
  * Prepends 0x00 to this ByteArray for encoding it into a BIT STRING. Useful for implicit tagging
@@ -346,13 +340,13 @@ private fun Long.encodeToDer() = if (this == 0L) byteArrayOf(0) else
  * Produces a UTC TIME as [Asn1Primitive]
  */
 fun Instant.encodeToAsn1UtcTime() =
-    Asn1Primitive(UTC_TIME.toULong(), encodeToAsn1Time().drop(2).encodeToByteArray())
+    Asn1Primitive(Asn1Element.Tag.TIME_UTC, encodeToAsn1Time().drop(2).encodeToByteArray())
 
 /**
  * Produces a GENERALIZED TIME as [Asn1Primitive]
  */
 fun Instant.encodeToAsn1GeneralizedTime() =
-    Asn1Primitive(GENERALIZED_TIME.toULong(), encodeToAsn1Time().encodeToByteArray())
+    Asn1Primitive(Asn1Element.Tag.TIME_GENERALIZED, encodeToAsn1Time().encodeToByteArray())
 
 private fun Instant.encodeToAsn1Time(): String {
     val value = this.toString()

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/Asn1Encoding.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/Asn1Encoding.kt
@@ -209,16 +209,16 @@ object Asn1 {
     fun Bool(value: Boolean) = value.encodeToTlv()
 
 
-    /**
-     * Adds an INTEGER [Asn1Primitive] to this ASN.1 structure
-     */
+    /** Adds an INTEGER [Asn1Primitive] to this ASN.1 structure */
     fun Int(value: Int) = value.encodeToTlv()
-
-
-    /**
-     * Adds an INTEGER [Asn1Primitive] to this ASN.1 structure
-     */
+    /** Adds an INTEGER [Asn1Primitive] to this ASN.1 structure */
     fun Int(value: Long) = value.encodeToTlv()
+    /** Adds an INTEGER [Asn1Primitive] to this ASN.1 structure */
+    fun Int(value: UInt) = value.encodeToTlv()
+    /** Adds an INTEGER [Asn1Primitive] to this ASN.1 structure */
+    fun Int(value: ULong) = value.encodeToTlv()
+    /** Adds an INTEGER [Asn1Primitive] to this ASN.1 structure */
+    fun Int(value: BigInteger) = value.encodeToTlv()
 
 
     /**
@@ -295,25 +295,20 @@ object Asn1 {
 }
 
 /**
- * Produces an INTEGER as [Asn1Primitive]
- */
-fun Int.encodeToTlv() = Asn1Primitive(Asn1Element.Tag.INT, encodeToDer())
-
-
-/**
  * Produces a BOOLEAN as [Asn1Primitive]
  */
 fun Boolean.encodeToTlv() = Asn1Primitive(Asn1Element.Tag.BOOL, byteArrayOf(if (this) 0xff.toByte() else 0))
 
-/**
- * Produces an INTEGER as [Asn1Primitive]
- */
+/** Produces an INTEGER as [Asn1Primitive] */
+fun Int.encodeToTlv() = Asn1Primitive(Asn1Element.Tag.INT, encodeToDer())
+/** Produces an INTEGER as [Asn1Primitive] */
 fun Long.encodeToTlv() = Asn1Primitive(Asn1Element.Tag.INT, encodeToDer())
-
-/**
- * Produces an INTEGER as [Asn1Primitive]
- */
-fun BigInteger.encodeToTlv() = Asn1Primitive(Asn1Element.Tag.INT, toTwosComplementByteArray())
+/** Produces an INTEGER as [Asn1Primitive] */
+fun UInt.encodeToTlv() = Asn1Primitive(Asn1Element.Tag.INT, encodeToDer())
+/** Produces an INTEGER as [Asn1Primitive] */
+fun ULong.encodeToTlv() = Asn1Primitive(Asn1Element.Tag.INT, encodeToDer())
+/** Produces an INTEGER as [Asn1Primitive] */
+fun BigInteger.encodeToTlv() = Asn1Primitive(Asn1Element.Tag.INT, encodeToDer())
 
 /**
  * Produces an OCTET STRING as [Asn1Primitive]
@@ -330,11 +325,11 @@ fun ByteArray.encodeToTlvBitString() = Asn1Primitive(Asn1Element.Tag.BIT_STRING,
  */
 fun ByteArray.encodeToBitString() = byteArrayOf(0x00) + this
 
-internal fun Int.encodeToDer() = if (this == 0) byteArrayOf(0) else
-    toTwosComplementByteArray()
-
-private fun Long.encodeToDer() = if (this == 0L) byteArrayOf(0) else
-    toTwosComplementByteArray()
+private fun Int.encodeToDer() = toTwosComplementByteArray()
+private fun Long.encodeToDer() = toTwosComplementByteArray()
+private fun UInt.encodeToDer() = toTwosComplementByteArray()
+private fun ULong.encodeToDer() = toTwosComplementByteArray()
+private fun BigInteger.encodeToDer() = toTwosComplementByteArray()
 
 /**
  * Produces a UTC TIME as [Asn1Primitive]
@@ -394,64 +389,128 @@ fun Long.encodeTo8Bytes(): ByteArray = byteArrayOf(
     (this).toByte()
 )
 
-/** Encodes a signed Long to a minimum-size twos-complement byte array */
-fun Long.toTwosComplementByteArray(): ByteArray {
-    //fast case
-    if (this >= Byte.MIN_VALUE && this <= Byte.MAX_VALUE) return byteArrayOf(this.toByte())
-    if (this >= Short.MIN_VALUE && this <= Short.MAX_VALUE) return byteArrayOf(
-        (this ushr 8).toByte(),
-        this.toByte()
-    )
-    if (this >= -(0x80 shl 16) && this < (0x80 shl 16)) return byteArrayOf(
-        (this ushr 16).toByte(),
-        (this ushr 8).toByte(),
-        this.toByte()
-    )
-    if (this >= -((0x80L shl 24)) && this < (0x80L shl 24)) return byteArrayOf(
-        (this ushr 24).toByte(),
-        (this ushr 16).toByte(),
-        (this ushr 8).toByte(),
-        this.toByte()
-    )
-    if (this >= Int.MIN_VALUE && this <= Int.MAX_VALUE) return byteArrayOf(
-        (this ushr 32).toByte(),
-        (this ushr 24).toByte(),
-        (this ushr 16).toByte(),
-        (this ushr 8).toByte(),
-        this.toByte()
-    )
+/** Encodes an unsigned Long to a minimum-size twos-complement byte array */
+fun ULong.toTwosComplementByteArray() = when {
+    this >= 0x8000000000000000UL ->
+        byteArrayOf(
+            0x00,
+            (this shr 56).toByte(),
+            (this shr 48).toByte(),
+            (this shr 40).toByte(),
+            (this shr 32).toByte(),
+            (this shr 24).toByte(),
+            (this shr 16).toByte(),
+            (this shr 8).toByte(),
+            this.toByte())
+    else -> this.toLong().toTwosComplementByteArray()
+}
 
-    if (this >= -((0x80L shl 40)) && this < (0x80L shl 40)) return byteArrayOf(
-        (this ushr 40).toByte(),
-        (this ushr 32).toByte(),
-        (this ushr 24).toByte(),
-        (this ushr 16).toByte(),
-        (this ushr 8).toByte(),
-        this.toByte()
-    )
-    if (this >= -((0x80L shl 48)) && this < (0x80L shl 48)) return byteArrayOf(
-        (this ushr 48).toByte(),
-        (this ushr 40).toByte(),
-        (this ushr 32).toByte(),
-        (this ushr 24).toByte(),
-        (this ushr 16).toByte(),
-        (this ushr 8).toByte(),
-        this.toByte()
-    )
-    return byteArrayOf(
-        (this ushr 56).toByte(),
-        (this ushr 48).toByte(),
-        (this ushr 40).toByte(),
-        (this ushr 32).toByte(),
-        (this ushr 24).toByte(),
-        (this ushr 16).toByte(),
-        (this ushr 8).toByte(),
-        this.toByte()
-    )
+/** Encodes an unsigned Int to a minimum-size twos-complement byte array */
+fun UInt.toTwosComplementByteArray() = toLong().toTwosComplementByteArray()
+
+/** Encodes a signed Long to a minimum-size twos-complement byte array */
+fun Long.toTwosComplementByteArray() = when {
+    (this >= -0x80L && this <= 0x7FL) ->
+        byteArrayOf(
+            this.toByte())
+    (this >= -0x8000L && this <= 0x7FFFL) ->
+        byteArrayOf(
+            (this ushr 8).toByte(),
+            this.toByte())
+    (this >= -0x800000L && this <= 0x7FFFFFL) ->
+        byteArrayOf(
+            (this ushr 16).toByte(),
+            (this ushr 8).toByte(),
+            this.toByte())
+    (this >= -0x80000000L && this <= 0x7FFFFFFFL) ->
+        byteArrayOf(
+            (this ushr 24).toByte(),
+            (this ushr 16).toByte(),
+            (this ushr 8).toByte(),
+            this.toByte())
+    (this >= -0x8000000000L && this <= 0x7FFFFFFFFFL) ->
+        byteArrayOf(
+            (this ushr 32).toByte(),
+            (this ushr 24).toByte(),
+            (this ushr 16).toByte(),
+            (this ushr 8).toByte(),
+            this.toByte())
+    (this >= -0x800000000000L && this <= 0x7FFFFFFFFFFFL) ->
+        byteArrayOf(
+            (this ushr 40).toByte(),
+            (this ushr 32).toByte(),
+            (this ushr 24).toByte(),
+            (this ushr 16).toByte(),
+            (this ushr 8).toByte(),
+            this.toByte())
+    (this >= -0x80000000000000L && this <= 0x7FFFFFFFFFFFFFL) ->
+        byteArrayOf(
+            (this ushr 48).toByte(),
+            (this ushr 40).toByte(),
+            (this ushr 32).toByte(),
+            (this ushr 24).toByte(),
+            (this ushr 16).toByte(),
+            (this ushr 8).toByte(),
+            this.toByte())
+    else ->
+        byteArrayOf(
+            (this ushr 56).toByte(),
+            (this ushr 48).toByte(),
+            (this ushr 40).toByte(),
+            (this ushr 32).toByte(),
+            (this ushr 24).toByte(),
+            (this ushr 16).toByte(),
+            (this ushr 8).toByte(),
+            this.toByte())
 }
 
 /** Encodes a signed Int to a minimum-size twos-complement byte array */
 fun Int.toTwosComplementByteArray() = toLong().toTwosComplementByteArray()
+
+fun Int.Companion.fromTwosComplementByteArray(it: ByteArray) = when (it.size) {
+    4 -> (it[0].toInt() shl 24) or (it[1].toUByte().toInt() shl 16) or (it[2].toUByte().toInt() shl 8) or (it[3].toUByte().toInt())
+    3 -> (it[0].toInt() shl 16) or (it[1].toUByte().toInt() shl 8) or (it[2].toUByte().toInt())
+    2 -> (it[0].toInt() shl 8) or (it[1].toUByte().toInt() shl 0)
+    1 -> (it[0].toInt())
+    else -> throw IllegalArgumentException("Input with size $it is out of bounds for Int")
+}
+
+fun UInt.Companion.fromTwosComplementByteArray(it: ByteArray) =
+    Long.fromTwosComplementByteArray(it).let {
+        require ((0 <= it) && (it <= 0xFFFFFFFFL)) { "Value $it is out of bounds for UInt" }
+        it.toUInt()
+    }
+
+fun Long.Companion.fromTwosComplementByteArray(it: ByteArray) = when (it.size) {
+    8 -> (it[0].toLong() shl 56) or (it[1].toUByte().toLong() shl 48) or (it[2].toUByte().toLong() shl 40) or
+            (it[3].toUByte().toLong() shl 32) or (it[4].toUByte().toLong() shl 24) or
+            (it[5].toUByte().toLong() shl 16) or (it[6].toUByte().toLong() shl 8) or (it[7].toUByte().toLong())
+    7 -> (it[0].toLong() shl 48) or (it[1].toUByte().toLong() shl 40) or (it[2].toUByte().toLong() shl 32) or
+            (it[3].toUByte().toLong() shl 24) or (it[4].toUByte().toLong() shl 16) or
+            (it[5].toUByte().toLong() shl 8) or (it[6].toUByte().toLong())
+    6 -> (it[0].toLong() shl 40) or (it[1].toUByte().toLong() shl 32) or (it[2].toUByte().toLong() shl 24) or
+            (it[3].toUByte().toLong() shl 16) or (it[4].toUByte().toLong() shl 8) or (it[5].toUByte().toLong())
+    5 -> (it[0].toLong() shl 32) or (it[1].toUByte().toLong() shl 24) or (it[2].toUByte().toLong() shl 16) or
+            (it[3].toUByte().toLong() shl 8) or (it[4].toUByte().toLong())
+    4 -> (it[0].toLong() shl 24) or (it[1].toUByte().toLong() shl 16) or (it[2].toUByte().toLong() shl 8) or
+            (it[3].toUByte().toLong())
+    3 -> (it[0].toLong() shl 16) or (it[1].toUByte().toLong() shl 8) or (it[2].toUByte().toLong())
+    2 -> (it[0].toLong() shl 8) or (it[1].toUByte().toLong() shl 0)
+    1 -> (it[0].toLong())
+    else -> throw IllegalArgumentException("Input with size $it is out of bounds for Long")
+}
+
+fun ULong.Companion.fromTwosComplementByteArray(it: ByteArray) = when {
+    ((it.size == 9) && (it[0] == 0.toByte())) ->
+        (it[1].toUByte().toULong() shl 56) or (it[2].toUByte().toULong() shl 48) or (it[3].toUByte().toULong() shl 40) or
+                (it[4].toUByte().toULong() shl 32) or (it[5].toUByte().toULong() shl 24) or
+                (it[6].toUByte().toULong() shl 16) or (it[7].toUByte().toULong() shl 8) or
+                (it[8].toUByte().toULong())
+    else -> Long.fromTwosComplementByteArray(it).let {
+        require (it >= 0) { "Value $it is out of bounds for ULong" }
+        it.toULong()
+    }
+}
 
 /** Encodes an unsigned Long to a minimum-size unsigned byte array */
 fun Long.toUnsignedByteArray(): ByteArray {

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/Asn1Encoding.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/Asn1Encoding.kt
@@ -518,7 +518,7 @@ inline fun ByteArray.ensureSize(size: UInt) = ensureSize(size.toInt())
 fun ULong.toAsn1VarInt(): ByteArray {
     if (this < 128u) return byteArrayOf(this.toByte()) //Fast case
     var offset = 0
-    var result= mutableListOf<Byte>()
+    var result = mutableListOf<Byte>()
 
     var b0 = (this shr offset and 0x7FuL).toByte()
     while ((this shr offset > 0uL) || offset == 0) {
@@ -541,7 +541,7 @@ fun ULong.toAsn1VarInt(): ByteArray {
 fun UInt.toAsn1VarInt(): ByteArray {
     if (this < 128u) return byteArrayOf(this.toByte()) //Fast case
     var offset = 0
-    var result= mutableListOf<Byte>()
+    var result = mutableListOf<Byte>()
 
     var b0 = (this shr offset and 0x7Fu).toByte()
     while ((this shr offset > 0u) || offset == 0) {

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/Asn1Exception.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/Asn1Exception.kt
@@ -8,7 +8,7 @@ open class Asn1Exception(message: String?, cause: Throwable?) : Throwable(messag
     constructor(throwable: Throwable) : this(null, throwable)
 }
 
-class Asn1TagMismatchException(val expected: UByte, val actual: UByte, detailedMessage: String? = null) :
+class Asn1TagMismatchException(val expected: TLV.Tag, val actual: TLV.Tag, detailedMessage: String? = null) :
     Asn1Exception((detailedMessage?.let { "$it " } ?: "") + "Expected tag $expected, is: $actual")
 
 class Asn1StructuralException(message: String) : Asn1Exception(message)

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/Asn1Exception.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/Asn1Exception.kt
@@ -8,7 +8,7 @@ open class Asn1Exception(message: String?, cause: Throwable?) : Throwable(messag
     constructor(throwable: Throwable) : this(null, throwable)
 }
 
-class Asn1TagMismatchException(val expected: TLV.Tag, val actual: TLV.Tag, detailedMessage: String? = null) :
+class Asn1TagMismatchException(val expected: Asn1Element.Tag, val actual: Asn1Element.Tag, detailedMessage: String? = null) :
     Asn1Exception((detailedMessage?.let { "$it " } ?: "") + "Expected tag $expected, is: $actual")
 
 class Asn1StructuralException(message: String) : Asn1Exception(message)

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/Asn1String.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/Asn1String.kt
@@ -9,7 +9,7 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 sealed class Asn1String : Asn1Encodable<Asn1Primitive> {
-    abstract val tag: UByte
+    abstract val tag: UInt
     abstract val value: String
 
     /**
@@ -18,7 +18,7 @@ sealed class Asn1String : Asn1Encodable<Asn1Primitive> {
     @Serializable
     @SerialName("UTF8String")
     class UTF8(override val value: String) : Asn1String() {
-        override val tag = BERTags.UTF8_STRING
+        override val tag = BERTags.UTF8_STRING.toUInt()
     }
 
     /**
@@ -27,7 +27,7 @@ sealed class Asn1String : Asn1Encodable<Asn1Primitive> {
     @Serializable
     @SerialName("UniversalString")
     class Universal(override val value: String) : Asn1String() {
-        override val tag = BERTags.UNIVERSAL_STRING
+        override val tag = BERTags.UNIVERSAL_STRING.toUInt()
     }
 
     /**
@@ -36,7 +36,7 @@ sealed class Asn1String : Asn1Encodable<Asn1Primitive> {
     @Serializable
     @SerialName("VisibleString")
     class Visible(override val value: String) : Asn1String() {
-        override val tag = BERTags.VISIBLE_STRING
+        override val tag = BERTags.VISIBLE_STRING.toUInt()
     }
 
     /**
@@ -45,7 +45,7 @@ sealed class Asn1String : Asn1Encodable<Asn1Primitive> {
     @Serializable
     @SerialName("IA5String")
     class IA5(override val value: String) : Asn1String() {
-        override val tag = BERTags.IA5_STRING
+        override val tag = BERTags.IA5_STRING.toUInt()
     }
 
     /**
@@ -54,7 +54,7 @@ sealed class Asn1String : Asn1Encodable<Asn1Primitive> {
     @Serializable
     @SerialName("TeletexString")
     class Teletex(override val value: String) : Asn1String() {
-        override val tag = BERTags.T61_STRING
+        override val tag = BERTags.T61_STRING.toUInt()
     }
 
     /**
@@ -63,7 +63,7 @@ sealed class Asn1String : Asn1Encodable<Asn1Primitive> {
     @Serializable
     @SerialName("BMPString")
     class BMP(override val value: String) : Asn1String() {
-        override val tag = BERTags.BMP_STRING
+        override val tag = BERTags.BMP_STRING.toUInt()
     }
 
     /**
@@ -79,7 +79,7 @@ sealed class Asn1String : Asn1Encodable<Asn1Primitive> {
                 ?: throw Asn1Exception("Input contains invalid chars: '$value'")
         }
 
-        override val tag = BERTags.PRINTABLE_STRING
+        override val tag = BERTags.PRINTABLE_STRING.toUInt()
     }
 
     /**
@@ -94,7 +94,7 @@ sealed class Asn1String : Asn1Encodable<Asn1Primitive> {
                 ?: throw Asn1Exception("Input contains invalid chars: '$value'")
         }
 
-        override val tag = BERTags.NUMERIC_STRING
+        override val tag = BERTags.NUMERIC_STRING.toUInt()
     }
 
     override fun encodeToTlv() = Asn1Primitive(tag, value.encodeToByteArray())

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/Asn1String.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/Asn1String.kt
@@ -9,7 +9,7 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 sealed class Asn1String : Asn1Encodable<Asn1Primitive> {
-    abstract val tag: UInt
+    abstract val tag: ULong
     abstract val value: String
 
     /**
@@ -18,7 +18,7 @@ sealed class Asn1String : Asn1Encodable<Asn1Primitive> {
     @Serializable
     @SerialName("UTF8String")
     class UTF8(override val value: String) : Asn1String() {
-        override val tag = BERTags.UTF8_STRING.toUInt()
+        override val tag = BERTags.UTF8_STRING.toULong()
     }
 
     /**
@@ -27,7 +27,7 @@ sealed class Asn1String : Asn1Encodable<Asn1Primitive> {
     @Serializable
     @SerialName("UniversalString")
     class Universal(override val value: String) : Asn1String() {
-        override val tag = BERTags.UNIVERSAL_STRING.toUInt()
+        override val tag = BERTags.UNIVERSAL_STRING.toULong()
     }
 
     /**
@@ -36,7 +36,7 @@ sealed class Asn1String : Asn1Encodable<Asn1Primitive> {
     @Serializable
     @SerialName("VisibleString")
     class Visible(override val value: String) : Asn1String() {
-        override val tag = BERTags.VISIBLE_STRING.toUInt()
+        override val tag = BERTags.VISIBLE_STRING.toULong()
     }
 
     /**
@@ -45,7 +45,7 @@ sealed class Asn1String : Asn1Encodable<Asn1Primitive> {
     @Serializable
     @SerialName("IA5String")
     class IA5(override val value: String) : Asn1String() {
-        override val tag = BERTags.IA5_STRING.toUInt()
+        override val tag = BERTags.IA5_STRING.toULong()
     }
 
     /**
@@ -54,7 +54,7 @@ sealed class Asn1String : Asn1Encodable<Asn1Primitive> {
     @Serializable
     @SerialName("TeletexString")
     class Teletex(override val value: String) : Asn1String() {
-        override val tag = BERTags.T61_STRING.toUInt()
+        override val tag = BERTags.T61_STRING.toULong()
     }
 
     /**
@@ -63,7 +63,7 @@ sealed class Asn1String : Asn1Encodable<Asn1Primitive> {
     @Serializable
     @SerialName("BMPString")
     class BMP(override val value: String) : Asn1String() {
-        override val tag = BERTags.BMP_STRING.toUInt()
+        override val tag = BERTags.BMP_STRING.toULong()
     }
 
     /**
@@ -79,7 +79,7 @@ sealed class Asn1String : Asn1Encodable<Asn1Primitive> {
                 ?: throw Asn1Exception("Input contains invalid chars: '$value'")
         }
 
-        override val tag = BERTags.PRINTABLE_STRING.toUInt()
+        override val tag = BERTags.PRINTABLE_STRING.toULong()
     }
 
     /**
@@ -94,7 +94,7 @@ sealed class Asn1String : Asn1Encodable<Asn1Primitive> {
                 ?: throw Asn1Exception("Input contains invalid chars: '$value'")
         }
 
-        override val tag = BERTags.NUMERIC_STRING.toUInt()
+        override val tag = BERTags.NUMERIC_STRING.toULong()
     }
 
     override fun encodeToTlv() = Asn1Primitive(tag, value.encodeToByteArray())

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/Asn1Time.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/Asn1Time.kt
@@ -30,7 +30,7 @@ class Asn1Time(instant: Instant, formatOverride: Format? = null) : Asn1Encodable
 
         @Throws(Asn1Exception::class)
         override fun decodeFromTlv(src: Asn1Primitive) =
-            Asn1Time(src.readInstant(), if (src.tag == BERTags.UTC_TIME) Format.UTC else Format.GENERALIZED)
+            Asn1Time(src.readInstant(), if (src.tag.tagValue == BERTags.UTC_TIME.toUInt()) Format.UTC else Format.GENERALIZED)
     }
 
     override fun encodeToTlv(): Asn1Primitive =

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/Asn1Time.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/Asn1Time.kt
@@ -30,7 +30,7 @@ class Asn1Time(instant: Instant, formatOverride: Format? = null) : Asn1Encodable
 
         @Throws(Asn1Exception::class)
         override fun decodeFromTlv(src: Asn1Primitive) =
-            Asn1Time(src.readInstant(), if (src.tag.tagValue == BERTags.UTC_TIME.toULong()) Format.UTC else Format.GENERALIZED)
+            Asn1Time(src.readInstant(), if (src.tag == Asn1Element.Tag.TIME_UTC) Format.UTC else Format.GENERALIZED)
     }
 
     override fun encodeToTlv(): Asn1Primitive =

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/Asn1Time.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/Asn1Time.kt
@@ -30,7 +30,7 @@ class Asn1Time(instant: Instant, formatOverride: Format? = null) : Asn1Encodable
 
         @Throws(Asn1Exception::class)
         override fun decodeFromTlv(src: Asn1Primitive) =
-            Asn1Time(src.readInstant(), if (src.tag.tagValue == BERTags.UTC_TIME.toUInt()) Format.UTC else Format.GENERALIZED)
+            Asn1Time(src.readInstant(), if (src.tag.tagValue == BERTags.UTC_TIME.toULong()) Format.UTC else Format.GENERALIZED)
     }
 
     override fun encodeToTlv(): Asn1Primitive =

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/BERTags.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/BERTags.kt
@@ -61,7 +61,7 @@ object BERTags {
  * @param constructed whether to set the constructed bit
  */
 fun ULong.toImplicitTag(constructed: Boolean = false) =
-    TLV.Tag(this, constructed = constructed, tagClass = TagClass.CONTEXT_SPECIFIC)
+    Asn1Element.Tag(this, constructed = constructed, tagClass = TagClass.CONTEXT_SPECIFIC)
 
 fun UByte.isConstructed() = this and BERTags.CONSTRUCTED != 0.toUByte()
 

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/BERTags.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/BERTags.kt
@@ -50,35 +50,21 @@ object BERTags {
     const val CONSTRUCTED: UByte = 0x20u // decimal 32
     const val UNIVERSAL: UByte = 0x00u // decimal 32
     const val APPLICATION: UByte = 0x40u // decimal 64
-    const val TAGGED: UByte = 0x80u // decimal 128 - maybe should deprecate this.
     const val CONTEXT_SPECIFIC: UByte = 0x80u // decimal 128
     const val PRIVATE: UByte = 0xC0u // decimal 192
     const val FLAGS: UByte = 0xE0u
 
 }
 
-object DERTags {
-   /* fun UByte.toExplicitTag() = BERTags.CONSTRUCTED or BERTags.TAGGED or this
+/**
+ * Convenience helper to easily construct implicitly tagged elements. Can be CONSTRUCTED or PRIMITIVE
+ * @param constructed whether to set the constructed bit
+ */
+fun ULong.toImplicitTag(constructed: Boolean = false) =
+    TLV.Tag(this, constructed = constructed, tagClass = TagClass.CONTEXT_SPECIFIC)
 
-    val UByte.isExplicitTag get() = ((this and BERTags.CONSTRUCTED) != 0.toUByte()) && ((this and BERTags.TAGGED) != 0.toUByte())
+fun UByte.isConstructed() = this and BERTags.CONSTRUCTED != 0.toUByte()
 
-    fun UInt.toExplicitTag(): UInt {
-        val bytes = toInt().encodeToDer().dropWhile { it == 0.toByte() }.toMutableList()
-        bytes[0] = bytes.first().toUByte().toExplicitTag().toByte()
-        return UInt.decodeFromDer(bytes.toByteArray())
-    }*/
-
-    fun ULong.toImplicitTag(constructed: Boolean = false) =
-        TLV.Tag(this, constructed = constructed, tagClass = TagClass.CONTEXT_SPECIFIC)
-    //TODO: rework completely
-    /*
-    @Throws(Asn1Exception::class)
-    fun UByte.toImplicitTag() = runRethrowing {
-        if (isConstructed()) throw IllegalArgumentException("Implicit tag $this would result in CONSTRUCTED bit set") else BERTags.TAGGED or this
-    }*/
-
-    fun UByte.isConstructed() = this and BERTags.CONSTRUCTED != 0.toUByte()
-}
 
 enum class TagClass(val byteValue:UByte) {
     UNIVERSAL(0u),

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/BERTags.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/BERTags.kt
@@ -68,7 +68,8 @@ object DERTags {
         return UInt.decodeFromDer(bytes.toByteArray())
     }*/
 
-    fun UInt.toImplicitTag() = TLV.Tag(this, constructed = false, tagClass = TagClass.CONTEXT_SPECIFIC)
+    fun ULong.toImplicitTag(constructed: Boolean = false) =
+        TLV.Tag(this, constructed = constructed, tagClass = TagClass.CONTEXT_SPECIFIC)
     //TODO: rework completely
     /*
     @Throws(Asn1Exception::class)

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/BERTags.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/BERTags.kt
@@ -66,11 +66,11 @@ fun ULong.toImplicitTag(constructed: Boolean = false) =
 internal fun UByte.isConstructed() = this and BERTags.CONSTRUCTED != 0.toUByte()
 
 
-enum class TagClass(val byteValue: UByte) {
-    UNIVERSAL(0u),
-    APPLICATION(1u),
-    CONTEXT_SPECIFIC(2u),
-    PRIVATE(3u);
+enum class TagClass(val byteValue: UByte, val berTag: UByte) {
+    UNIVERSAL(0u, BERTags.UNIVERSAL),
+    APPLICATION(1u, BERTags.APPLICATION),
+    CONTEXT_SPECIFIC(2u, BERTags.CONTEXT_SPECIFIC),
+    PRIVATE(3u, BERTags.PRIVATE);
     companion object {
         fun fromByte(byteValue: Byte): KmmResult<TagClass> =
             catching { entries.first { it.byteValue == ((byteValue byteMask 0xC0).toUInt().toInt() ushr 6).toUByte()  } }

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/BERTags.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/BERTags.kt
@@ -67,9 +67,24 @@ internal fun UByte.isConstructed() = this and BERTags.CONSTRUCTED != 0.toUByte()
 
 
 enum class TagClass(val byteValue: UByte, val berTag: UByte) {
+    /**
+     * 00
+     */
     UNIVERSAL(0u, BERTags.UNIVERSAL),
+
+    /**
+     * 01
+     */
     APPLICATION(1u, BERTags.APPLICATION),
+
+    /**
+     * 10
+     */
     CONTEXT_SPECIFIC(2u, BERTags.CONTEXT_SPECIFIC),
+
+    /**
+     * 11
+     */
     PRIVATE(3u, BERTags.PRIVATE);
     companion object {
         fun fromByte(byteValue: Byte): KmmResult<TagClass> =

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/BERTags.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/BERTags.kt
@@ -63,10 +63,10 @@ object BERTags {
 fun ULong.toImplicitTag(constructed: Boolean = false) =
     Asn1Element.Tag(this, constructed = constructed, tagClass = TagClass.CONTEXT_SPECIFIC)
 
-fun UByte.isConstructed() = this and BERTags.CONSTRUCTED != 0.toUByte()
+internal fun UByte.isConstructed() = this and BERTags.CONSTRUCTED != 0.toUByte()
 
 
-enum class TagClass(val byteValue:UByte) {
+enum class TagClass(val byteValue: UByte) {
     UNIVERSAL(0u),
     APPLICATION(1u),
     CONTEXT_SPECIFIC(2u),

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/ObjectIdentifier.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/ObjectIdentifier.kt
@@ -76,7 +76,7 @@ class ObjectIdentifier @Throws(Asn1Exception::class) constructor(@Transient vara
     /**
      * @return an OBJECT IDENTIFIER [Asn1Primitive]
      */
-    override fun encodeToTlv() = Asn1Primitive(BERTags.OBJECT_IDENTIFIER.toUInt(), bytes)
+    override fun encodeToTlv() = Asn1Primitive(BERTags.OBJECT_IDENTIFIER.toULong(), bytes)
 
     companion object : Asn1Decodable<Asn1Primitive, ObjectIdentifier> {
 
@@ -86,9 +86,9 @@ class ObjectIdentifier @Throws(Asn1Exception::class) constructor(@Transient vara
          */
         @Throws(Asn1Exception::class)
         override fun decodeFromTlv(src: Asn1Primitive): ObjectIdentifier {
-            if (src.tag.tagValue != BERTags.OBJECT_IDENTIFIER.toUInt()) throw Asn1TagMismatchException(
+            if (src.tag.tagValue != BERTags.OBJECT_IDENTIFIER.toULong()) throw Asn1TagMismatchException(
                 TLV.Tag(
-                    BERTags.OBJECT_IDENTIFIER.toUInt(),
+                    BERTags.OBJECT_IDENTIFIER.toULong(),
                     constructed = false
                 ), src.tag
             )
@@ -162,7 +162,7 @@ interface Identifiable {
  */
 @Throws(Asn1Exception::class)
 fun Asn1Primitive.readOid() = runRethrowing {
-    decode(BERTags.OBJECT_IDENTIFIER.toUInt()) { ObjectIdentifier.parse(it) }
+    decode(BERTags.OBJECT_IDENTIFIER.toULong()) { ObjectIdentifier.parse(it) }
 }
 
 

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/ObjectIdentifier.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/ObjectIdentifier.kt
@@ -76,7 +76,7 @@ class ObjectIdentifier @Throws(Asn1Exception::class) constructor(@Transient vara
     /**
      * @return an OBJECT IDENTIFIER [Asn1Primitive]
      */
-    override fun encodeToTlv() = Asn1Primitive(BERTags.OBJECT_IDENTIFIER, bytes)
+    override fun encodeToTlv() = Asn1Primitive(BERTags.OBJECT_IDENTIFIER.toUInt(), bytes)
 
     companion object : Asn1Decodable<Asn1Primitive, ObjectIdentifier> {
 
@@ -86,7 +86,12 @@ class ObjectIdentifier @Throws(Asn1Exception::class) constructor(@Transient vara
          */
         @Throws(Asn1Exception::class)
         override fun decodeFromTlv(src: Asn1Primitive): ObjectIdentifier {
-            if (src.tag != BERTags.OBJECT_IDENTIFIER) throw Asn1TagMismatchException(BERTags.OBJECT_IDENTIFIER, src.tag)
+            if (src.tag.tagValue != BERTags.OBJECT_IDENTIFIER.toUInt()) throw Asn1TagMismatchException(
+                TLV.Tag(
+                    BERTags.OBJECT_IDENTIFIER.toUInt(),
+                    constructed = false
+                ), src.tag
+            )
             if (src.length < 1) throw Asn1StructuralException("Empty OIDs are not supported")
 
             return parse(src.content)
@@ -157,7 +162,7 @@ interface Identifiable {
  */
 @Throws(Asn1Exception::class)
 fun Asn1Primitive.readOid() = runRethrowing {
-    decode(BERTags.OBJECT_IDENTIFIER) { ObjectIdentifier.parse(it) }
+    decode(BERTags.OBJECT_IDENTIFIER.toUInt()) { ObjectIdentifier.parse(it) }
 }
 
 

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/ObjectIdentifier.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/ObjectIdentifier.kt
@@ -1,6 +1,5 @@
 package at.asitplus.signum.indispensable.asn1
 
-import at.asitplus.catching
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
@@ -8,9 +7,6 @@ import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
-import kotlin.experimental.and
-import kotlin.experimental.or
-import kotlin.math.ceil
 
 /**
  * ASN.1 OBJECT IDENTIFIER featuring the most cursed encoding of numbers known to man, which probably surfaced due to an ungodly combination
@@ -67,7 +63,7 @@ class ObjectIdentifier @Throws(Asn1Exception::class) constructor(@Transient vara
     /**
      * @return an OBJECT IDENTIFIER [Asn1Primitive]
      */
-    override fun encodeToTlv() = Asn1Primitive(BERTags.OBJECT_IDENTIFIER.toULong(), bytes)
+    override fun encodeToTlv() = Asn1Primitive(Asn1Element.Tag.OID, bytes)
 
     companion object : Asn1Decodable<Asn1Primitive, ObjectIdentifier> {
 
@@ -77,11 +73,8 @@ class ObjectIdentifier @Throws(Asn1Exception::class) constructor(@Transient vara
          */
         @Throws(Asn1Exception::class)
         override fun decodeFromTlv(src: Asn1Primitive): ObjectIdentifier {
-            if (src.tag.tagValue != BERTags.OBJECT_IDENTIFIER.toULong()) throw Asn1TagMismatchException(
-                TLV.Tag(
-                    BERTags.OBJECT_IDENTIFIER.toULong(),
-                    constructed = false
-                ), src.tag
+            if (src.tag != Asn1Element.Tag.OID) throw Asn1TagMismatchException(
+               Asn1Element.Tag.OID, src.tag
             )
             if (src.length < 1) throw Asn1StructuralException("Empty OIDs are not supported")
 
@@ -153,5 +146,5 @@ interface Identifiable {
  */
 @Throws(Asn1Exception::class)
 fun Asn1Primitive.readOid() = runRethrowing {
-    decode(BERTags.OBJECT_IDENTIFIER.toULong()) { ObjectIdentifier.parse(it) }
+    decode(Asn1Element.Tag.OID) { ObjectIdentifier.parse(it) }
 }

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/TLV.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/TLV.kt
@@ -1,0 +1,44 @@
+package at.asitplus.signum.indispensable.asn1
+
+import io.matthewnelson.encoding.base16.Base16
+import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
+
+internal data class TLV(val tag: Asn1Element.Tag, val content: ByteArray) {
+
+    val encodedContentLength by lazy { contentLength.encodeLength() }
+    val contentLength: Int by lazy { content.size }
+    val overallLength: Int by lazy { contentLength + tag.encodedTagLength + encodedContentLength.size }
+
+    val tagClass: TagClass get() = tag.tagClass
+
+    val isConstructed get() = tag.isConstructed
+
+    val encodedTag get() = tag.encodedTag
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null) return false
+        if (this::class != other::class) return false
+
+        other as TLV
+
+        if (tag != other.tag) return false
+        if (!content.contentEquals(other.content)) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = tag.hashCode()
+        result = 31 * result + content.contentHashCode()
+        return result
+    }
+
+    override fun toString(): String {
+        return "TLV(tag=$tag" +
+                ", length=$contentLength" +
+                ", overallLength=$overallLength" +
+                ", content=${content.encodeToString(Base16)})"
+    }
+
+}

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/pki/AlternativeNames.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/pki/AlternativeNames.kt
@@ -50,7 +50,7 @@ private constructor(private val extensions: List<Asn1Element>) {
         }.map {
             (it as Asn1Sequence).also {
                 if (it.children.size != 2) throw Asn1StructuralException("Invalid otherName Alternative Name found (!=2 children): ${it.toDerHexString()}")
-                if (it.children.last().tag != 0u.toImplicitTag()) throw Asn1StructuralException("Invalid otherName Alternative Name found (implicit tag != 0): ${it.toDerHexString()}")
+                if (it.children.last().tag != 0uL.toImplicitTag()) throw Asn1StructuralException("Invalid otherName Alternative Name found (implicit tag != 0): ${it.toDerHexString()}")
                 ObjectIdentifier.parse((it.children.first() as Asn1Primitive).content) //this throws if something is off
             }
         }
@@ -62,7 +62,7 @@ private constructor(private val extensions: List<Asn1Element>) {
         }.map {
             (it as Asn1Sequence).also {
                 if (it.children.size > 2) throw Asn1StructuralException("Invalid partyName Alternative Name found (>2 children): ${it.toDerHexString()}")
-                if (it.children.find { it.tag != 0u.toImplicitTag() && it.tag != 1u.toImplicitTag() } != null) throw Asn1StructuralException(
+                if (it.children.find { it.tag != 0uL.toImplicitTag() && it.tag != 1uL.toImplicitTag() } != null) throw Asn1StructuralException(
                     "Invalid partyName Alternative Name found (illegal implicit tag): ${it.toDerHexString()}"
                 )
                 //TODO: strict string parsing
@@ -132,13 +132,13 @@ private constructor(private val extensions: List<Asn1Element>) {
  * Enumeration of implicit tags used to indicate different `SubjectAltName`s
  */
 object SubjectAltNameImplicitTags {
-    val otherName = 0u.toImplicitTag()
-    val rfc822Name = 1u.toImplicitTag()
-    val dNSName = 2u.toImplicitTag()
-    val x400Address = 3u.toImplicitTag()
-    val directoryName = 4u.toImplicitTag()
-    val ediPartyName = 5u.toImplicitTag()
-    val uniformResourceIdentifier = 6u.toImplicitTag()
-    val iPAddress = 7u.toImplicitTag()
-    val registeredID = 8u.toImplicitTag()
+    val otherName = 0uL.toImplicitTag()
+    val rfc822Name = 1uL.toImplicitTag()
+    val dNSName = 2uL.toImplicitTag()
+    val x400Address = 3uL.toImplicitTag()
+    val directoryName = 4uL.toImplicitTag()
+    val ediPartyName = 5uL.toImplicitTag()
+    val uniformResourceIdentifier = 6uL.toImplicitTag()
+    val iPAddress = 7uL.toImplicitTag()
+    val registeredID = 8uL.toImplicitTag()
 }

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/pki/AlternativeNames.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/pki/AlternativeNames.kt
@@ -86,7 +86,7 @@ private constructor(private val extensions: List<Asn1Element>) {
             }
         }.map { ObjectIdentifier.parse((it as Asn1Primitive).content) }
 
-    private fun parseStringSANs(implicitTag: TLV.Tag) =
+    private fun parseStringSANs(implicitTag: Asn1Element.Tag) =
         extensions.filter { it.tag == implicitTag }.apply {
             forEach { if (it !is Asn1Primitive) throw Asn1StructuralException("Invalid dnsName Alternative Name found: ${it.toDerHexString()}") }
         }.map { (it as Asn1Primitive).content.decodeToString() }

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/pki/AlternativeNames.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/pki/AlternativeNames.kt
@@ -1,7 +1,6 @@
 package at.asitplus.signum.indispensable.pki
 
 import at.asitplus.signum.indispensable.asn1.*
-import at.asitplus.signum.indispensable.asn1.DERTags.toImplicitTag
 import at.asitplus.signum.indispensable.pki.AlternativeNames.Companion.findIssuerAltNames
 import at.asitplus.signum.indispensable.pki.AlternativeNames.Companion.findSubjectAltNames
 

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/pki/AlternativeNames.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/pki/AlternativeNames.kt
@@ -87,7 +87,7 @@ private constructor(private val extensions: List<Asn1Element>) {
             }
         }.map { ObjectIdentifier.parse((it as Asn1Primitive).content) }
 
-    private fun parseStringSANs(implicitTag: UByte) =
+    private fun parseStringSANs(implicitTag: TLV.Tag) =
         extensions.filter { it.tag == implicitTag }.apply {
             forEach { if (it !is Asn1Primitive) throw Asn1StructuralException("Invalid dnsName Alternative Name found: ${it.toDerHexString()}") }
         }.map { (it as Asn1Primitive).content.decodeToString() }

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/pki/X509Certificate.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/pki/X509Certificate.kt
@@ -66,7 +66,7 @@ constructor(
     override fun encodeToTlv() = runRethrowing {
         Asn1.Sequence {
             +Version(version)
-            +Asn1Primitive(BERTags.INTEGER, serialNumber)
+            +Asn1Primitive(BERTags.INTEGER.toUInt(), serialNumber)
             +signatureAlgorithm
             +Asn1.Sequence { issuerName.forEach { +it } }
 
@@ -147,7 +147,7 @@ constructor(
             val version = src.nextChild().let {
                 ((it as Asn1Tagged).verifyTag(0u).single() as Asn1Primitive).readInt()
             }
-            val serialNumber = (src.nextChild() as Asn1Primitive).decode(BERTags.INTEGER) { it }
+            val serialNumber = (src.nextChild() as Asn1Primitive).decode(BERTags.INTEGER.toUInt()) { it }
             val sigAlg = X509SignatureAlgorithm.decodeFromTlv(src.nextChild() as Asn1Sequence)
             val issuerNames = (src.nextChild() as Asn1Sequence).children.map {
                 RelativeDistinguishedName.decodeFromTlv(it as Asn1Set)

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/pki/X509Certificate.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/pki/X509Certificate.kt
@@ -65,7 +65,7 @@ constructor(
     override fun encodeToTlv() = runRethrowing {
         Asn1.Sequence {
             +Version(version)
-            +Asn1Primitive(BERTags.INTEGER.toULong(), serialNumber)
+            +Asn1Primitive(Asn1Element.Tag.INT, serialNumber)
             +signatureAlgorithm
             +Asn1.Sequence { issuerName.forEach { +it } }
 
@@ -146,7 +146,7 @@ constructor(
             val version = src.nextChild().let {
                 ((it as Asn1Tagged).verifyTag(0u).single() as Asn1Primitive).readInt()
             }
-            val serialNumber = (src.nextChild() as Asn1Primitive).decode(BERTags.INTEGER.toULong()) { it }
+            val serialNumber = (src.nextChild() as Asn1Primitive).decode(Asn1Element.Tag.INT) { it }
             val sigAlg = X509SignatureAlgorithm.decodeFromTlv(src.nextChild() as Asn1Sequence)
             val issuerNames = (src.nextChild() as Asn1Sequence).children.map {
                 RelativeDistinguishedName.decodeFromTlv(it as Asn1Set)

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/pki/X509Certificate.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/pki/X509Certificate.kt
@@ -66,7 +66,7 @@ constructor(
     override fun encodeToTlv() = runRethrowing {
         Asn1.Sequence {
             +Version(version)
-            +Asn1Primitive(BERTags.INTEGER.toUInt(), serialNumber)
+            +Asn1Primitive(BERTags.INTEGER.toULong(), serialNumber)
             +signatureAlgorithm
             +Asn1.Sequence { issuerName.forEach { +it } }
 
@@ -82,12 +82,12 @@ constructor(
 
             issuerUniqueID?.let {
                 +Asn1Primitive(
-                    1u.toImplicitTag(),
+                    1uL.toImplicitTag(),
                     Asn1BitString(it).let { byteArrayOf(it.numPaddingBits, *it.rawBytes) })
             }
             subjectUniqueID?.let {
                 +Asn1Primitive(
-                    1u.toImplicitTag(),
+                    1uL.toImplicitTag(),
                     Asn1BitString(it).let { byteArrayOf(it.numPaddingBits, *it.rawBytes) })
 
             }
@@ -147,7 +147,7 @@ constructor(
             val version = src.nextChild().let {
                 ((it as Asn1Tagged).verifyTag(0u).single() as Asn1Primitive).readInt()
             }
-            val serialNumber = (src.nextChild() as Asn1Primitive).decode(BERTags.INTEGER.toUInt()) { it }
+            val serialNumber = (src.nextChild() as Asn1Primitive).decode(BERTags.INTEGER.toULong()) { it }
             val sigAlg = X509SignatureAlgorithm.decodeFromTlv(src.nextChild() as Asn1Sequence)
             val issuerNames = (src.nextChild() as Asn1Sequence).children.map {
                 RelativeDistinguishedName.decodeFromTlv(it as Asn1Set)
@@ -161,14 +161,14 @@ constructor(
             val cryptoPublicKey = CryptoPublicKey.decodeFromTlv(src.nextChild() as Asn1Sequence)
 
             val issuerUniqueID = src.peek()?.let { next ->
-                if (next.tag == 1u.toImplicitTag()) {
-                    (src.nextChild() as Asn1Primitive).let { Asn1BitString.decodeFromTlv(it, 1u.toImplicitTag()) }
+                if (next.tag == 1uL.toImplicitTag()) {
+                    (src.nextChild() as Asn1Primitive).let { Asn1BitString.decodeFromTlv(it, 1uL.toImplicitTag()) }
                 } else null
             }
 
             val subjectUniqueID = src.peek()?.let { next ->
-                if (next.tag == 2u.toImplicitTag()) {
-                    (src.nextChild() as Asn1Primitive).let { Asn1BitString.decodeFromTlv(it, 2u.toImplicitTag()) }
+                if (next.tag == 2uL.toImplicitTag()) {
+                    (src.nextChild() as Asn1Primitive).let { Asn1BitString.decodeFromTlv(it, 2uL.toImplicitTag()) }
                 } else null
             }
             val extensions = if (src.hasMoreChildren()) {

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/pki/X509Certificate.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/pki/X509Certificate.kt
@@ -5,7 +5,6 @@ import at.asitplus.signum.indispensable.X509SignatureAlgorithm
 import at.asitplus.signum.indispensable.CryptoPublicKey
 import at.asitplus.signum.indispensable.CryptoSignature
 import at.asitplus.signum.indispensable.asn1.*
-import at.asitplus.signum.indispensable.asn1.DERTags.toImplicitTag
 import at.asitplus.signum.indispensable.io.BitSet
 import at.asitplus.signum.indispensable.io.ByteArrayBase64Serializer
 import at.asitplus.signum.indispensable.pki.AlternativeNames.Companion.findIssuerAltNames

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/pki/X509CertificateExtension.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/pki/X509CertificateExtension.kt
@@ -16,7 +16,7 @@ data class X509CertificateExtension @Throws(Asn1Exception::class) private constr
 ) : Asn1Encodable<Asn1Sequence>, Identifiable {
 
     init {
-        if (value.tag != BERTags.OCTET_STRING) throw Asn1TagMismatchException(BERTags.OCTET_STRING, value.tag)
+        if (value.tag.tagValue != BERTags.OCTET_STRING.toUInt()) throw Asn1TagMismatchException(TLV.Tag(BERTags.OCTET_STRING.toUInt(), constructed = false), value.tag)
     }
 
     constructor(
@@ -44,7 +44,7 @@ data class X509CertificateExtension @Throws(Asn1Exception::class) private constr
 
             val id = (src.children[0] as Asn1Primitive).readOid()
             val critical =
-                if (src.children[1].tag == BERTags.BOOLEAN) (src.children[1] as Asn1Primitive).content[0] == 0xff.toByte() else false
+                if (src.children[1].tag.tagValue == BERTags.BOOLEAN.toUInt()) (src.children[1] as Asn1Primitive).content[0] == 0xff.toByte() else false
 
             val value = src.children.last()
             return X509CertificateExtension(id, value, critical)

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/pki/X509CertificateExtension.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/pki/X509CertificateExtension.kt
@@ -16,7 +16,7 @@ data class X509CertificateExtension @Throws(Asn1Exception::class) private constr
 ) : Asn1Encodable<Asn1Sequence>, Identifiable {
 
     init {
-        if (value.tag.tagValue != BERTags.OCTET_STRING.toUInt()) throw Asn1TagMismatchException(TLV.Tag(BERTags.OCTET_STRING.toUInt(), constructed = false), value.tag)
+        if (value.tag.tagValue != BERTags.OCTET_STRING.toULong()) throw Asn1TagMismatchException(TLV.Tag(BERTags.OCTET_STRING.toULong(), constructed = false), value.tag)
     }
 
     constructor(
@@ -44,7 +44,7 @@ data class X509CertificateExtension @Throws(Asn1Exception::class) private constr
 
             val id = (src.children[0] as Asn1Primitive).readOid()
             val critical =
-                if (src.children[1].tag.tagValue == BERTags.BOOLEAN.toUInt()) (src.children[1] as Asn1Primitive).content[0] == 0xff.toByte() else false
+                if (src.children[1].tag.tagValue == BERTags.BOOLEAN.toULong()) (src.children[1] as Asn1Primitive).content[0] == 0xff.toByte() else false
 
             val value = src.children.last()
             return X509CertificateExtension(id, value, critical)

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/pki/X509CertificateExtension.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/pki/X509CertificateExtension.kt
@@ -16,7 +16,7 @@ data class X509CertificateExtension @Throws(Asn1Exception::class) private constr
 ) : Asn1Encodable<Asn1Sequence>, Identifiable {
 
     init {
-        if (value.tag.tagValue != BERTags.OCTET_STRING.toULong()) throw Asn1TagMismatchException(TLV.Tag(BERTags.OCTET_STRING.toULong(), constructed = false), value.tag)
+        if (value.tag != Asn1Element.Tag.OCTET_STRING) throw Asn1TagMismatchException(Asn1Element.Tag.OCTET_STRING, value.tag)
     }
 
     constructor(
@@ -44,7 +44,7 @@ data class X509CertificateExtension @Throws(Asn1Exception::class) private constr
 
             val id = (src.children[0] as Asn1Primitive).readOid()
             val critical =
-                if (src.children[1].tag.tagValue == BERTags.BOOLEAN.toULong()) (src.children[1] as Asn1Primitive).content[0] == 0xff.toByte() else false
+                if (src.children[1].tag == Asn1Element.Tag.BOOL) (src.children[1] as Asn1Primitive).content[0] == 0xff.toByte() else false
 
             val value = src.children.last()
             return X509CertificateExtension(id, value, critical)

--- a/indispensable/src/jvmTest/kotlin/at/asitplus/signum/indispensable/Asn1EncodingTest.kt
+++ b/indispensable/src/jvmTest/kotlin/at/asitplus/signum/indispensable/Asn1EncodingTest.kt
@@ -11,14 +11,17 @@ import at.asitplus.signum.indispensable.asn1.Asn1.Tagged
 import at.asitplus.signum.indispensable.asn1.Asn1.UtcTime
 import at.asitplus.signum.indispensable.asn1.Asn1.Utf8String
 import at.asitplus.signum.indispensable.io.BitSet
+import com.ionspin.kotlin.bignum.integer.BigInteger
+import com.ionspin.kotlin.bignum.integer.base63.toJavaBigInteger
+import com.ionspin.kotlin.bignum.integer.toBigInteger
+import com.ionspin.kotlin.bignum.integer.util.fromTwosComplementByteArray
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FreeSpec
 import io.kotest.datatest.withData
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
-import io.kotest.property.arbitrary.boolean
-import io.kotest.property.arbitrary.int
-import io.kotest.property.arbitrary.long
+import io.kotest.property.arbitrary.*
 import io.kotest.property.checkAll
 import kotlinx.datetime.Clock
 import org.bouncycastle.asn1.ASN1Integer
@@ -98,22 +101,93 @@ class Asn1EncodingTest : FreeSpec({
 
 
         "longs" - {
-            checkAll(iterations = 150000, Arb.long()) {
-                val seq = Asn1.Sequence { +Asn1.Int(it) }
-                val decoded = (seq.nextChild() as Asn1Primitive).readLong()
-                decoded shouldBe it
+            "failures: too small" - {
+                checkAll(iterations = 5000, Arb.bigInt(128)) {
+                    val v = BigInteger.fromLong(Long.MIN_VALUE).minus(1).minus(BigInteger.fromTwosComplementByteArray(it.toByteArray()))
+                    shouldThrow<Asn1Exception> { Asn1.Int(v).readLong() }
+                }
+            }
+            "failures: too large" - {
+                checkAll(iterations = 5000, Arb.bigInt(128)) {
+                    val v = BigInteger.fromLong(Long.MAX_VALUE).plus(1).plus(BigInteger.fromTwosComplementByteArray(it.toByteArray()))
+                    shouldThrow<Asn1Exception> { Asn1.Int(v).readLong() }
+                }
+            }
+            "successes" - {
+                checkAll(iterations = 150000, Arb.long()) {
+                    val seq = Asn1.Sequence { +Asn1.Int(it) }
+                    val decoded = (seq.nextChild() as Asn1Primitive).readLong()
+                    decoded shouldBe it
 
-                Asn1.Int(it).derEncoded shouldBe ASN1Integer(it).encoded
+                    Asn1.Int(it).derEncoded shouldBe ASN1Integer(it).encoded
+                }
             }
         }
 
         "ints" - {
-            checkAll(iterations = 150000, Arb.int()) {
-                val seq = Asn1.Sequence { +Asn1.Int(it) }
-                val decoded = (seq.nextChild() as Asn1Primitive).readInt()
-                decoded shouldBe it
+            "failures: too small" - {
+                checkAll(iterations = 5000, Arb.long(Long.MIN_VALUE..<Int.MIN_VALUE.toLong())) {
+                    shouldThrow<Asn1Exception> { Asn1.Int(it).readInt() }
+                }
+            }
+            "failures: too large" - {
+                checkAll(iterations = 5000, Arb.long(Int.MAX_VALUE.toLong()+1..<Long.MAX_VALUE)) {
+                    shouldThrow<Asn1Exception> { Asn1.Int(it).readInt() }
+                }
+            }
+            "successes" - {
+                checkAll(iterations = 75000, Arb.int()) {
+                    val seq = Asn1.Sequence { +Asn1.Int(it) }
+                    val decoded = (seq.nextChild() as Asn1Primitive).readInt()
+                    decoded shouldBe it
 
-                Asn1.Int(it).derEncoded shouldBe ASN1Integer(it.toLong()).encoded
+                    Asn1.Int(it).derEncoded shouldBe ASN1Integer(it.toLong()).encoded
+                }
+            }
+        }
+
+        "unsigned ints" - {
+            "failures: negative" - {
+                checkAll(iterations = 5000, Arb.long(Long.MIN_VALUE..<0)) {
+                    shouldThrow<Asn1Exception> { Asn1.Int(it).readUInt() }
+                }
+            }
+            "failures: too large" - {
+                checkAll(iterations = 5000, Arb.long(UInt.MAX_VALUE.toLong() + 1..Long.MAX_VALUE)) {
+                    shouldThrow<Asn1Exception> { Asn1.Int(it).readUInt() }
+                }
+            }
+            "successes" - {
+                checkAll(iterations = 75000, Arb.uInt()) {
+                    val seq = Asn1.Sequence { +Asn1.Int(it) }
+                    val decoded = (seq.nextChild() as Asn1Primitive).readUInt()
+                    decoded shouldBe it
+
+                    Asn1.Int(it).derEncoded shouldBe ASN1Integer(it.toBigInteger().toJavaBigInteger()).encoded
+                }
+            }
+        }
+
+        "unsigned longs" - {
+            "failures: negative" - {
+                checkAll(iterations = 5000, Arb.long(Long.MIN_VALUE..<0)) {
+                    shouldThrow<Asn1Exception> { Asn1.Int(it).readULong() }
+                }
+            }
+            "failures: too large" - {
+                checkAll(iterations = 5000, Arb.bigInt(128)) {
+                    val v = BigInteger.fromULong(ULong.MAX_VALUE).plus(1).plus(BigInteger.fromTwosComplementByteArray(it.toByteArray()))
+                    shouldThrow<Asn1Exception> { Asn1.Int(v).readULong() }
+                }
+            }
+            "successes" - {
+                checkAll(iterations = 75000, Arb.uLong()) {
+                    val seq = Asn1.Sequence { +Asn1.Int(it) }
+                    val decoded = (seq.nextChild() as Asn1Primitive).readULong()
+                    decoded shouldBe it
+
+                    Asn1.Int(it).derEncoded shouldBe ASN1Integer(it.toBigInteger().toJavaBigInteger()).encoded
+                }
             }
         }
 
@@ -121,7 +195,7 @@ class Asn1EncodingTest : FreeSpec({
 
     "Parsing and encoding results in the same bytes" {
         val certBytes = Base64.getMimeDecoder()
-            .decode(javaClass.classLoader.getResourceAsStream("github-com.pem").reader().readText())
+            .decode(javaClass.classLoader.getResourceAsStream("github-com.pem")!!.reader().readText())
         val tree = Asn1Element.parse(certBytes)
             tree.derEncoded shouldBe certBytes
         }

--- a/indispensable/src/jvmTest/kotlin/at/asitplus/signum/indispensable/Asn1EncodingTest.kt
+++ b/indispensable/src/jvmTest/kotlin/at/asitplus/signum/indispensable/Asn1EncodingTest.kt
@@ -11,6 +11,7 @@ import at.asitplus.signum.indispensable.asn1.Asn1.Tagged
 import at.asitplus.signum.indispensable.asn1.Asn1.UtcTime
 import at.asitplus.signum.indispensable.asn1.Asn1.Utf8String
 import at.asitplus.signum.indispensable.io.BitSet
+import io.kotest.assertions.withClue
 import io.kotest.core.spec.style.FreeSpec
 import io.kotest.datatest.withData
 import io.kotest.matchers.nulls.shouldNotBeNull
@@ -20,6 +21,8 @@ import io.kotest.property.arbitrary.boolean
 import io.kotest.property.arbitrary.int
 import io.kotest.property.arbitrary.long
 import io.kotest.property.checkAll
+import io.matthewnelson.encoding.base16.Base16
+import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
 import kotlinx.datetime.Clock
 import org.bouncycastle.asn1.ASN1Integer
 import java.util.*
@@ -119,8 +122,11 @@ class Asn1EncodingTest : FreeSpec({
         val certBytes = Base64.getMimeDecoder()
             .decode(javaClass.classLoader.getResourceAsStream("github-com.pem").reader().readText())
         val tree = Asn1Element.parse(certBytes)
-        tree.derEncoded shouldBe certBytes
-    }
+        println(tree.prettyPrint())
+
+            tree.derEncoded shouldBe certBytes
+        }
+
 
     "Old and new encoder produce the same bytes" {
 

--- a/indispensable/src/jvmTest/kotlin/at/asitplus/signum/indispensable/Asn1EncodingTest.kt
+++ b/indispensable/src/jvmTest/kotlin/at/asitplus/signum/indispensable/Asn1EncodingTest.kt
@@ -91,7 +91,7 @@ class Asn1EncodingTest : FreeSpec({
             val fromBC = ASN1Integer(it).encoded
             val long = Long.decodeFromDerValue(bytes)
 
-            val encoded = Asn1Primitive(BERTags.INTEGER, bytes).derEncoded
+            val encoded = Asn1Primitive(Asn1Element.Tag.INT, bytes).derEncoded
             encoded shouldBe fromBC
             long shouldBe it
         }

--- a/indispensable/src/jvmTest/kotlin/at/asitplus/signum/indispensable/Asn1EncodingTest.kt
+++ b/indispensable/src/jvmTest/kotlin/at/asitplus/signum/indispensable/Asn1EncodingTest.kt
@@ -11,7 +11,6 @@ import at.asitplus.signum.indispensable.asn1.Asn1.Tagged
 import at.asitplus.signum.indispensable.asn1.Asn1.UtcTime
 import at.asitplus.signum.indispensable.asn1.Asn1.Utf8String
 import at.asitplus.signum.indispensable.io.BitSet
-import io.kotest.assertions.withClue
 import io.kotest.core.spec.style.FreeSpec
 import io.kotest.datatest.withData
 import io.kotest.matchers.nulls.shouldNotBeNull
@@ -21,8 +20,6 @@ import io.kotest.property.arbitrary.boolean
 import io.kotest.property.arbitrary.int
 import io.kotest.property.arbitrary.long
 import io.kotest.property.checkAll
-import io.matthewnelson.encoding.base16.Base16
-import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
 import kotlinx.datetime.Clock
 import org.bouncycastle.asn1.ASN1Integer
 import java.util.*
@@ -92,7 +89,7 @@ class Asn1EncodingTest : FreeSpec({
             val bytes = (it).encodeToByteArray()
 
             val fromBC = ASN1Integer(it).encoded
-            val long = Long.decodeFromDer(bytes)
+            val long = Long.decodeFromDerValue(bytes)
 
             val encoded = Asn1Primitive(BERTags.INTEGER, bytes).derEncoded
             encoded shouldBe fromBC

--- a/indispensable/src/jvmTest/kotlin/at/asitplus/signum/indispensable/Asn1EncodingTest.kt
+++ b/indispensable/src/jvmTest/kotlin/at/asitplus/signum/indispensable/Asn1EncodingTest.kt
@@ -119,8 +119,6 @@ class Asn1EncodingTest : FreeSpec({
         val certBytes = Base64.getMimeDecoder()
             .decode(javaClass.classLoader.getResourceAsStream("github-com.pem").reader().readText())
         val tree = Asn1Element.parse(certBytes)
-        println(tree.prettyPrint())
-
             tree.derEncoded shouldBe certBytes
         }
 

--- a/indispensable/src/jvmTest/kotlin/at/asitplus/signum/indispensable/Asn1EncodingTest.kt
+++ b/indispensable/src/jvmTest/kotlin/at/asitplus/signum/indispensable/Asn1EncodingTest.kt
@@ -83,10 +83,10 @@ class Asn1EncodingTest : FreeSpec({
         parsed.shouldNotBeNull()
     }
 
-    "Ans1 Number encoding" - {
+    "Asn1 Number encoding" - {
 
         withData(15253481L, -1446230472L, 0L, 1L, -1L, -2L, -9994587L, 340281555L) {
-            val bytes = (it).encodeToByteArray()
+            val bytes = (it).toTwosComplementByteArray()
 
             val fromBC = ASN1Integer(it).encoded
             val long = Long.decodeFromDerValue(bytes)
@@ -98,18 +98,22 @@ class Asn1EncodingTest : FreeSpec({
 
 
         "longs" - {
-            checkAll(iterations = 15000, Arb.long()) {
-                val seq = Asn1.Sequence { +Asn1.Long(it) }
+            checkAll(iterations = 150000, Arb.long()) {
+                val seq = Asn1.Sequence { +Asn1.Int(it) }
                 val decoded = (seq.nextChild() as Asn1Primitive).readLong()
                 decoded shouldBe it
+
+                Asn1.Int(it).derEncoded shouldBe ASN1Integer(it).encoded
             }
         }
 
         "ints" - {
-            checkAll(iterations = 15000, Arb.int()) {
+            checkAll(iterations = 150000, Arb.int()) {
                 val seq = Asn1.Sequence { +Asn1.Int(it) }
                 val decoded = (seq.nextChild() as Asn1Primitive).readInt()
                 decoded shouldBe it
+
+                Asn1.Int(it).derEncoded shouldBe ASN1Integer(it.toLong()).encoded
             }
         }
 
@@ -152,7 +156,7 @@ class Asn1EncodingTest : FreeSpec({
 
             +Asn1.Set {
                 +Asn1.Int(3)
-                +Asn1.Long(-65789876543L)
+                +Asn1.Int(-65789876543L)
                 +Bool(false)
                 +Bool(true)
             }

--- a/indispensable/src/jvmTest/kotlin/at/asitplus/signum/indispensable/CryptoSignatureTest.kt
+++ b/indispensable/src/jvmTest/kotlin/at/asitplus/signum/indispensable/CryptoSignatureTest.kt
@@ -1,6 +1,6 @@
 package at.asitplus.signum.indispensable
 
-import at.asitplus.signum.indispensable.asn1.encodeToByteArray
+import at.asitplus.signum.indispensable.asn1.toTwosComplementByteArray
 import com.ionspin.kotlin.bignum.integer.BigInteger
 import com.ionspin.kotlin.bignum.integer.toBigInteger
 import io.kotest.assertions.throwables.shouldThrow
@@ -20,9 +20,9 @@ class CryptoSignatureTest : FreeSpec({
             val ec1 = CryptoSignature.EC.fromRS(first.toBigInteger(), second.toBigInteger())
             val ec2 = CryptoSignature.EC.fromRS(first.toBigInteger(), second.toBigInteger())
             val ec3 = CryptoSignature.EC.fromRS(second.toBigInteger(), first.toBigInteger())
-            val rsa1 = CryptoSignature.RSAorHMAC(first.encodeToByteArray())
-            val rsa2 = CryptoSignature.RSAorHMAC(first.encodeToByteArray())
-            val rsa3 = CryptoSignature.RSAorHMAC(second.encodeToByteArray())
+            val rsa1 = CryptoSignature.RSAorHMAC(first.toTwosComplementByteArray())
+            val rsa2 = CryptoSignature.RSAorHMAC(first.toTwosComplementByteArray())
+            val rsa3 = CryptoSignature.RSAorHMAC(second.toTwosComplementByteArray())
 
             ec1 shouldBe ec1
             ec1 shouldBe ec2

--- a/indispensable/src/jvmTest/kotlin/at/asitplus/signum/indispensable/CustomTaggedTest.kt
+++ b/indispensable/src/jvmTest/kotlin/at/asitplus/signum/indispensable/CustomTaggedTest.kt
@@ -1,0 +1,42 @@
+package at.asitplus.signum.indispensable
+
+import at.asitplus.signum.indispensable.asn1.*
+import io.kotest.core.spec.style.FreeSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.int
+import io.kotest.property.checkAll
+import org.bouncycastle.asn1.ASN1InputStream
+
+class CustomTaggedTest : FreeSpec({
+    "Custom CONSTRUCTED" - {
+        checkAll(Arb.int(min = 0, max = Int.MAX_VALUE/*BC limits*/)) {
+            Asn1CustomStructure(
+                listOf(),
+                it.toULong(),
+                TagClass.entries.filterNot { it == TagClass.UNIVERSAL }.random()
+            ).also {
+                ASN1InputStream(it.derEncoded).readObject().encoded shouldBe it.derEncoded
+                Asn1Element.parse(it.derEncoded) shouldBe it
+            }
+        }
+    }
+
+    "Custom as Primitive" - {
+        checkAll(Arb.int(min = 0, max = Int.MAX_VALUE/*BC limits*/)) {
+            Asn1CustomStructure.asPrimitive(
+                listOf(),
+                it.toULong(),
+                TagClass.entries.filterNot { it == TagClass.UNIVERSAL }.random()
+            ).also {
+                ASN1InputStream(it.derEncoded).readObject().encoded shouldBe it.derEncoded
+                Asn1Element.parse(it.derEncoded).apply {
+                    derEncoded shouldBe it.derEncoded //it will parse to a primitive
+                    this.shouldBeInstanceOf<Asn1Primitive>()
+                }
+            }
+        }
+    }
+
+})

--- a/indispensable/src/jvmTest/kotlin/at/asitplus/signum/indispensable/OidTest.kt
+++ b/indispensable/src/jvmTest/kotlin/at/asitplus/signum/indispensable/OidTest.kt
@@ -1,6 +1,7 @@
 package at.asitplus.signum.indispensable
 
 import at.asitplus.signum.indispensable.asn1.ObjectIdentifier
+import io.kotest.assertions.withClue
 import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
@@ -9,6 +10,9 @@ import io.kotest.property.arbitrary.int
 import io.kotest.property.arbitrary.intArray
 import io.kotest.property.arbitrary.positiveInt
 import io.kotest.property.checkAll
+import org.bouncycastle.asn1.ASN1Integer
+import org.bouncycastle.asn1.ASN1ObjectIdentifier
+import org.bouncycastle.asn1.DERTaggedObject
 
 class OidTest : FreeSpec({
     "OID test" - {
@@ -27,13 +31,17 @@ class OidTest : FreeSpec({
 
         "Automated" - {
             checkAll(iterations = 15, Arb.positiveInt(39)) { second ->
-                checkAll(iterations = 1000, Arb.intArray(Arb.int(0..128), Arb.positiveInt(Int.MAX_VALUE))) {
+                checkAll(iterations = 5000, Arb.intArray(Arb.int(0..128), Arb.positiveInt(Int.MAX_VALUE))) {
                     listOf(1, 2).forEach { first ->
                         val oid = ObjectIdentifier(
                             first.toUInt(),
                             second.toUInt(),
                             *(it.map { it.toUInt() }.toUIntArray())
                         )
+
+                        val stringRepresentation =
+                            "$first.$second" + if (it.isEmpty()) "" else ("." + it.joinToString("."))
+
                         val second1 = if (second > 1) second - 1 else second + 1
 
                         val oid1 = ObjectIdentifier(
@@ -42,6 +50,21 @@ class OidTest : FreeSpec({
                             *(it.map { it.toUInt() }.toUIntArray())
                         )
                         val parsed = ObjectIdentifier.decodeFromTlv(oid.encodeToTlv())
+                        val fromBC = ASN1ObjectIdentifier(stringRepresentation)
+
+                        val bcEncoded = fromBC.encoded
+                        val ownEncoded = oid.encodeToDer()
+
+                        @OptIn(ExperimentalStdlibApi::class)
+                        withClue(
+                            "Expected: ${bcEncoded.toHexString(HexFormat.UpperCase)}\nActual: ${
+                                ownEncoded.toHexString(
+                                    HexFormat.UpperCase
+                                )
+                            }"
+                        ) {
+                            bcEncoded shouldBe ownEncoded
+                        }
                         parsed shouldBe oid
                         parsed.hashCode() shouldBe oid.hashCode()
                         parsed shouldNotBe oid1

--- a/indispensable/src/jvmTest/kotlin/at/asitplus/signum/indispensable/TagEncodingTest.kt
+++ b/indispensable/src/jvmTest/kotlin/at/asitplus/signum/indispensable/TagEncodingTest.kt
@@ -20,7 +20,7 @@ class TagEncodingTest : FreeSpec({
     "Manual" -{
         withData(207692171uL, 128uL, 36uL, 16088548868045964978uL, 15871772363588580035uL) {
             it.toAsn1VarInt().decodeAsn1VarULong().first shouldBe it
-            val tag = TLV.Tag(it, constructed = it % 2uL == 0uL)
+            val tag = Asn1Element.Tag(it, constructed = it % 2uL == 0uL)
             tag.tagValue shouldBe it
 
         }
@@ -29,12 +29,12 @@ class TagEncodingTest : FreeSpec({
     "Automated" - {
         checkAll(iterations = 100000, Arb.uLong()) {
             it.toAsn1VarInt().decodeAsn1VarULong().first shouldBe it
-            TLV.Tag(it,constructed = it %2uL==0uL).tagValue shouldBe it
+            Asn1Element.Tag(it, constructed = it % 2uL == 0uL).tagValue shouldBe it
         }
     }
     "Against BC" - {
         checkAll(iterations = 1000000, Arb.int(min=0)) {
-            val tag = TLV.Tag(it.toULong(), constructed = false)
+            val tag = Asn1Element.Tag(it.toULong(), constructed = false)
             tag.tagValue shouldBe it.toULong()
 
             val bc = DERTaggedObject(true, it, ASN1Integer(1337))
@@ -56,7 +56,7 @@ class TagEncodingTest : FreeSpec({
 
     "Manual against BC" - {
         withData(207692171, 1337) {
-            val tag = TLV.Tag(it.toULong(), constructed = false)
+            val tag = Asn1Element.Tag(it.toULong(), constructed = false)
             tag.tagValue shouldBe it.toULong()
 
             val bc = DERTaggedObject(true, it, ASN1Integer(1337))

--- a/indispensable/src/jvmTest/kotlin/at/asitplus/signum/indispensable/TagEncodingTest.kt
+++ b/indispensable/src/jvmTest/kotlin/at/asitplus/signum/indispensable/TagEncodingTest.kt
@@ -17,6 +17,16 @@ import org.bouncycastle.asn1.DERTaggedObject
 
 class TagEncodingTest : FreeSpec({
 
+    "fails" {
+        val it = 2204309167L
+        val bytes = (it).toTwosComplementByteArray()
+        val fromBC = ASN1Integer(it).encoded
+        val long = Long.decodeFromDerValue(bytes)
+        val encoded = Asn1.Int(it).derEncoded
+        encoded shouldBe fromBC
+        long shouldBe it
+    }
+
     "Manual" - {
         withData(207692171uL, 128uL, 36uL, 16088548868045964978uL, 15871772363588580035uL) {
             it.toAsn1VarInt().decodeAsn1VarULong().first shouldBe it

--- a/indispensable/src/jvmTest/kotlin/at/asitplus/signum/indispensable/TagEncodingTest.kt
+++ b/indispensable/src/jvmTest/kotlin/at/asitplus/signum/indispensable/TagEncodingTest.kt
@@ -1,0 +1,89 @@
+@file:OptIn(ExperimentalStdlibApi::class)
+
+package at.asitplus.signum.indispensable
+
+import at.asitplus.signum.indispensable.asn1.*
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FreeSpec
+import io.kotest.datatest.withData
+import io.kotest.matchers.shouldBe
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.int
+import io.kotest.property.arbitrary.uInt
+import io.kotest.property.arbitrary.uLong
+import io.kotest.property.checkAll
+import org.bouncycastle.asn1.ASN1Integer
+import org.bouncycastle.asn1.DERTaggedObject
+
+class TagEncodingTest : FreeSpec({
+
+    "Manual" -{
+        withData(207692171uL, 128uL, 36uL, 16088548868045964978uL, 15871772363588580035uL) {
+            it.toAsn1VarInt().decodeAsn1VarULong().first shouldBe it
+            val tag = TLV.Tag(it, constructed = it % 2uL == 0uL)
+            tag.tagValue shouldBe it
+
+        }
+
+    }
+    "Automated" - {
+        checkAll(iterations = 100000, Arb.uLong()) {
+            it.toAsn1VarInt().decodeAsn1VarULong().first shouldBe it
+            TLV.Tag(it,constructed = it %2uL==0uL).tagValue shouldBe it
+        }
+    }
+    "Against BC" - {
+        checkAll(iterations = 1000000, Arb.int(min=0)) {
+            val tag = TLV.Tag(it.toULong(), constructed = false)
+            tag.tagValue shouldBe it.toULong()
+
+            val bc = DERTaggedObject(true, it, ASN1Integer(1337))
+            val own = Asn1.Tagged(it.toULong()) {
+                +Asn1.Int(1337)
+            }
+            withClue(
+                "Expected: ${bc.encoded.toHexString(HexFormat.UpperCase)}, actual: ${
+                    own.derEncoded.toHexString(
+                        HexFormat.UpperCase
+                    )
+                }"
+            ) {
+                own.derEncoded shouldBe bc.encoded
+            }
+        }
+    }
+
+
+    "Manual against BC" - {
+        withData(207692171, 1337) {
+            val tag = TLV.Tag(it.toULong(), constructed = false)
+            tag.tagValue shouldBe it.toULong()
+
+            val bc = DERTaggedObject(true, it, ASN1Integer(1337))
+            val own = Asn1.Tagged(it.toULong()) {
+                +Asn1.Int(1337)
+            }
+            withClue(
+                "Expected: ${bc.encoded.toHexString(HexFormat.UpperCase)}, actual: ${
+                    own.derEncoded.toHexString(
+                        HexFormat.UpperCase
+                    )
+                }"
+            ) {
+                own.derEncoded shouldBe bc.encoded
+            }
+        }
+    }
+
+
+    "Ints" - {
+        checkAll(iterations = 100000, Arb.uInt()) {
+            it.toAsn1VarInt().apply {
+                decodeAsn1VarULong().first.toUInt() shouldBe it
+                decodeAsn1VarULong().first shouldBe it.toULong()
+                decodeAsn1VarUInt().first shouldBe it
+            }
+        }
+    }
+
+})

--- a/indispensable/src/jvmTest/kotlin/at/asitplus/signum/indispensable/TagEncodingTest.kt
+++ b/indispensable/src/jvmTest/kotlin/at/asitplus/signum/indispensable/TagEncodingTest.kt
@@ -17,7 +17,7 @@ import org.bouncycastle.asn1.DERTaggedObject
 
 class TagEncodingTest : FreeSpec({
 
-    "Manual" -{
+    "Manual" - {
         withData(207692171uL, 128uL, 36uL, 16088548868045964978uL, 15871772363588580035uL) {
             it.toAsn1VarInt().decodeAsn1VarULong().first shouldBe it
             val tag = Asn1Element.Tag(it, constructed = it % 2uL == 0uL)
@@ -33,7 +33,7 @@ class TagEncodingTest : FreeSpec({
         }
     }
     "Against BC" - {
-        checkAll(iterations = 1000000, Arb.int(min=0)) {
+        checkAll(iterations = 1000000, Arb.int(min = 0)) {
             val tag = Asn1Element.Tag(it.toULong(), constructed = false)
             tag.tagValue shouldBe it.toULong()
 

--- a/indispensable/src/jvmTest/kotlin/at/asitplus/signum/indispensable/TagSortingTest.kt
+++ b/indispensable/src/jvmTest/kotlin/at/asitplus/signum/indispensable/TagSortingTest.kt
@@ -1,0 +1,82 @@
+@file:OptIn(ExperimentalStdlibApi::class)
+
+package at.asitplus.signum.indispensable
+
+import at.asitplus.signum.indispensable.asn1.Asn1Element
+import at.asitplus.signum.indispensable.asn1.TagClass
+import io.kotest.core.spec.style.FreeSpec
+import io.kotest.matchers.comparables.shouldBeGreaterThan
+import io.kotest.matchers.comparables.shouldBeLessThan
+import io.kotest.matchers.shouldBe
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.uLong
+import io.kotest.property.checkAll
+
+class TagSortingTest : FreeSpec({
+
+    "Automated" - {
+        val sortedClasses =
+            listOf(TagClass.UNIVERSAL, TagClass.APPLICATION, TagClass.CONTEXT_SPECIFIC, TagClass.PRIVATE)
+        checkAll(iterations = 1000, Arb.uLong()) { a ->
+            val tagA = Asn1Element.Tag(
+                a,
+                constructed = false,
+                tagClass = TagClass.UNIVERSAL
+            )
+            val tagAAPP = Asn1Element.Tag(
+                a,
+                constructed = false,
+                tagClass = TagClass.APPLICATION
+            )
+            val tagACTX = Asn1Element.Tag(
+                a,
+                constructed = false,
+                tagClass = TagClass.CONTEXT_SPECIFIC
+            )
+            val tagAP = Asn1Element.Tag(
+                a,
+                constructed = false,
+                tagClass = TagClass.PRIVATE
+            )
+
+            val tagAC = Asn1Element.Tag(
+                a,
+                constructed = true,
+                tagClass = TagClass.UNIVERSAL
+            )
+
+            tagA shouldBeLessThan tagAC
+
+            tagA shouldBeLessThan tagAAPP
+            tagA shouldBeLessThan tagACTX
+            tagA shouldBeLessThan tagAP
+
+            tagAC shouldBeLessThan tagAAPP
+            tagAC shouldBeLessThan tagACTX
+            tagAC shouldBeLessThan tagAP
+
+            val aTags = listOf(tagA, tagAC, tagAAPP, tagACTX, tagAP)
+            checkAll(iterations = 1000, Arb.uLong()) { b ->
+                val tagB = Asn1Element.Tag(
+                    b,
+                    constructed = false,
+                    tagClass = TagClass.UNIVERSAL
+                )
+
+                a.compareTo(b) shouldBe tagA.compareTo(tagB)
+
+                if(tagA.encodedTagLength < tagB.encodedTagLength) {
+                    aTags.forEach { it shouldBeLessThan tagB }
+                }
+                if(tagA.encodedTagLength>tagB.encodedTagLength) {
+                    aTags.forEach { it shouldBeGreaterThan  tagB }
+                }
+
+                if(tagA.encodedTagLength==tagB.encodedTagLength) {
+                    aTags.filterNot { it.tagClass==TagClass.UNIVERSAL }.forEach { it shouldBeGreaterThan  tagB }
+                }
+
+            }
+        }
+    }
+})

--- a/indispensable/src/jvmTest/kotlin/at/asitplus/signum/indispensable/UVarIntTest.kt
+++ b/indispensable/src/jvmTest/kotlin/at/asitplus/signum/indispensable/UVarIntTest.kt
@@ -1,0 +1,40 @@
+package at.asitplus.signum.indispensable
+
+import at.asitplus.signum.indispensable.asn1.decodeAsn1VarUInt
+import at.asitplus.signum.indispensable.asn1.decodeAsn1VarULong
+import at.asitplus.signum.indispensable.asn1.toAsn1VarInt
+import io.kotest.core.spec.style.FreeSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.uInt
+import io.kotest.property.arbitrary.uLong
+import io.kotest.property.checkAll
+import kotlin.random.Random
+
+class UVarIntTest : FreeSpec({
+
+    "UInts with trailing bytes" - {
+        "manual" {
+            byteArrayOf(65, 0, 0, 0).decodeAsn1VarUInt().first shouldBe 65u
+        }
+        "automated -" {
+            checkAll(Arb.uInt()) { int ->
+                (int.toAsn1VarInt().asList() + Random.nextBytes(8).asList()).decodeAsn1VarUInt().first shouldBe int
+
+            }
+        }
+    }
+
+    "ULongs with trailing bytes" - {
+        "manual" {
+            byteArrayOf(65, 0, 0, 0).decodeAsn1VarULong().first shouldBe 65uL
+        }
+        "automated -" {
+            checkAll(Arb.uLong()) { long ->
+                (long.toAsn1VarInt().asList() + Random.nextBytes(8).asList()).decodeAsn1VarULong().first shouldBe long
+
+            }
+        }
+    }
+
+})

--- a/indispensable/src/jvmTest/kotlin/at/asitplus/signum/indispensable/X509CertificateJvmTest.kt
+++ b/indispensable/src/jvmTest/kotlin/at/asitplus/signum/indispensable/X509CertificateJvmTest.kt
@@ -456,8 +456,8 @@ fun List<Asn1Element>.expect(init: SequenceReader.() -> Unit): Boolean {
 class SequenceReader(var asn1Elements: List<Asn1Element>) {
     var matches: Boolean = true
 
-    fun sequence(function: SequenceReader.() -> Unit) = container(0x30u, function)
-    fun set(function: SequenceReader.() -> Unit) = container(0x31u, function)
+    fun sequence(function: SequenceReader.() -> Unit) = container(BERTags.SEQUENCE, function)
+    fun set(function: SequenceReader.() -> Unit) = container(BERTags.SET, function)
 
     fun integer() = tag(0x02u)
     fun long() = tag(0x02u)
@@ -468,13 +468,13 @@ class SequenceReader(var asn1Elements: List<Asn1Element>) {
 
     fun container(tag: UByte, function: SequenceReader.() -> Unit) {
         val first = takeAndDrop()
-        if (first.tag != tag)
+        if (first.tag != TLV.Tag(tag.toUInt(), constructed = true))
             matches = false
         matches = matches and (first as Asn1Structure).children.expect(function)
     }
 
-    fun tag(tag: UByte) {
-        if (takeAndDrop().tag != tag)
+    fun tag(tag: UInt) {
+        if (takeAndDrop().tag != TLV.Tag(tag.toUInt(), constructed = false))
             matches = false
     }
 


### PR DESCRIPTION
* Completely revamped ASN.1 Tag Handling
  * Properly handle multi-byte tags
  * Introduce a new data structure `TLV.Tag` with an accompanying `TagClass` enum and a `constructed` flag to accurately represent arbitrary tags up to `ULong.MAX_VALUE`
  * Make all `tag` parameters `ULong` to reflect support for multi-byte tags
  * Remove `DERTags`
  * Revamp implicit tagging (there is still work to be done, but at least it supports CONSTRUCTED ASN.1 elements)
* Refactor `Int.Companion.decodeFromDer()` -> `Int.Companion.decodeFromDerValue()`
* Refactor `Long.Companion.decodeFromDer()` -> `Long.Companion.decodeFromDerValue()`
* Introduce `ULong.toAsn1VarInt()` to encode ULongs into ASN.1 unsigned VarInts (**not to be confused with
  multi^2_base's`UVarInt`!**)
* Introduce `decodeAsn1VarULong()` and `decodeAsn1VarUInt()` which can handle overlong inputs, as long as they start with a valid unsigned number encoding.
  * Comes in three ULong flavours:
    * `Iterator<Byte>.decodeAsn1VarULong()`
    * `Iterable<Byte>.decodeAsn1VarULong()`
    * `ByteArray.decodeAsn1VarULong()`
  * and three UInt flavours:
      * `Iterator<Byte>.decodeAsn1VarUInt()`
      * `Iterable<Byte>.decodeAsn1VarUInt()`
      * `ByteArray.decodeAsn1VarUInt()`