### PR TITLE
Migrate JCA signing from DER encoding to P1363 encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 * Change CSR to take an actual `CryptoSignature` instead of a ByteArray
 * Introduce shorthand to create CSR from TbsCSR
 * Introduce shorthand to create certificate from TbsCertificate
+* Add `SignatureAlgorithm.signWithJCA` and `SignatureAlgorithm.verifyWithJCA` helpers.
+* Deprecate `SignatureAlgorithm.getJCASignatureInstance`, `CryptoSignature.parseFromJCA` etc as hazmat.
 
 
 ### 3.9.0 (Supreme 0.4.0)

--- a/docs/docs/indispensable.md
+++ b/docs/docs/indispensable.md
@@ -124,10 +124,10 @@ The following functions provide interop functionality with platform types.
 
 ### JVM/Android
 
-* `SignatureAlgorithm.getJCASignatureInstance()` gets a pre-configured JCA instance for this algorithm
-* `SpecializedSignatureAlgorithm.getJCASignatureInstance()` gets a pre-configured JCA instance for this algorithm
-* `SignatureAlgorithm.getJCASignatureInstancePreHashed()` gets  a pre-configured JCA instance for pre-hashed data for this algorithm
-* `SpecializedSignatureAlgorithm.getJCASignatureInstancePreHashed()` gets  a pre-configured JCA instance for pre-hashed data for this algorithm
+* `SignatureAlgorithm.signWithJCA { initSign(key); update(data); sign() }` allows transparent signing using the JCA
+* `SignatureAlgorithm.signWithJCAPreHashed { initSign(key); update(data); sign() }` allows transparent signing of pre-hashed data using the JCA
+* `SignatureAlgorithm.signWithJCA { initSign(key); update(data); sign() }` allows transparent signing using the JCA
+* `SignatureAlgorithm.signWithJCAPreHashed { initSign(key); update(data); sign() }` allows transparent signing of pre-hashed data using the JCA
 
 * `Digest.jcaPSSParams` returns a sane default `PSSParameterSpec` for computing PSS signatures
 * `Digest.jcaName` returns the JCA name of the digest

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/HazardousMaterials.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/HazardousMaterials.kt
@@ -1,0 +1,5 @@
+package at.asitplus.signum
+
+@RequiresOptIn(message = "Access to potentially hazardous platform-specific internals requires explicit opt-in. Specify @OptIn(HazardousMaterials::class). These accessors are unstable and may change without warning.")
+/** This is an internal property. It is exposed if you know what you are doing. You very likely don't actually need it. */
+annotation class HazardousMaterials

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/ObjectIdentifier.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/ObjectIdentifier.kt
@@ -27,7 +27,7 @@ class ObjectIdentifier @Throws(Asn1Exception::class) constructor(@Transient vara
         if (nodes[0] * 40u > UByte.MAX_VALUE.toUInt()) throw Asn1Exception("first node too lage!")
         //TODO more sanity checks
 
-        if (nodes.first() > 2u) throw Asn1Exception("OID must start with either 1 or 2")
+        if (nodes.first() > 2u) throw Asn1Exception("OID must start with 0, 1 or 2")
         if (nodes[1] > 39u) throw Asn1Exception("Second segment must be <40")
     }
 

--- a/indispensable/src/jvmTest/kotlin/at/asitplus/signum/ecmath/ECMathTest.kt
+++ b/indispensable/src/jvmTest/kotlin/at/asitplus/signum/ecmath/ECMathTest.kt
@@ -33,7 +33,7 @@ class ECMathTest : FreeSpec({
             // if new curves are ever added that violate this assumption,
             //   the algorithms in ECMath must be revisited!
             // the current algorithm only works on this particular class of curve
-            curve.a == curve.coordinateCreator.fromInt(-3)
+            curve.a shouldBe curve.coordinateCreator.fromInt(-3)
         }
     }
     "Addition: group axioms" - {

--- a/indispensable/src/jvmTest/kotlin/at/asitplus/signum/indispensable/Pkcs10CertificationRequestJvmTest.kt
+++ b/indispensable/src/jvmTest/kotlin/at/asitplus/signum/indispensable/Pkcs10CertificationRequestJvmTest.kt
@@ -1,5 +1,6 @@
 package at.asitplus.signum.indispensable
 
+import at.asitplus.signum.HazardousMaterials
 import at.asitplus.signum.indispensable.asn1.*
 import at.asitplus.signum.indispensable.asn1.encoding.encodeToAsn1Primitive
 import at.asitplus.signum.indispensable.io.ensureSize
@@ -26,9 +27,9 @@ import java.security.KeyPairGenerator
 import java.security.PrivateKey
 import java.security.interfaces.ECPublicKey
 
+@OptIn(HazardousMaterials::class)
 internal fun X509SignatureAlgorithm.getContentSigner(key: PrivateKey) : ContentSigner {
-    lateinit var algorithm: String
-    signWithJCA { algorithm = this.algorithm; TODO() }
+    val algorithm = getJCASignatureInstance(provider = null, forSigning = false).getOrThrow().algorithm
     return JcaContentSignerBuilder(algorithm).build(key)
 }
 

--- a/indispensable/src/jvmTest/kotlin/at/asitplus/signum/indispensable/X509CertificateJvmTest.kt
+++ b/indispensable/src/jvmTest/kotlin/at/asitplus/signum/indispensable/X509CertificateJvmTest.kt
@@ -77,11 +77,11 @@ class X509CertificateJvmTest : FreeSpec({
             subjectName = listOf(RelativeDistinguishedName(AttributeTypeAndValue.CommonName(Asn1String.UTF8(commonName)))),
             publicKey = cryptoPublicKey
         )
-        val signed = signatureAlgorithm.getJCASignatureInstance().getOrThrow().apply {
+        val test = signatureAlgorithm.signWithJCA {
             initSign(keyPair.private)
             update(tbsCertificate.encodeToTlv().derEncoded)
-        }.sign()
-        val test = CryptoSignature.decodeFromDer(signed)
+            sign()
+        }.getOrThrow()
         val x509Certificate = X509Certificate(tbsCertificate, signatureAlgorithm, test)
 
         val kotlinEncoded = x509Certificate.encodeToDer()
@@ -123,11 +123,11 @@ class X509CertificateJvmTest : FreeSpec({
             subjectName = listOf(RelativeDistinguishedName(AttributeTypeAndValue.CommonName(Asn1String.UTF8(commonName)))),
             publicKey = cryptoPublicKey
         )
-        val signed = signatureAlgorithm.getJCASignatureInstance().getOrThrow().apply {
+        val test = signatureAlgorithm.signWithJCA {
             initSign(keyPair.private)
             update(tbsCertificate.encodeToTlv().derEncoded)
-        }.sign()
-        val test = CryptoSignature.decodeFromDer(signed)
+            sign()
+        }.getOrThrow()
         val x509Certificate = X509Certificate(tbsCertificate, signatureAlgorithm, test)
 
         repeat(500) {
@@ -275,24 +275,21 @@ class X509CertificateJvmTest : FreeSpec({
             X509Certificate
         */
 
-        val signed1 = signatureAlgorithm256.getJCASignatureInstance().getOrThrow().apply {
+        val signature1 = signatureAlgorithm256.signWithJCA {
             initSign(keyPair.private)
             update(tbsCertificate1.encodeToTlv().derEncoded)
-        }.sign()
-        val signed2 = signatureAlgorithm256.getJCASignatureInstance().getOrThrow().apply {
+            sign()
+        }.getOrThrow()
+        val signature2 = signatureAlgorithm256.signWithJCA {
             initSign(keyPair.private)
             update(tbsCertificate2.encodeToTlv().derEncoded)
-        }.sign()
-        val signed3 = signatureAlgorithm512.getJCASignatureInstance().getOrThrow().apply {
+            sign()
+        }.getOrThrow()
+        val signature3 = signatureAlgorithm512.signWithJCA {
             initSign(keyPair.private)
             update(tbsCertificate3.encodeToTlv().derEncoded)
-        }.sign()
-        val signature1 =
-            (CryptoSignature.decodeFromDer(signed1) as CryptoSignature.EC.IndefiniteLength).withCurve(ECCurve.SECP_256_R_1)
-        val signature2 =
-            (CryptoSignature.decodeFromDer(signed2) as CryptoSignature.EC.IndefiniteLength).withCurve(ECCurve.SECP_256_R_1)
-        val signature3 =
-            (CryptoSignature.decodeFromDer(signed3) as CryptoSignature.EC.IndefiniteLength).withCurve(ECCurve.SECP_521_R_1)
+            sign()
+        }.getOrThrow()
         val x509Certificate1 = X509Certificate(tbsCertificate1, signatureAlgorithm256, signature1)
         val x509Certificate2 = X509Certificate(tbsCertificate2, signatureAlgorithm256, signature2)
         val x509Certificate3 = X509Certificate(tbsCertificate3, signatureAlgorithm512, signature3)

--- a/supreme/src/androidMain/kotlin/at/asitplus/signum/supreme/hazmat/InternalsAccessors.kt
+++ b/supreme/src/androidMain/kotlin/at/asitplus/signum/supreme/hazmat/InternalsAccessors.kt
@@ -1,7 +1,6 @@
 package at.asitplus.signum.supreme.hazmat
 
-import at.asitplus.signum.indispensable.getJCASignatureInstance
-import at.asitplus.signum.supreme.HazardousMaterials
+import at.asitplus.signum.HazardousMaterials
 import at.asitplus.signum.supreme.os.AndroidKeystoreSigner
 import at.asitplus.signum.supreme.sign.AndroidEphemeralSigner
 import at.asitplus.signum.supreme.sign.EphemeralKey

--- a/supreme/src/androidMain/kotlin/at/asitplus/signum/supreme/os/AndroidKeyStoreProvider.kt
+++ b/supreme/src/androidMain/kotlin/at/asitplus/signum/supreme/os/AndroidKeyStoreProvider.kt
@@ -14,6 +14,7 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import at.asitplus.KmmResult
 import at.asitplus.catching
+import at.asitplus.signum.HazardousMaterials
 import at.asitplus.signum.indispensable.*
 import at.asitplus.signum.indispensable.asn1.Asn1StructuralException
 import at.asitplus.signum.indispensable.pki.X509Certificate
@@ -352,6 +353,7 @@ sealed class AndroidKeystoreSigner private constructor(
         }
     }
 
+    @OptIn(HazardousMaterials::class)
     internal suspend fun getJCASignature(signingConfig: AndroidSignerSigningConfiguration): Signature =
         signatureAlgorithm.getJCASignatureInstance().getOrThrow().also {
             if (needsAuthenticationForEveryUse) {
@@ -373,6 +375,7 @@ sealed class AndroidKeystoreSigner private constructor(
         }
     }
 
+    @OptIn(HazardousMaterials::class)
     final override suspend fun sign(
         data: SignatureInput,
         configure: DSLConfigureFn<AndroidSignerSigningConfiguration>
@@ -382,7 +385,7 @@ sealed class AndroidKeystoreSigner private constructor(
             .let { data.data.forEach(it::update); it.sign() }
 
         return@signCatching when (this@AndroidKeystoreSigner) {
-            is ECDSA -> CryptoSignature.EC.parseFromJca(jcaSig).withCurve(publicKey.curve)
+            is ECDSA -> CryptoSignature.EC.parseFromJca(jcaSig)
             is RSA -> CryptoSignature.RSAorHMAC.parseFromJca(jcaSig)
         }
     }}

--- a/supreme/src/androidMain/kotlin/at/asitplus/signum/supreme/os/AndroidKeyStoreProvider.kt
+++ b/supreme/src/androidMain/kotlin/at/asitplus/signum/supreme/os/AndroidKeyStoreProvider.kt
@@ -355,7 +355,7 @@ sealed class AndroidKeystoreSigner private constructor(
 
     @OptIn(HazardousMaterials::class)
     internal suspend fun getJCASignature(signingConfig: AndroidSignerSigningConfiguration): Signature =
-        signatureAlgorithm.getJCASignatureInstance().getOrThrow().also {
+        signatureAlgorithm.getJCASignatureInstance(provider = null, forSigning = true).getOrThrow().also {
             if (needsAuthenticationForEveryUse) {
                 it.initSign(jcaPrivateKey)
                 attemptBiometry(DSL.ConfigStack(signingConfig.unlockPrompt.v, config.unlockPrompt.v), CryptoObject(it))

--- a/supreme/src/androidMain/kotlin/at/asitplus/signum/supreme/sign/EphemeralKeysImpl.kt
+++ b/supreme/src/androidMain/kotlin/at/asitplus/signum/supreme/sign/EphemeralKeysImpl.kt
@@ -2,13 +2,11 @@ package at.asitplus.signum.supreme.sign
 
 import android.security.keystore.KeyProperties
 import at.asitplus.signum.indispensable.CryptoPublicKey
-import at.asitplus.signum.indispensable.CryptoSignature
 import at.asitplus.signum.indispensable.SignatureAlgorithm
 import at.asitplus.signum.indispensable.fromJcaPublicKey
-import at.asitplus.signum.indispensable.getJCASignatureInstancePreHashed
 import at.asitplus.signum.indispensable.jcaName
-import at.asitplus.signum.indispensable.parseFromJca
-import at.asitplus.signum.supreme.signCatching
+import at.asitplus.signum.indispensable.signWithJCAPreHashed
+import at.asitplus.signum.supreme.asSignatureResult
 import com.ionspin.kotlin.bignum.integer.base63.toJavaBigInteger
 import java.security.KeyPairGenerator
 import java.security.PrivateKey
@@ -20,30 +18,22 @@ actual class EphemeralSignerConfiguration internal actual constructor(): Ephemer
 
 sealed class AndroidEphemeralSigner (internal val privateKey: PrivateKey) : Signer {
     override val mayRequireUserUnlock = false
-    override suspend fun sign(data: SignatureInput) = signCatching {
-        val inputData = data.convertTo(signatureAlgorithm.preHashedSignatureFormat).getOrThrow()
-        signatureAlgorithm.getJCASignatureInstancePreHashed(provider = null).getOrThrow().run {
-            initSign(privateKey)
-            inputData.data.forEach { update(it) }
-            sign().let(::parseFromJca)
-        }
-    }
-
-    protected abstract fun parseFromJca(bytes: ByteArray): CryptoSignature.RawByteEncodable
+    override suspend fun sign(data: SignatureInput) =
+        data.convertTo(signatureAlgorithm.preHashedSignatureFormat).transform { inputData ->
+            signatureAlgorithm.signWithJCAPreHashed(provider = null) {
+                initSign(privateKey)
+                inputData.data.forEach { update(it) }
+                sign()
+            }
+        }.asSignatureResult()
 
     class EC (config: EphemeralSignerConfiguration, privateKey: PrivateKey,
               override val publicKey: CryptoPublicKey.EC, override val signatureAlgorithm: SignatureAlgorithm.ECDSA)
-        : AndroidEphemeralSigner(privateKey), Signer.ECDSA {
-
-        override fun parseFromJca(bytes: ByteArray) = CryptoSignature.EC.parseFromJca(bytes).withCurve(publicKey.curve)
-    }
+        : AndroidEphemeralSigner(privateKey), Signer.ECDSA
 
     class RSA (config: EphemeralSignerConfiguration, privateKey: PrivateKey,
                override val publicKey: CryptoPublicKey.RSA, override val signatureAlgorithm: SignatureAlgorithm.RSA)
-        : AndroidEphemeralSigner(privateKey), Signer.RSA {
-
-        override fun parseFromJca(bytes: ByteArray) = CryptoSignature.RSAorHMAC.parseFromJca(bytes)
-    }
+        : AndroidEphemeralSigner(privateKey), Signer.RSA
 }
 
 internal actual fun makeEphemeralKey(configuration: EphemeralSigningKeyConfiguration) : EphemeralKey =

--- a/supreme/src/androidMain/kotlin/at/asitplus/signum/supreme/sign/VerifierImpl.kt
+++ b/supreme/src/androidMain/kotlin/at/asitplus/signum/supreme/sign/VerifierImpl.kt
@@ -1,12 +1,16 @@
 package at.asitplus.signum.supreme.sign
 
+import at.asitplus.signum.HazardousMaterials
 import at.asitplus.signum.indispensable.CryptoPublicKey
 import at.asitplus.signum.indispensable.CryptoSignature
 import at.asitplus.signum.indispensable.RSAPadding
 import at.asitplus.signum.indispensable.SignatureAlgorithm
+import at.asitplus.signum.indispensable.getJCASignatureInstance
 import at.asitplus.signum.indispensable.getJcaPublicKey
 import at.asitplus.signum.indispensable.jcaAlgorithmComponent
 import at.asitplus.signum.indispensable.jcaSignatureBytes
+import at.asitplus.signum.indispensable.verifyWithJCA
+import at.asitplus.signum.indispensable.verifyWithJCAPreHashed
 import at.asitplus.signum.supreme.dsl.DSL
 import at.asitplus.signum.supreme.UnsupportedCryptoException
 import at.asitplus.wrapping
@@ -21,20 +25,15 @@ actual class PlatformVerifierConfiguration internal actual constructor() : DSL.D
     var provider: String? = null
 }
 
-private fun getSigInstance(alg: String, p: String?) =
-    when (p) {
-        null -> Signature.getInstance(alg)
-        else -> Signature.getInstance(alg, p)
-    }
-
+@OptIn(HazardousMaterials::class)
 @Throws(UnsupportedCryptoException::class)
 internal actual fun checkAlgorithmKeyCombinationSupportedByECDSAPlatformVerifier
             (signatureAlgorithm: SignatureAlgorithm.ECDSA, publicKey: CryptoPublicKey.EC,
              config: PlatformVerifierConfiguration)
 {
     wrapping(asA=::UnsupportedCryptoException) {
-        getSigInstance("${signatureAlgorithm.digest.jcaAlgorithmComponent}withECDSA", config.provider)
-            .initVerify(publicKey.getJcaPublicKey().getOrThrow())
+        signatureAlgorithm.getJCASignatureInstance(provider = config.provider, forSigning = false)
+            .getOrThrow().initVerify(publicKey.getJcaPublicKey().getOrThrow())
     }.getOrThrow()
 }
 
@@ -44,35 +43,31 @@ internal actual fun verifyECDSAImpl
      data: SignatureInput, signature: CryptoSignature.EC,
      config: PlatformVerifierConfiguration)
 {
-    val (input, alg) = when {
+    when {
         (data.format == null) -> /* input data is not hashed, let JCA do hashing */
-            Pair(data, "${signatureAlgorithm.digest.jcaAlgorithmComponent}withECDSA")
+            signatureAlgorithm.verifyWithJCA(signature) { sigBytes ->
+                initVerify(publicKey.getJcaPublicKey().getOrThrow())
+                data.data.forEach(this::update)
+                verify(sigBytes)
+            }
         else -> /* input data is already hashed, request raw sig from JCA */
-            Pair(data.convertTo(signatureAlgorithm.digest).getOrThrow(), "NONEwithECDSA")
-    }
-    getSigInstance(alg, config.provider).run {
-        initVerify(publicKey.getJcaPublicKey().getOrThrow())
-        input.data.forEach(this::update)
-        val success = verify(signature.jcaSignatureBytes)
-        if (!success)
-            throw InvalidSignature("Signature is cryptographically invalid")
-    }
+            signatureAlgorithm.verifyWithJCAPreHashed(signature) { sigBytes ->
+                initVerify(publicKey.getJcaPublicKey().getOrThrow())
+                data.convertTo(signatureAlgorithm.digest).getOrThrow().data.forEach(this::update)
+                verify(sigBytes)
+            }
+    }.getOrThrow()
 }
 
-private fun getRSAInstance(alg: SignatureAlgorithm.RSA, config: PlatformVerifierConfiguration) =
-    getSigInstance(when (alg.padding) {
-        RSAPadding.PKCS1 -> "${alg.digest.jcaAlgorithmComponent}withRSA"
-        RSAPadding.PSS -> "${alg.digest.jcaAlgorithmComponent}withRSA/PSS"
-    }, config.provider)
-
+@OptIn(HazardousMaterials::class)
 @Throws(UnsupportedCryptoException::class)
 internal actual fun checkAlgorithmKeyCombinationSupportedByRSAPlatformVerifier
             (signatureAlgorithm: SignatureAlgorithm.RSA, publicKey: CryptoPublicKey.RSA,
              config: PlatformVerifierConfiguration)
 {
     wrapping(asA=::UnsupportedCryptoException) {
-        getRSAInstance(signatureAlgorithm, config)
-            .initVerify(publicKey.getJcaPublicKey().getOrThrow())
+        signatureAlgorithm.getJCASignatureInstance(provider = config.provider, forSigning = false)
+            .getOrThrow().initVerify(publicKey.getJcaPublicKey().getOrThrow())
     }.getOrThrow()
 }
 
@@ -82,11 +77,18 @@ internal actual fun verifyRSAImpl
      data: SignatureInput, signature: CryptoSignature.RSAorHMAC,
      config: PlatformVerifierConfiguration)
 {
-    getRSAInstance(signatureAlgorithm, config).run {
-        initVerify(publicKey.getJcaPublicKey().getOrThrow())
-        data.data.forEach(this::update)
-        val success = verify(signature.jcaSignatureBytes)
-        if (!success)
-            throw InvalidSignature("Signature is cryptographically invalid")
-    }
+    when {
+        (data.format == null) -> /* input data is not hashed, let JCA do hashing */
+            signatureAlgorithm.verifyWithJCA(signature) { sigBytes ->
+                initVerify(publicKey.getJcaPublicKey().getOrThrow())
+                data.data.forEach(this::update)
+                verify(sigBytes)
+            }
+        else -> /* input data is already hashed, request raw sig from JCA */
+            signatureAlgorithm.verifyWithJCAPreHashed(signature) { sigBytes ->
+                initVerify(publicKey.getJcaPublicKey().getOrThrow())
+                data.convertTo(signatureAlgorithm.digest).getOrThrow().data.forEach(this::update)
+                verify(sigBytes)
+            }
+    }.getOrThrow()
 }

--- a/supreme/src/commonMain/kotlin/at/asitplus/signum/supreme/SignatureResult.kt
+++ b/supreme/src/commonMain/kotlin/at/asitplus/signum/supreme/SignatureResult.kt
@@ -48,16 +48,17 @@ inline fun <T: CryptoSignature.RawByteEncodable, S: CryptoSignature.RawByteEncod
         is SignatureResult.Error -> this
     }
 
+inline fun <T: CryptoSignature.RawByteEncodable> KmmResult<T>.asSignatureResult() =
+    this.fold(
+        onSuccess = { SignatureResult.Success(it) },
+        onFailure = { SignatureResult.FromException(it) })
+
 /** Modifies the contained [CryptoSignature], usually in order to reinterpret it as a more narrow type. */
 inline fun <T: CryptoSignature.RawByteEncodable, S: CryptoSignature.RawByteEncodable> SignatureResult<T>
         .modify(block: KmmResult<T>.()->KmmResult<S>) =
-    catching { this.signature }.block().fold(
-        onSuccess = { SignatureResult.Success(it) },
-        onFailure = { SignatureResult.FromException(it) })
+    catching { this.signature }.block().asSignatureResult()
 
 /** Runs the block, catches exceptions, and maps to [SignatureResult].
  * @see SignatureResult.FromException */
 internal inline fun signCatching(fn: ()->CryptoSignature.RawByteEncodable): SignatureResult<*> =
-    catching { fn() }.fold(
-        onSuccess = { SignatureResult.Success(it) },
-        onFailure = { SignatureResult.FromException(it) })
+    catching { fn() }.asSignatureResult()

--- a/supreme/src/commonMain/kotlin/at/asitplus/signum/supreme/Throwables.kt
+++ b/supreme/src/commonMain/kotlin/at/asitplus/signum/supreme/Throwables.kt
@@ -1,9 +1,5 @@
 package at.asitplus.signum.supreme
 
-@RequiresOptIn(message = "Access to potentially hazardous platform-specific internals requires explicit opt-in. Specify @OptIn(HazardousMaterials::class). These accessors are unstable and may change without warning.")
-/** This is an internal property. It is exposed if you know what you are doing. You very likely don't actually need it. */
-annotation class HazardousMaterials
-
 sealed class CryptoException(message: String? = null, cause: Throwable? = null) : Throwable(message, cause)
 open class CryptoOperationFailed(message: String) : CryptoException(message)
 open class UnsupportedCryptoException(message: String? = null, cause: Throwable? = null) : CryptoException(message, cause)

--- a/supreme/src/iosMain/kotlin/at/asitplus/signum/supreme/hazmat/InternalsAccessors.kt
+++ b/supreme/src/iosMain/kotlin/at/asitplus/signum/supreme/hazmat/InternalsAccessors.kt
@@ -1,8 +1,8 @@
 @file:OptIn(ExperimentalForeignApi::class)
 package at.asitplus.signum.supreme.hazmat
 
+import at.asitplus.signum.HazardousMaterials
 import at.asitplus.signum.supreme.AutofreeVariable
-import at.asitplus.signum.supreme.HazardousMaterials
 import at.asitplus.signum.supreme.os.IosSigner
 import at.asitplus.signum.supreme.os.IosSignerSigningConfiguration
 import at.asitplus.signum.supreme.sign.EphemeralKey

--- a/supreme/src/jvmMain/kotlin/at/asitplus/signum/supreme/hazmat/InternalsAccessors.kt
+++ b/supreme/src/jvmMain/kotlin/at/asitplus/signum/supreme/hazmat/InternalsAccessors.kt
@@ -1,6 +1,6 @@
 package at.asitplus.signum.supreme.hazmat
 
-import at.asitplus.signum.supreme.HazardousMaterials
+import at.asitplus.signum.HazardousMaterials
 import at.asitplus.signum.supreme.sign.EphemeralKey
 import at.asitplus.signum.supreme.sign.EphemeralKeyBase
 import at.asitplus.signum.supreme.sign.EphemeralSigner

--- a/supreme/src/jvmMain/kotlin/at/asitplus/signum/supreme/os/JKSProvider.kt
+++ b/supreme/src/jvmMain/kotlin/at/asitplus/signum/supreme/os/JKSProvider.kt
@@ -2,24 +2,14 @@ package at.asitplus.signum.supreme.os
 
 import at.asitplus.KmmResult
 import at.asitplus.catching
-import at.asitplus.signum.indispensable.CryptoPublicKey
-import at.asitplus.signum.indispensable.CryptoSignature
-import at.asitplus.signum.indispensable.Digest
-import at.asitplus.signum.indispensable.RSAPadding
-import at.asitplus.signum.indispensable.SignatureAlgorithm
-import at.asitplus.signum.indispensable.X509SignatureAlgorithm
+import at.asitplus.signum.indispensable.*
 import at.asitplus.signum.indispensable.asn1.Asn1String
 import at.asitplus.signum.indispensable.asn1.Asn1Time
-import at.asitplus.signum.indispensable.fromJcaPublicKey
-import at.asitplus.signum.indispensable.getJCASignatureInstance
-import at.asitplus.signum.indispensable.jcaName
-import at.asitplus.signum.indispensable.parseFromJca
 import at.asitplus.signum.indispensable.pki.AttributeTypeAndValue
 import at.asitplus.signum.indispensable.pki.RelativeDistinguishedName
 import at.asitplus.signum.indispensable.pki.TbsCertificate
 import at.asitplus.signum.indispensable.pki.X509Certificate
 import at.asitplus.signum.indispensable.pki.leaf
-import at.asitplus.signum.indispensable.toJcaCertificate
 import at.asitplus.signum.supreme.UnsupportedCryptoException
 import at.asitplus.signum.supreme.dsl.DSL
 import at.asitplus.signum.supreme.dsl.DSLConfigureFn
@@ -148,11 +138,11 @@ class JKSProvider internal constructor (private val access: JKSAccessor)
                 validUntil = Asn1Time(Clock.System.now() + config.certificateValidityPeriod),
                 publicKey = publicKey
             )
-            val cert = certAlg.getJCASignatureInstance(provider = config.provider).getOrThrow().run {
+            val cert = certAlg.signWithJCA(provider = config.provider) {
                 initSign(keyPair.private)
                 update(tbsCert.encodeToDer())
                 sign()
-            }.let { X509Certificate(tbsCert, certAlg, CryptoSignature.parseFromJca(it, certAlg)) }
+            }.let { X509Certificate(tbsCert, certAlg, it.getOrThrow()) }
             ctx.ks.setKeyEntry(alias, keyPair.private, config.privateKeyPassword,
                             arrayOf(cert.toJcaCertificate().getOrThrow()))
             ctx.markAsDirty()


### PR DESCRIPTION
DER-encoded ECDSA signatures are an ASN.1 structure, with variable length integer representation. P1363-encoded ECDSA signatures are fixed-length concatenated integers with no additional structure.

This means that P1363 -> DER is easy, while DER -> P1363 is impossible without additional information (such as the curve used).
We currently use the `RawByteEncodable` marker interface to indicate whether a given (EC) signature can be encoded to P1363.

The JCA extensions in Indispensable currently produce and consume DER signatures. This is awkward, since it means that `CryptoSignature.parseFromJCA` cannot return `RawByteEncodable` signatures -- not even in the RSA case!

This PR fixes this. It declares the individual parts of the signing process as hazmat (since they are encoding dependent) and switches them to use P1363. The stable API going forward for signing ops using the JCA will be `.signWithJCA`, which guarantees that the signature object and signature byte decoding use the same encoding (whatever that may be on any given platform).