### PR TITLE
Consume only the first ASN.1 Element when parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@
         * `Iterable<Byte>.decodeAsn1VarUInt()`
         * `ByteArray.decodeAsn1VarUInt()`
 * Revamp implicit tagging
+* Consume only the first `Asn1Element.parse()` only consumes the first parsable element and
+  `Asn1Element.parserWithRemainder()` additionally returns the remaining bytes for convenience
 
 ## 3.0
 

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/Asn1Elements.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/Asn1Elements.kt
@@ -41,7 +41,8 @@ sealed class Asn1Element(
 
     companion object {
         /**
-         * Convenience method to directly parse a HEX-string representation of DER-encoded data
+         * Convenience method to directly parse a HEX-string representation of DER-encoded data.
+         * Ignores and strips all whitespace.
          * @throws [Throwable] all sorts of errors on invalid input
          */
         @Throws(Throwable::class)

--- a/indispensable/src/jvmTest/kotlin/at/asitplus/signum/indispensable/X509CertParserTest.kt
+++ b/indispensable/src/jvmTest/kotlin/at/asitplus/signum/indispensable/X509CertParserTest.kt
@@ -22,6 +22,8 @@ import java.io.FileReader
 import java.io.InputStream
 import java.security.cert.CertificateFactory
 import java.util.*
+import kotlin.random.Random
+import kotlin.random.nextInt
 import java.security.cert.X509Certificate as JcaCertificate
 
 
@@ -34,6 +36,12 @@ class X509CertParserTest : FreeSpec({
         val derBytes =
             javaClass.classLoader.getResourceAsStream("certs/ok-uniqueid-incomplete-byte.der").readBytes()
         X509Certificate.decodeFromDer(derBytes)
+
+        val garbage = Random.nextBytes(Random.nextInt(0..128))
+        Asn1Element.parseWithRemainder(derBytes + garbage).let { (parsed, remainder) ->
+            parsed.derEncoded shouldBe derBytes
+            remainder shouldBe garbage
+        }
     }
 
 
@@ -52,6 +60,12 @@ class X509CertParserTest : FreeSpec({
                 cert.encodeToTlv().derEncoded shouldBe jcaCert.encoded
 
                 cert shouldBe X509Certificate.decodeFromByteArray(certBytes)
+
+                val garbage = Random.nextBytes(Random.nextInt(0..128))
+                Asn1Element.parseWithRemainder(certBytes + garbage).let { (parsed, remainder) ->
+                    parsed.derEncoded shouldBe certBytes
+                    remainder shouldBe garbage
+                }
             }
         }
     }
@@ -106,6 +120,12 @@ class X509CertParserTest : FreeSpec({
             ) {
                 own shouldBe crt.encoded
                 parsed shouldBe X509Certificate.decodeFromByteArray(crt.encoded)
+
+                val garbage = Random.nextBytes(Random.nextInt(0..128))
+                Asn1Element.parseWithRemainder(crt.encoded + garbage).let { (parsed, remainder) ->
+                    parsed.derEncoded shouldBe own
+                    remainder shouldBe garbage
+                }
             }
         }
     }
@@ -122,6 +142,12 @@ class X509CertParserTest : FreeSpec({
                 val src = Asn1Element.parse(it.second) as Asn1Sequence
                 val decoded = X509Certificate.decodeFromTlv(src)
                 decoded shouldBe X509Certificate.decodeFromByteArray(it.second)
+
+                val garbage = Random.nextBytes(Random.nextInt(0..128))
+                Asn1Element.parseWithRemainder(it.second + garbage).let { (parsed, remainder) ->
+                    parsed.derEncoded shouldBe it.second
+                    remainder shouldBe garbage
+                }
             }
         }
         "Faulty certs should glitch out" - {
@@ -159,6 +185,12 @@ class X509CertParserTest : FreeSpec({
 
                 jcaCert.encoded shouldBe encodedSrc
                 cert.encodeToTlv().derEncoded shouldBe encodedSrc
+
+                val garbage = Random.nextBytes(Random.nextInt(0..128))
+                Asn1Element.parseWithRemainder(jcaCert.encoded + garbage).let { (parsed, remainder) ->
+                    parsed.derEncoded shouldBe jcaCert.encoded
+                    remainder shouldBe garbage
+                }
             }
         }
 


### PR DESCRIPTION
addresses #121.
this is a stop-gap solution until we get to adopting kotlinx.io