### PR TITLE
fix cose signed equals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 * Introduce shorthand to create CSR from TbsCSR
 * Introduce shorthand to create certificate from TbsCertificate
 * Remove requirement from CSR to have certificate extensions
-
+* Fix CoseSigned equals
 
 ### 3.9.0 (Supreme 0.4.0)
 

--- a/indispensable-cosef/src/commonMain/kotlin/at/asitplus/signum/indispensable/cosef/CoseSigned.kt
+++ b/indispensable-cosef/src/commonMain/kotlin/at/asitplus/signum/indispensable/cosef/CoseSigned.kt
@@ -71,7 +71,7 @@ data class CoseSigned(
             if (other.payload == null) return false
             if (!payload.contentEquals(other.payload)) return false
         } else if (other.payload != null) return false
-        return rawSignature != other.rawSignature
+        return !rawSignature.contentEquals(other.rawSignature)
     }
 
     override fun hashCode(): Int {


### PR DESCRIPTION
Still assumes that whatever is passed to `ByteStringWrapper` correctly implements equals. If you pass an Array of something, it will break. This is broken in Kotlin and properly working around this is really, really, really tedious.