### PR TITLE
Fix/oid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Remove requirement from CSR to have certificate extensions
 * Fix CoseSigned equals
 * Base OIDs on BigInteger instead of UInt
+* Directly support UUID-based OID creation
 
 ### 3.9.0 (Supreme 0.4.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Introduce shorthand to create certificate from TbsCertificate
 * Remove requirement from CSR to have certificate extensions
 * Fix CoseSigned equals
+* Base OIDs on BigInteger instead of UInt
 
 ### 3.9.0 (Supreme 0.4.0)
 

--- a/docs/docs/indispensable.md
+++ b/docs/docs/indispensable.md
@@ -342,6 +342,25 @@ Asn1.Sequence { +Asn1.Int(42) } withImplicitTag (0x5EUL without CONSTRUCTED)
     Just blame the mess you created only on yourself and nobody else!
 
 
+### Object Identifiers
+Signum's _Indispensable_ module comes with an expressive, convenient, and efficient ASN.1 `ObjectIdentifier` class.
+It can be constructed by either parsing a `ByteArray` containing ASN.1-encoded representation of an OID,
+or constructing it from a humanly-readable string representation (`"1.2.96"`, `"1 2 96"`).
+In addition, it is possible to pass OID node components as either `UInt` or `BigInteger` to construct an OID: `ObjectIdentifier(1u, 3u, 6u, 1u)`.
+
+The OID class exposes a `nodes` property, corresponding to the individual components that make up an OID node for convenience,
+as well as a `bytes` property, corresponding to its ASN.1-encoded `ByteArray` representation.  
+One peculiar characteristic of the `ObjectIdentifier` class is that both `nodes` and `bytes` properties are lazily evaluated.
+This means that if the OID was constructed from raw bytes, accessing `bytes` is a NOOP, but operating on `nodes` is initially
+quite expensive, since the bytes have yet to be parsed.
+Conversely, if an OID was constructed from `BigInteger` components, accessing `bytes` is slow.
+If, however, an OID was constructed from `UInt` components, those are eagerly encoded into bytes and the `nodes` property
+is not immediately initialized.
+
+This behaviour boils down to performance: Only very rarely, will you want to create an OID with components exceeding `UInt.MAX_VALUE`,
+but you will almost certainly want to encode a OID you created to ASN.1.
+On the other hand, parsing an OID from ASN.1-encoded bytes and re-encoding it are both close to a NOOP (object creation aside).
+
 ### ASN.1 Builder DSL
 So far, custom high-level types and manually constructing low-level types was discussed.
 When actually constructing ASN.1 structures, a far more streamlined and intuitive approach exists.

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/ObjectIdentifier.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/ObjectIdentifier.kt
@@ -48,6 +48,7 @@ class ObjectIdentifier @Throws(Asn1Exception::class) private constructor(
             }else {
                 if (get(1) > 47u) throw Asn1Exception("Second segment must be <48")
             }
+            forEach { if (it.isNegative) throw Asn1Exception("Negative Number encountered: $it") }
         }
     }
 
@@ -169,27 +170,13 @@ class ObjectIdentifier @Throws(Asn1Exception::class) private constructor(
         fun parse(rawValue: ByteArray): ObjectIdentifier = ObjectIdentifier(rawValue)
 
         private fun UIntArray.toOidBytes(): ByteArray {
-            if (size < 2) throw Asn1StructuralException("at least two nodes required!")
-            if (first() > 2u) throw Asn1Exception("OID top-level arc can only be number 0, 1 or 2")
-            if(first()<2u) {
-                if (get(1) > 39u) throw Asn1Exception("Second segment must be <40")
-            }else {
-                if (get(1) > 47u) throw Asn1Exception("Second segment must be <48")
-            }
             return slice(2..<size).map { it.toAsn1VarInt() }.fold(
                 byteArrayOf((first() * 40u + get(1)).toUByte().toByte())
             ) { acc, bytes -> acc + bytes }
         }
 
         private fun List<out BigInteger>.toOidBytes(): ByteArray {
-            if (size < 2) throw Asn1StructuralException("at least two nodes required!")
-            if (first() > 2u) throw Asn1Exception("OID top-level arc can only be number 0, 1 or 2")
-            if(first()<2u) {
-                if (get(1) > 39u) throw Asn1Exception("Second segment must be <40")
-            }else {
-                if (get(1) > 47u) throw Asn1Exception("Second segment must be <48")
-            }
-            return slice(2..<size).map { if (it.isNegative) throw Asn1Exception("Negative Number encountered: $it") else it.toAsn1VarInt() }
+            return slice(2..<size).map { it.toAsn1VarInt() }
                 .fold(
                     byteArrayOf((first().intValue() * 40 + get(1).intValue()).toUByte().toByte())
                 ) { acc, bytes -> acc + bytes }

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/ObjectIdentifier.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/ObjectIdentifier.kt
@@ -25,14 +25,14 @@ private val BIGINT_40 = BigInteger.fromUByte(40u)
  * @throws Asn1Exception if less than two nodes are supplied, the first node is >2 or the second node is >39
  */
 @Serializable(with = ObjectIdSerializer::class)
-class ObjectIdentifier @Throws(Asn1Exception::class) constructor(
+class ObjectIdentifier @Throws(Asn1Exception::class) private constructor(
     val bytes: ByteArray,
     @Transient private val _nodes: List<BigInteger>? = null, dontVerify: Boolean = false
 ) :
     Asn1Encodable<Asn1Primitive> {
 
     init {
-        if (_nodes == null || dontVerify) {
+        if (_nodes == null || !dontVerify) {
             //Verify that everything can be parsed into nodes
             if (bytes.isEmpty()) throw Asn1Exception("Empty OIDs are not supported")
             var index = 1

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/ObjectIdentifier.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/ObjectIdentifier.kt
@@ -3,7 +3,9 @@ package at.asitplus.signum.indispensable.asn1
 import at.asitplus.signum.indispensable.asn1.encoding.decode
 import at.asitplus.signum.indispensable.asn1.encoding.decodeAsn1VarBigInt
 import at.asitplus.signum.indispensable.asn1.encoding.toAsn1VarInt
+import at.asitplus.signum.indispensable.asn1.encoding.toBigInteger
 import com.ionspin.kotlin.bignum.integer.BigInteger
+import com.ionspin.kotlin.bignum.integer.Sign
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
@@ -11,6 +13,8 @@ import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
 
 private val BIGINT_40 = BigInteger.fromUByte(40u)
 
@@ -33,6 +37,18 @@ class ObjectIdentifier @Throws(Asn1Exception::class) constructor(@Transient vara
         if (nodes.first() > 2u) throw Asn1Exception("OID must start with either 1 or 2")
         if (nodes[1] > 39u) throw Asn1Exception("Second segment must be <40")
     }
+
+    /**
+     * Creates an OID in the 2.25 subtree that requires no formal registration.
+     * E.g. the UUID `550e8400-e29b-41d4-a716-446655440000` results in the OID
+     * `2.25.113059749145936325402354257176981405696`
+     */
+    @OptIn(ExperimentalUuidApi::class)
+    constructor(uuid: Uuid) : this(
+        BigInteger.fromByte(2),
+        BigInteger.fromByte(25),
+        uuid.toBigInteger()
+    )
 
     /**
      * @param nodes OID Tree nodes passed in order (e.g. 1u, 2u, 96u, …)

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/ObjectIdentifier.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/ObjectIdentifier.kt
@@ -5,7 +5,6 @@ import at.asitplus.signum.indispensable.asn1.encoding.decodeAsn1VarBigInt
 import at.asitplus.signum.indispensable.asn1.encoding.toAsn1VarInt
 import at.asitplus.signum.indispensable.asn1.encoding.toBigInteger
 import com.ionspin.kotlin.bignum.integer.BigInteger
-import com.ionspin.kotlin.bignum.integer.Sign
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
@@ -26,16 +25,38 @@ private val BIGINT_40 = BigInteger.fromUByte(40u)
  * @throws Asn1Exception if less than two nodes are supplied, the first node is >2 or the second node is >39
  */
 @Serializable(with = ObjectIdSerializer::class)
-class ObjectIdentifier @Throws(Asn1Exception::class) constructor(@Transient vararg val nodes: BigInteger) :
+class ObjectIdentifier @Throws(Asn1Exception::class) constructor(
+    val bytes: ByteArray,
+    @Transient private val _nodes: List<BigInteger>? = null, dontVerify: Boolean = false
+) :
     Asn1Encodable<Asn1Primitive> {
 
     init {
-        if (nodes.size < 2) throw Asn1StructuralException("at least two nodes required!")
-        if ((nodes[0] * BIGINT_40) > UByte.MAX_VALUE.toUInt()) throw Asn1Exception("first node too lage!")
-        //TODO more sanity checks
-
-        if (nodes.first() > 2u) throw Asn1Exception("OID must start with either 1 or 2")
-        if (nodes[1] > 39u) throw Asn1Exception("Second segment must be <40")
+        if (_nodes == null || dontVerify) {
+            //Verify that everything can be parsed into nodes
+            if (bytes.isEmpty()) throw Asn1Exception("Empty OIDs are not supported")
+            var index = 1
+            while (index < bytes.size) {
+                if (bytes[index] >= 0) {
+                    index++
+                } else {
+                    val currentNode = mutableListOf<Byte>()
+                    while (bytes[index] < 0) {
+                        currentNode += bytes[index] //+= parsed
+                        index++
+                    }
+                    currentNode += bytes[index]
+                    index++
+                    val consumed = currentNode.iterator().consumeVarIntEncoded()
+                    @OptIn(ExperimentalStdlibApi::class)
+                    if (consumed != currentNode) throw Asn1Exception(
+                        "Trailing bytes in OID Node ${
+                            currentNode.toByteArray().toHexString(HexFormat.UpperCase)
+                        }"
+                    )
+                }
+            }
+        }
     }
 
     /**
@@ -45,17 +66,23 @@ class ObjectIdentifier @Throws(Asn1Exception::class) constructor(@Transient vara
      */
     @OptIn(ExperimentalUuidApi::class)
     constructor(uuid: Uuid) : this(
-        BigInteger.fromByte(2),
-        BigInteger.fromByte(25),
-        uuid.toBigInteger()
+        byteArrayOf((2 * 40 + 25).toUByte().toByte(), *uuid.toBigInteger().toAsn1VarInt())
     )
 
     /**
      * @param nodes OID Tree nodes passed in order (e.g. 1u, 2u, 96u, …)
      * @throws Asn1Exception if less than two nodes are supplied, the first node is >2 or the second node is >39
      */
-    constructor(vararg ints: UInt) : this(*(ints.map { BigInteger.fromUInt(it) }.toTypedArray()))
+    constructor(vararg nodes: UInt) : this(
+        nodes.toOidBytes(),
+        dontVerify = true
+    )
 
+    /**
+     * @param nodes OID Tree nodes passed in order (e.g. 1, 2, 96, …)
+     * @throws Asn1Exception if less than two nodes are supplied, the first node is >2, the second node is >39 or any node is negative
+     */
+    constructor(vararg nodes: BigInteger) : this(nodes.toOidBytes(), _nodes = nodes.asList())
 
     /**
      * @param oid in human-readable format (e.g. "1.2.96")
@@ -64,30 +91,52 @@ class ObjectIdentifier @Throws(Asn1Exception::class) constructor(@Transient vara
         .toTypedArray())
 
     /**
+     * Lazily evaluated list of OID nodes (e.g. `[1, 2, 35, 4654]`)
+     */
+    val nodes: List<BigInteger> by lazy {
+        if (_nodes != null) _nodes else {
+            val (first, second) =
+                if (bytes[0] >= 80) {
+                    BigInteger.fromUByte(2u) to BigInteger.fromUInt(bytes[0].toUByte() - 80u)
+                } else {
+                    BigInteger.fromUInt(bytes[0].toUByte() / 40u) to BigInteger.fromUInt(bytes[0].toUByte() % 40u)
+                }
+            var index = 1
+            val collected = mutableListOf(first, second)
+            while (index < bytes.size) {
+                if (bytes[index] >= 0) {
+                    collected += BigInteger.fromUInt(bytes[index].toUInt())
+                    index++
+                } else {
+                    val currentNode = mutableListOf<Byte>()
+                    while (bytes[index] < 0) {
+                        currentNode += bytes[index] //+= parsed
+                        index++
+                    }
+                    currentNode += bytes[index]
+                    index++
+                    collected += currentNode.decodeAsn1VarBigInt().first
+                }
+            }
+            collected
+        }
+    }
+
+    /**
      * @return human-readable format (e.g. "1.2.96")
      */
-    override fun toString() = nodes.joinToString(separator = ".") { it.toString() }
+    override fun toString(): String {
+        return nodes.joinToString(".")
+    }
 
     override fun equals(other: Any?): Boolean {
         if (other == null) return false
         if (other !is ObjectIdentifier) return false
-        return nodes contentEquals other.nodes
+        return bytes contentEquals other.bytes
     }
 
     override fun hashCode(): Int {
         return bytes.contentHashCode()
-    }
-
-
-    /**
-     * Cursed encoding of OID nodes. A sacrifice of pristine numbers requested by past gods of the netherrealm
-     */
-    val bytes: ByteArray by lazy {
-        nodes.slice(2..<nodes.size).map { it.toAsn1VarInt() }.fold(
-            byteArrayOf(
-                (nodes[0] * BIGINT_40 + nodes[1]).ubyteValue(exactRequired = true).toByte()
-            )
-        ) { acc, bytes -> acc + bytes }
     }
 
     /**
@@ -115,33 +164,37 @@ class ObjectIdentifier @Throws(Asn1Exception::class) constructor(@Transient vara
          * @throws Asn1Exception all sorts of errors on invalid input
          */
         @Throws(Asn1Exception::class)
-        fun parse(rawValue: ByteArray): ObjectIdentifier = runRethrowing {
-            if (rawValue.isEmpty()) throw Asn1Exception("Empty OIDs are not supported")
-            val (first, second) =
-                if (rawValue[0] >= 80) {
-                    BigInteger.fromUByte(2u) to BigInteger.fromUInt(rawValue[0].toUByte() - 80u)
-                } else {
-                    BigInteger.fromUInt(rawValue[0].toUByte() / 40u) to BigInteger.fromUInt(rawValue[0].toUByte() % 40u)
-                }
+        fun parse(rawValue: ByteArray): ObjectIdentifier = ObjectIdentifier(rawValue)
 
-            var index = 1
-            val collected = mutableListOf(first, second)
-            while (index < rawValue.size) {
-                if (rawValue[index] >= 0) {
-                    collected += BigInteger.fromUInt(rawValue[index].toUInt())
-                    index++
-                } else {
-                    val currentNode = mutableListOf<Byte>()
-                    while (rawValue[index] < 0) {
-                        currentNode += rawValue[index] //+= parsed
-                        index++
-                    }
-                    currentNode += rawValue[index]
-                    index++
-                    collected += currentNode.decodeAsn1VarBigInt().first
-                }
+        private fun Iterator<Byte>.consumeVarIntEncoded(): MutableList<Byte> {
+            val accumulator = mutableListOf<Byte>()
+            while (hasNext()) {
+                val curByte = next()
+                val current = BigInteger(curByte.toUByte().toInt())
+                accumulator += curByte
+                if (current < 0x80.toUByte()) break
             }
-            return ObjectIdentifier(*collected.toTypedArray())
+            return accumulator
+        }
+
+        private fun UIntArray.toOidBytes(): ByteArray {
+            if (size < 2) throw Asn1StructuralException("at least two nodes required!")
+            if (first() > 2u) throw Asn1Exception("OID must start with either 1 or 2")
+            if (get(1) > 39u) throw Asn1Exception("Second segment must be <40")
+            return slice(2..<size).map { it.toAsn1VarInt() }.fold(
+                byteArrayOf((first() * 40u + get(1)).toUByte().toByte())
+            ) { acc, bytes -> acc + bytes }
+        }
+
+        private fun Array<out BigInteger>.toOidBytes(): ByteArray {
+            if (size < 2) throw Asn1StructuralException("at least two nodes required!")
+            if (first() > 2u) throw Asn1Exception("OID must start with either 1 or 2")
+            if (get(1) > 39u) throw Asn1Exception("Second segment must be <40")
+
+            return slice(2..<size).map { if (it.isNegative) throw Asn1Exception("Negative Number encountered: $it") else it.toAsn1VarInt() }
+                .fold(
+                    byteArrayOf((first().intValue() * 40 + get(1).intValue()).toUByte().toByte())
+                ) { acc, bytes -> acc + bytes }
         }
     }
 }
@@ -152,7 +205,7 @@ object ObjectIdSerializer : KSerializer<ObjectIdentifier> {
     override fun deserialize(decoder: Decoder): ObjectIdentifier = ObjectIdentifier(decoder.decodeString())
 
     override fun serialize(encoder: Encoder, value: ObjectIdentifier) {
-        encoder.encodeString(value.nodes.joinToString(separator = ".") { it.toString() })
+        encoder.encodeString(toString())
     }
 
 }

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/encoding/NumberEncoding.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/encoding/NumberEncoding.kt
@@ -1,9 +1,14 @@
 package at.asitplus.signum.indispensable.asn1.encoding
 
+import at.asitplus.catching
 import at.asitplus.signum.indispensable.asn1.ObjectIdentifier
+import at.asitplus.signum.indispensable.io.ensureSize
 import com.ionspin.kotlin.bignum.integer.BigInteger
+import com.ionspin.kotlin.bignum.integer.Sign
 import kotlin.experimental.or
 import kotlin.math.ceil
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
 
 
 /**
@@ -439,3 +444,20 @@ fun Iterator<Byte>.decodeAsn1VarUInt(): Pair<UInt, ByteArray> {
 
     return result to accumulator.toByteArray()
 }
+
+/**
+ * Converts this UUID to a BigInteger representation
+ */
+@OptIn(ExperimentalUuidApi::class)
+fun Uuid.toBigInteger(): BigInteger = BigInteger.fromByteArray(toByteArray(), Sign.POSITIVE)
+
+/**
+ * Tries to convert a BigInteger to a UUID. Only guaranteed to work with BigIntegers that contain the unsigned (positive)
+ * integer representation of a UUID, chances are high, though, that it works with random positive BigIntegers between
+ * 16 and 14 bytes large.
+ *
+ * Returns `null` if conversion fails. Never throws.
+ */
+@OptIn(ExperimentalUuidApi::class)
+fun Uuid.Companion.fromBigintOrNull(bigInteger: BigInteger): Uuid? =
+    catching { fromByteArray(bigInteger.toByteArray().ensureSize(16)) }.getOrNull()

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/encoding/NumberEncoding.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/encoding/NumberEncoding.kt
@@ -377,14 +377,13 @@ inline fun ByteArray.decodeAsn1VarBigInt(): Pair<BigInteger, ByteArray> = iterat
 
 
 /**
- * Decodes an ULong from bytes using varint encoding as used within ASN.1: groups of seven bits are encoded into a byte,
+ * Decodes an BigInteger from bytes using varint encoding as used within ASN.1: groups of seven bits are encoded into a byte,
  * while the highest bit indicates if more bytes are to come. Trailing bytes are ignored.
  *
- * @return the decoded ULong and the underlying varint-encoded bytes as `ByteArray`
+ * @return the decoded BigInteger and the underlying varint-encoded bytes as `ByteArray`
  * @throws IllegalArgumentException if the number is larger than [ULong.MAX_VALUE]
  */
 fun Iterator<Byte>.decodeAsn1VarBigInt(): Pair<BigInteger, ByteArray> {
-    var offset = 0
     var result = BigInteger.ZERO
     val mask = BigInteger.fromUByte(0x7Fu)
     val accumulator = mutableListOf<Byte>()

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/encoding/NumberEncoding.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/encoding/NumberEncoding.kt
@@ -1,6 +1,7 @@
 package at.asitplus.signum.indispensable.asn1.encoding
 
 import at.asitplus.signum.indispensable.asn1.ObjectIdentifier
+import com.ionspin.kotlin.bignum.integer.BigInteger
 import kotlin.experimental.or
 import kotlin.math.ceil
 
@@ -247,6 +248,30 @@ fun ULong.toAsn1VarInt(): ByteArray {
         if (offset > (ULong.SIZE_BITS - 1)) break //End of Fahnenstange
         b0 = (this shr offset and 0x7FuL).toByte()
     }
+    return with(result) {
+        ByteArray(size) { fromBack(it) or asn1VarIntByteMask(it) }
+    }
+}
+
+/**
+ * Encodes this number using varint encoding as used within ASN.1: groups of seven bits are encoded into a byte,
+ * while the highest bit indicates if more bytes are to come
+ */
+fun BigInteger.toAsn1VarInt(): ByteArray {
+    if (isZero()) return byteArrayOf(0)
+    require(isPositive) { "Only positive Numbers are supported" }
+    if (this < 128) return byteArrayOf(this.byteValue(exactRequired = true)) //Fast case
+    var offset = 0
+    var result = mutableListOf<Byte>()
+
+    val mask = BigInteger.fromUByte(0x7Fu)
+    var b0 = ((this shr offset) and mask).byteValue(exactRequired = false)
+    while ((this shr offset > 0uL) || offset == 0) {
+        result += b0
+        offset += 7
+        if (offset > (this.bitLength() - 1)) break //End of Fahnenstange
+        b0 = ((this shr offset) and mask).byteValue(exactRequired = false)
+    }
 
     return with(result) {
         ByteArray(size) { fromBack(it) or asn1VarIntByteMask(it) }
@@ -323,6 +348,47 @@ fun Iterator<Byte>.decodeAsn1VarULong(): Pair<ULong, ByteArray> {
             break
         }
         if (++offset > ceil(ULong.SIZE_BYTES.toFloat() * 8f / 7f)) throw IllegalArgumentException("Tag number too Large do decode into ULong!")
+    }
+
+    return result to accumulator.toByteArray()
+}
+
+
+/**
+ * Decodes an unsigned BigInteger from bytes using varint encoding as used within ASN.1: groups of seven bits are encoded into a byte,
+ * while the highest bit indicates if more bytes are to come. Trailing bytes are ignored.
+ *
+ * @return the decoded unsigned BigInteger and the underlying varint-encoded bytes as `ByteArray`
+ */
+inline fun Iterable<Byte>.decodeAsn1VarBigInt(): Pair<BigInteger, ByteArray> = iterator().decodeAsn1VarBigInt()
+
+/**
+ * Decodes an unsigned BigInteger from bytes using varint encoding as used within ASN.1: groups of seven bits are encoded into a byte,
+ * while the highest bit indicates if more bytes are to come. Trailing bytes are ignored.
+ *
+ * @return the decoded unsigned BigInteger and the underlying varint-encoded bytes as `ByteArray`
+ */
+inline fun ByteArray.decodeAsn1VarBigInt(): Pair<BigInteger, ByteArray> = iterator().decodeAsn1VarBigInt()
+
+
+/**
+ * Decodes an ULong from bytes using varint encoding as used within ASN.1: groups of seven bits are encoded into a byte,
+ * while the highest bit indicates if more bytes are to come. Trailing bytes are ignored.
+ *
+ * @return the decoded ULong and the underlying varint-encoded bytes as `ByteArray`
+ * @throws IllegalArgumentException if the number is larger than [ULong.MAX_VALUE]
+ */
+fun Iterator<Byte>.decodeAsn1VarBigInt(): Pair<BigInteger, ByteArray> {
+    var offset = 0
+    var result = BigInteger.ZERO
+    val mask = BigInteger.fromUByte(0x7Fu)
+    val accumulator = mutableListOf<Byte>()
+    while (hasNext()) {
+        val curByte = next()
+        val current = BigInteger(curByte.toUByte().toInt())
+        accumulator += curByte
+        result = (current and mask) or (result shl 7)
+        if (current < 0x80.toUByte()) break
     }
 
     return result to accumulator.toByteArray()

--- a/indispensable/src/jvmTest/kotlin/at/asitplus/signum/indispensable/OidTest.kt
+++ b/indispensable/src/jvmTest/kotlin/at/asitplus/signum/indispensable/OidTest.kt
@@ -1,22 +1,22 @@
 package at.asitplus.signum.indispensable
 
-import at.asitplus.signum.indispensable.asn1.ObjectIdentifier
-import at.asitplus.signum.indispensable.asn1.encoding.fromBigintOrNull
-import at.asitplus.signum.indispensable.asn1.encoding.toBigInteger
+import at.asitplus.signum.indispensable.asn1.*
+import at.asitplus.signum.indispensable.asn1.encoding.*
 import com.ionspin.kotlin.bignum.integer.BigInteger
 import com.ionspin.kotlin.bignum.integer.Sign
 import io.kotest.assertions.withClue
 import io.kotest.core.spec.style.FreeSpec
 import io.kotest.datatest.withData
+import io.kotest.matchers.comparables.shouldBeLessThan
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.property.Arb
-import io.kotest.property.arbitrary.bigInt
-import io.kotest.property.arbitrary.int
-import io.kotest.property.arbitrary.intArray
-import io.kotest.property.arbitrary.positiveInt
+import io.kotest.property.arbitrary.*
 import io.kotest.property.checkAll
+import kotlinx.datetime.Clock
 import org.bouncycastle.asn1.ASN1ObjectIdentifier
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 
@@ -82,6 +82,56 @@ class OidTest : FreeSpec({
                     }
                 }
             }
+        }
+
+        "Benchmarking fast case" - {
+            val optimized = mutableListOf<Duration>()
+            val repetitions= 10
+
+            "Optimized" - {
+                repeat(repetitions) {
+                    val before = Clock.System.now()
+                    checkAll(iterations = 15, Arb.uInt(max = 39u)) { second ->
+                        checkAll(iterations = 5000, Arb.uIntArray(Arb.int(0..256), Arb.uInt(UInt.MAX_VALUE))) {
+                            listOf(1u, 2u).forEach { first ->
+                                val oid = ObjectIdentifier(first, second, *it.toUIntArray())
+                                ObjectIdentifier.decodeFromTlv(oid.encodeToTlv())
+                            }
+                        }
+                    }
+                    val duration = Clock.System.now() - before
+                    optimized += duration
+                    println("Optimized: $duration")
+                }
+            }
+
+            val avgOpt = (optimized.sorted().subList(1, optimized.size - 1)
+                .sumOf { it.inWholeMilliseconds } / optimized.size - 2).milliseconds
+            println("AvgOpt: $avgOpt")
+            val simple = mutableListOf<Duration>()
+            "Simple" - {
+                repeat(repetitions) {
+                    val before = Clock.System.now()
+                    checkAll(iterations = 15, Arb.uInt(max = 39u)) { second ->
+                        checkAll(iterations = 5000, Arb.uIntArray(Arb.int(0..256), Arb.uInt(UInt.MAX_VALUE))) {
+                            listOf(1u, 2u).forEach { first ->
+                                val oid = OldOIDObjectIdentifier(first, second, *it.toUIntArray())
+                                OldOIDObjectIdentifier.decodeFromTlv(oid.encodeToTlv())
+                            }
+                        }
+                    }
+                    val duration = Clock.System.now() - before
+                    simple += duration
+                    println("Simple $duration")
+                }
+            }
+
+            val avgSimple = (simple.sorted().subList(1, simple.size - 1)
+                .sumOf { it.inWholeMilliseconds } / simple.size - 2).milliseconds
+            println("AvgSimple: $avgSimple")
+
+            avgOpt shouldBeLessThan avgSimple
+
         }
 
         "Automated BigInt" - {
@@ -155,3 +205,145 @@ class OidTest : FreeSpec({
         }
     }
 })
+
+
+// old implementation for benchmarking
+private val BIGINT_40 = BigInteger.fromUByte(40u)
+
+class OldOIDObjectIdentifier @Throws(Asn1Exception::class) constructor(@Transient vararg val nodes: BigInteger) :
+    Asn1Encodable<Asn1Primitive> {
+
+    init {
+        if (nodes.size < 2) throw Asn1StructuralException("at least two nodes required!")
+        if ((nodes[0] * BIGINT_40) > UByte.MAX_VALUE.toUInt()) throw Asn1Exception("first node too lage!")
+        //TODO more sanity checks
+
+        if (nodes.first() > 2u) throw Asn1Exception("OID must start with either 1 or 2")
+        if (nodes[1] > 39u) throw Asn1Exception("Second segment must be <40")
+    }
+
+    /**
+     * Creates an OID in the 2.25 subtree that requires no formal registration.
+     * E.g. the UUID `550e8400-e29b-41d4-a716-446655440000` results in the OID
+     * `2.25.113059749145936325402354257176981405696`
+     */
+    @OptIn(ExperimentalUuidApi::class)
+    constructor(uuid: Uuid) : this(
+        BigInteger.fromByte(2),
+        BigInteger.fromByte(25),
+        uuid.toBigInteger()
+    )
+
+    /**
+     * @param nodes OID Tree nodes passed in order (e.g. 1u, 2u, 96u, …)
+     * @throws Asn1Exception if less than two nodes are supplied, the first node is >2 or the second node is >39
+     */
+    constructor(vararg ints: UInt) : this(*(ints.map { BigInteger.fromUInt(it) }.toTypedArray()))
+
+
+    /**
+     * @param oid in human-readable format (e.g. "1.2.96")
+     */
+    constructor(oid: String) : this(*(oid.split(if (oid.contains('.')) '.' else ' ')).map { BigInteger.parseString(it) }
+        .toTypedArray())
+
+    /**
+     * @return human-readable format (e.g. "1.2.96")
+     */
+    override fun toString() = nodes.joinToString(separator = ".") { it.toString() }
+
+    override fun equals(other: Any?): Boolean {
+        if (other == null) return false
+        if (other !is OldOIDObjectIdentifier) return false
+        return bytes contentEquals other.bytes
+    }
+
+    override fun hashCode(): Int {
+        return bytes.contentHashCode()
+    }
+
+
+    /**
+     * Cursed encoding of OID nodes. A sacrifice of pristine numbers requested by past gods of the netherrealm
+     */
+    val bytes: ByteArray by lazy {
+        nodes.slice(2..<nodes.size).map { it.toAsn1VarInt() }.fold(
+            byteArrayOf(
+                (nodes[0] * BIGINT_40 + nodes[1]).ubyteValue(exactRequired = true).toByte()
+            )
+        ) { acc, bytes -> acc + bytes }
+    }
+
+    /**
+     * @return an OBJECT IDENTIFIER [Asn1Primitive]
+     */
+    override fun encodeToTlv() = Asn1Primitive(Asn1Element.Tag.OID, bytes)
+
+    companion object : Asn1Decodable<Asn1Primitive, ObjectIdentifier> {
+
+        /**
+         * Parses an OBJECT IDENTIFIER contained in [src] to an [ObjectIdentifier]
+         * @throws Asn1Exception  all sorts of errors on invalid input
+         */
+        @Throws(Asn1Exception::class)
+        override fun doDecode(src: Asn1Primitive): ObjectIdentifier {
+            if (src.length < 1) throw Asn1StructuralException("Empty OIDs are not supported")
+
+            return parse(src.content)
+
+        }
+
+        /**
+         * Casts out the evil demons that haunt OID components encoded into [rawValue]
+         * @return ObjectIdentifier if decoding succeeded
+         * @throws Asn1Exception all sorts of errors on invalid input
+         */
+        @Throws(Asn1Exception::class)
+        fun parse(rawValue: ByteArray): ObjectIdentifier = runRethrowing {
+            if (rawValue.isEmpty()) throw Asn1Exception("Empty OIDs are not supported")
+            val (first, second) =
+                if (rawValue[0] >= 80) {
+                    BigInteger.fromUByte(2u) to BigInteger.fromUInt(rawValue[0].toUByte() - 80u)
+                } else {
+                    BigInteger.fromUInt(rawValue[0].toUByte() / 40u) to BigInteger.fromUInt(rawValue[0].toUByte() % 40u)
+                }
+
+            var index = 1
+            val collected = mutableListOf(first, second)
+            while (index < rawValue.size) {
+                if (rawValue[index] >= 0) {
+                    collected += BigInteger.fromUInt(rawValue[index].toUInt())
+                    index++
+                } else {
+                    val currentNode = mutableListOf<Byte>()
+                    while (rawValue[index] < 0) {
+                        currentNode += rawValue[index] //+= parsed
+                        index++
+                    }
+                    currentNode += rawValue[index]
+                    index++
+                    collected += currentNode.decodeAsn1VarBigInt().first
+                }
+            }
+            return ObjectIdentifier(*collected.toTypedArray())
+        }
+    }
+}
+
+
+/**
+ * Adds [oid] to the implementing class
+ */
+interface Identifiable {
+    val oid: ObjectIdentifier
+}
+
+/**
+ * decodes this [Asn1Primitive]'s content into an [ObjectIdentifier]
+ *
+ * @throws Asn1Exception on invalid input
+ */
+@Throws(Asn1Exception::class)
+fun Asn1Primitive.readOid() = runRethrowing {
+    decode(Asn1Element.Tag.OID) { OldOIDObjectIdentifier.parse(it) }
+}

--- a/indispensable/src/jvmTest/kotlin/at/asitplus/signum/indispensable/OidTest.kt
+++ b/indispensable/src/jvmTest/kotlin/at/asitplus/signum/indispensable/OidTest.kt
@@ -1,18 +1,19 @@
 package at.asitplus.signum.indispensable
 
 import at.asitplus.signum.indispensable.asn1.ObjectIdentifier
+import com.ionspin.kotlin.bignum.integer.BigInteger
+import com.ionspin.kotlin.bignum.integer.Sign
 import io.kotest.assertions.withClue
 import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.property.Arb
+import io.kotest.property.arbitrary.bigInt
 import io.kotest.property.arbitrary.int
 import io.kotest.property.arbitrary.intArray
 import io.kotest.property.arbitrary.positiveInt
 import io.kotest.property.checkAll
-import org.bouncycastle.asn1.ASN1Integer
 import org.bouncycastle.asn1.ASN1ObjectIdentifier
-import org.bouncycastle.asn1.DERTaggedObject
 
 class OidTest : FreeSpec({
     "OID test" - {
@@ -29,7 +30,7 @@ class OidTest : FreeSpec({
             oid.hashCode() shouldNotBe oid2.hashCode()
         }
 
-        "Automated" - {
+        "Automated UInt Capped" - {
             checkAll(iterations = 15, Arb.positiveInt(39)) { second ->
                 checkAll(iterations = 5000, Arb.intArray(Arb.int(0..128), Arb.positiveInt(Int.MAX_VALUE))) {
                     listOf(1, 2).forEach { first ->
@@ -42,12 +43,62 @@ class OidTest : FreeSpec({
                         val stringRepresentation =
                             "$first.$second" + if (it.isEmpty()) "" else ("." + it.joinToString("."))
 
+
+                        oid.toString() shouldBe stringRepresentation
+
                         val second1 = if (second > 1) second - 1 else second + 1
 
                         val oid1 = ObjectIdentifier(
                             first.toUInt(),
                             second1.toUInt(),
                             *(it.map { it.toUInt() }.toUIntArray())
+                        )
+                        val parsed = ObjectIdentifier.decodeFromTlv(oid.encodeToTlv())
+                        val fromBC = ASN1ObjectIdentifier(stringRepresentation)
+
+                        val bcEncoded = fromBC.encoded
+                        val ownEncoded = oid.encodeToDer()
+
+                        @OptIn(ExperimentalStdlibApi::class)
+                        withClue(
+                            "Expected: ${bcEncoded.toHexString(HexFormat.UpperCase)}\nActual: ${
+                                ownEncoded.toHexString(
+                                    HexFormat.UpperCase
+                                )
+                            }"
+                        ) {
+                            bcEncoded shouldBe ownEncoded
+                        }
+                        parsed shouldBe oid
+                        parsed.hashCode() shouldBe oid.hashCode()
+                        parsed shouldNotBe oid1
+                        parsed.hashCode() shouldNotBe oid1.hashCode()
+                    }
+                }
+            }
+        }
+
+        "Automated BigInt" - {
+            checkAll(iterations = 15, Arb.positiveInt(39)) { second ->
+                checkAll(iterations = 500, Arb.bigInt(1, 358)) {
+                    listOf(1, 2).forEach { first ->
+                        val third = BigInteger.fromByteArray(it.toByteArray(), Sign.POSITIVE)
+                        val oid = ObjectIdentifier(
+                            BigInteger.fromUInt(first.toUInt()),
+                            BigInteger.fromUInt(second.toUInt()),
+                            third
+                        )
+
+                        val stringRepresentation =
+                            "$first.$second.$third"
+
+                        oid.toString() shouldBe stringRepresentation
+
+                        val second1 = if (second > 1) second - 1 else second + 1
+
+                        val oid1 = ObjectIdentifier(
+                            BigInteger.fromUInt(first.toUInt()),
+                            BigInteger.fromUInt(second1.toUInt()),
                         )
                         val parsed = ObjectIdentifier.decodeFromTlv(oid.encodeToTlv())
                         val fromBC = ASN1ObjectIdentifier(stringRepresentation)

--- a/indispensable/src/jvmTest/kotlin/at/asitplus/signum/indispensable/OidTest.kt
+++ b/indispensable/src/jvmTest/kotlin/at/asitplus/signum/indispensable/OidTest.kt
@@ -35,10 +35,6 @@ class OidTest : FreeSpec({
             oid shouldNotBe oid2
             oid.hashCode() shouldBe oid1.hashCode()
             oid.hashCode() shouldNotBe oid2.hashCode()
-
-            println(ObjectIdentifier("2.39").encodeToTlv().prettyPrint())
-            println(ASN1ObjectIdentifier("0.15").encoded.toHexString(HexFormat.UpperCase))
-
         }
 
         "Full Root Arc" - {

--- a/indispensable/src/jvmTest/kotlin/at/asitplus/signum/indispensable/OidTest.kt
+++ b/indispensable/src/jvmTest/kotlin/at/asitplus/signum/indispensable/OidTest.kt
@@ -104,6 +104,20 @@ class OidTest : FreeSpec({
 
         }
 
+        "Failing negative Bigints" - {
+            checkAll(iterations = 50, Arb.negativeInt()) { negativeInt ->
+                checkAll(iterations = 15, Arb.positiveInt(39)) { second ->
+                    checkAll(iterations = 100, Arb.intArray(Arb.int(0..128), Arb.positiveInt(Int.MAX_VALUE))) { rest ->
+                        listOf(0, 1, 2).forEach { first ->
+                            val withNegative = intArrayOf(negativeInt, *rest).apply { shuffle() }.map { BigInteger(it) }.toTypedArray()
+                            shouldThrow<Asn1Exception> {
+                                ObjectIdentifier(BigInteger(first), BigInteger(second), *withNegative)
+                            }
+                        }
+                    }
+                }
+            }
+        }
         "Automated UInt Capped" - {
             checkAll(iterations = 15, Arb.positiveInt(39)) { second ->
                 checkAll(iterations = 5000, Arb.intArray(Arb.int(0..128), Arb.positiveInt(Int.MAX_VALUE))) {

--- a/indispensable/src/jvmTest/kotlin/at/asitplus/signum/indispensable/UVarIntTest.kt
+++ b/indispensable/src/jvmTest/kotlin/at/asitplus/signum/indispensable/UVarIntTest.kt
@@ -1,11 +1,15 @@
 package at.asitplus.signum.indispensable
 
+import at.asitplus.signum.indispensable.asn1.encoding.decodeAsn1VarBigInt
 import at.asitplus.signum.indispensable.asn1.encoding.decodeAsn1VarUInt
 import at.asitplus.signum.indispensable.asn1.encoding.decodeAsn1VarULong
 import at.asitplus.signum.indispensable.asn1.encoding.toAsn1VarInt
+import com.ionspin.kotlin.bignum.integer.BigInteger
+import com.ionspin.kotlin.bignum.integer.Sign
 import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
+import io.kotest.property.arbitrary.bigInt
 import io.kotest.property.arbitrary.uInt
 import io.kotest.property.arbitrary.uLong
 import io.kotest.property.checkAll
@@ -33,6 +37,29 @@ class UVarIntTest : FreeSpec({
             checkAll(Arb.uLong()) { long ->
                 (long.toAsn1VarInt().asList() + Random.nextBytes(8).asList()).decodeAsn1VarULong().first shouldBe long
 
+            }
+        }
+    }
+
+    "BigInts" - {
+        "long-capped" - {
+            checkAll(Arb.uLong()) { long ->
+                val uLongVarInt = long.toAsn1VarInt()
+                val bigInteger = BigInteger.fromULong(long)
+                val bigIntVarInt = bigInteger.toAsn1VarInt()
+
+                bigIntVarInt shouldBe uLongVarInt
+
+                (uLongVarInt.asList() + Random.nextBytes(8).asList()).decodeAsn1VarBigInt().first shouldBe bigInteger
+
+            }
+        }
+
+        "larger" - {
+            checkAll(Arb.bigInt(1, 1024 * 32)) { javaBigInt ->
+                val bigInt = BigInteger.fromByteArray(javaBigInt.toByteArray(), Sign.POSITIVE)
+                (bigInt.toAsn1VarInt().asList() + Random.nextBytes(33)
+                    .asList()).decodeAsn1VarBigInt().first shouldBe bigInt
             }
         }
     }


### PR DESCRIPTION
Revamps OIDs to be based on BigIntegers and directly supports 2.25.<UUID int representation> OIDs.

Yes, this halves OID performance, but the thing is: we need all validations while parsing, so basing everything on Bytes is nice for creation, but we'd need to move all parsing logic into the primary constructor.   
Hence, using BigInts as the foundation may be a bit slower, but creating and parsing remains symmetric.
The performance difference would be 1/3 AT BEST, realistically, it would probably more like 15-20% at the cost of harder-to-comprehend code