### PR TITLE
Add digest to interface

### DIFF
--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/SignatureAlgorithm.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/SignatureAlgorithm.kt
@@ -6,21 +6,24 @@ enum class RSAPadding {
 }
 
 sealed interface SignatureAlgorithm {
+
+    val digest: Digest?
+
     data class HMAC(
         /** The digest to use */
-        val digest: Digest
+        override val digest: Digest
     ) : SignatureAlgorithm
 
     data class ECDSA(
         /** The digest to apply to the data, or `null` to directly process the raw data. */
-        val digest: Digest?,
+        override val digest: Digest?,
         /** Whether this algorithm specifies a particular curve to use, or `null` for any curve. */
         val requiredCurve: ECCurve?
     ) : SignatureAlgorithm
 
     data class RSA(
         /** The digest to apply to the data. */
-        val digest: Digest,
+        override val digest: Digest?,
         /** The padding to apply to the data. */
         val padding: RSAPadding
     ) : SignatureAlgorithm

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/SignatureAlgorithm.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/SignatureAlgorithm.kt
@@ -23,7 +23,7 @@ sealed interface SignatureAlgorithm {
 
     data class RSA(
         /** The digest to apply to the data. */
-        override val digest: Digest?,
+        override val digest: Digest,
         /** The padding to apply to the data. */
         val padding: RSAPadding
     ) : SignatureAlgorithm


### PR DESCRIPTION
I propose to add digest as a variable to the `SignatureAlgorithm` interface in order to prevent the following code snippet.
@JesusMcCloud told me to ask you about it.

![Screenshot from 2024-10-07 17-59-15](https://github.com/user-attachments/assets/a61c64d8-533b-4c56-95e5-2396f0b5d183)
