### PR TITLE
Feature/ktxio number encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 3.0
 
-### 3.10.0 NEXT (Supreme 0.5.0 NEXT)
+### 3.10.0 NEXT (Supreme 0.5.0 NEXT) Breaking Changes Ahead!
 
 * Introduce generic tag assertion to `Asn1Element`
 * Change CSR to take an actual `CryptoSignature` instead of a ByteArray
@@ -12,6 +12,7 @@
 * Fix CoseSigned equals
 * Base OIDs on BigInteger instead of UInt
 * Directly support UUID-based OID creation
+* Migrate to kotlinx-io to avoid byte copying.
 
 ### 3.9.0 (Supreme 0.4.0)
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
 core = "1.5.0"
+kotlinxIoCore = "0.5.4"
 multibase = "1.2.0"
 kotestExtensionsAndroid = "0.1.3"
 kotestRunnerAndroid = "1.1.1"
@@ -9,12 +10,14 @@ jose = "9.31"
 kotlinpoet = "1.16.0"
 runner = "1.5.2"
 kotest-plugin = "20240918.002009-71"
+kmmresult = "1.8.0"
 
 [libraries]
 bignum = { group = "com.ionspin.kotlin", name = "bignum", version.ref = "bignum" }
 core = { module = "androidx.test:core", version.ref = "core" }
 kotest-extensions-android = { module = "br.com.colman:kotest-extensions-android", version.ref = "kotestExtensionsAndroid" }
 kotest-runner-android = { module = "br.com.colman:kotest-runner-android", version.ref = "kotestRunnerAndroid" }
+kotlinx-io-core = { module = "org.jetbrains.kotlinx:kotlinx-io-core", version.ref = "kotlinxIoCore" }
 okio = { group = "com.squareup.okio", name = "okio", version.ref = "okio" }
 jose = { group = "com.nimbusds", name = "nimbus-jose-jwt", version.ref = "jose" }
 kotlinpoet = { group = "com.squareup", name = "kotlinpoet", version.ref = "kotlinpoet" }

--- a/indispensable/build.gradle.kts
+++ b/indispensable/build.gradle.kts
@@ -171,6 +171,7 @@ kotlin {
             )
 
             dependencies {
+                api(libs.kotlinx.io.core)
                 api(kmmresult())
                 api(serialization("json"))
                 api(datetime())

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/io/Encoding.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/io/Encoding.kt
@@ -6,6 +6,8 @@ import io.matthewnelson.encoding.base64.Base64
 import io.matthewnelson.encoding.base64.Base64ConfigBuilder
 import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArray
 import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
+import kotlinx.io.Buffer
+import kotlinx.io.bytestring.ByteString
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.builtins.ListSerializer
@@ -123,3 +125,12 @@ fun ByteArray.ensureSize(size: Int): ByteArray = (this.size - size).let { toDrop
 
 @Suppress("NOTHING_TO_INLINE")
 inline fun ByteArray.ensureSize(size: UInt) = ensureSize(size.toInt())
+
+/**
+ * gets the first byte
+ */
+@Suppress("NOTHING_TO_INLINE")
+inline fun ByteString.first() = get(0)
+
+@Suppress("NOTHING_TO_INLINE")
+inline fun ByteArray.asBuffer()=Buffer().also{it.write(this)}

--- a/indispensable/src/jvmTest/kotlin/at/asitplus/signum/indispensable/TagEncodingTest.kt
+++ b/indispensable/src/jvmTest/kotlin/at/asitplus/signum/indispensable/TagEncodingTest.kt
@@ -10,9 +10,12 @@ import io.kotest.datatest.withData
 import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
 import io.kotest.property.arbitrary.int
+import io.kotest.property.arbitrary.positiveInt
 import io.kotest.property.arbitrary.uInt
 import io.kotest.property.arbitrary.uLong
 import io.kotest.property.checkAll
+import kotlinx.io.Buffer
+import kotlinx.io.snapshot
 import org.bouncycastle.asn1.ASN1Integer
 import org.bouncycastle.asn1.DERTaggedObject
 
@@ -26,6 +29,12 @@ class TagEncodingTest : FreeSpec({
         val encoded = Asn1.Int(it).derEncoded
         encoded shouldBe fromBC
         long shouldBe it
+    }
+
+    "length encoding" - {
+        checkAll(Arb.positiveInt()) {
+           Buffer().apply { encodeLength(it.toLong()) }.snapshot().toByteArray() shouldBe it.encodeLength()
+        }
     }
 
     "Manual" - {

--- a/indispensable/src/jvmTest/kotlin/at/asitplus/signum/indispensable/UVarIntTest.kt
+++ b/indispensable/src/jvmTest/kotlin/at/asitplus/signum/indispensable/UVarIntTest.kt
@@ -1,41 +1,65 @@
 package at.asitplus.signum.indispensable
 
-import at.asitplus.signum.indispensable.asn1.encoding.decodeAsn1VarBigInt
-import at.asitplus.signum.indispensable.asn1.encoding.decodeAsn1VarUInt
-import at.asitplus.signum.indispensable.asn1.encoding.decodeAsn1VarULong
-import at.asitplus.signum.indispensable.asn1.encoding.toAsn1VarInt
+import at.asitplus.signum.indispensable.asn1.encoding.*
+import at.asitplus.signum.indispensable.io.asBuffer
 import com.ionspin.kotlin.bignum.integer.BigInteger
 import com.ionspin.kotlin.bignum.integer.Sign
 import io.kotest.core.spec.style.FreeSpec
+import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
 import io.kotest.property.arbitrary.bigInt
 import io.kotest.property.arbitrary.uInt
 import io.kotest.property.arbitrary.uLong
 import io.kotest.property.checkAll
+import kotlinx.io.Buffer
+import kotlinx.io.snapshot
+import kotlinx.io.writeULong
 import kotlin.random.Random
 
 class UVarIntTest : FreeSpec({
 
     "UInts with trailing bytes" - {
         "manual" {
-            byteArrayOf(65, 0, 0, 0).decodeAsn1VarUInt().first shouldBe 65u
+            val src = byteArrayOf(65, 0, 0, 0)
+            src.decodeAsn1VarUInt().first shouldBe 65u
+            val buf = src.asBuffer()
+            buf.decodeAsn1VarUInt().first shouldBe 65u
+            repeat(3){buf.readByte() shouldBe 0.toByte()}
+            buf.exhausted().shouldBeTrue()
         }
         "automated -" {
             checkAll(Arb.uInt()) { int ->
-                (int.toAsn1VarInt().asList() + Random.nextBytes(8).asList()).decodeAsn1VarUInt().first shouldBe int
-
+                val rnd = Random.nextBytes(8)
+                val src = int.toAsn1VarInt().asList() + rnd.asList()
+                src.decodeAsn1VarUInt().first shouldBe int
+                val buffer = src.toByteArray().asBuffer()
+                buffer.decodeAsn1VarUInt().first shouldBe int
+                rnd.forEach { it shouldBe buffer.readByte() }
+                buffer.exhausted().shouldBeTrue()
             }
         }
     }
 
     "ULongs with trailing bytes" - {
         "manual" {
-            byteArrayOf(65, 0, 0, 0).decodeAsn1VarULong().first shouldBe 65uL
+            val src = byteArrayOf(65, 0, 0, 0)
+            src.decodeAsn1VarULong().first shouldBe 65uL
+            val buf = src.asBuffer()
+            buf.decodeAsn1VarULong().first shouldBe 65uL
+            repeat(3){buf.readByte() shouldBe 0.toByte()}
+            buf.exhausted().shouldBeTrue()
         }
         "automated -" {
             checkAll(Arb.uLong()) { long ->
-                (long.toAsn1VarInt().asList() + Random.nextBytes(8).asList()).decodeAsn1VarULong().first shouldBe long
+                val rnd = Random.nextBytes(8)
+                val src = long.toAsn1VarInt().asList() + rnd.asList()
+                src.decodeAsn1VarULong().first shouldBe long
+
+                val buffer = src.toByteArray().asBuffer()
+                buffer.decodeAsn1VarULong().first shouldBe long
+                rnd.forEach { it shouldBe buffer.readByte() }
+                buffer.exhausted().shouldBeTrue()
 
             }
         }
@@ -49,8 +73,18 @@ class UVarIntTest : FreeSpec({
                 val bigIntVarInt = bigInteger.toAsn1VarInt()
 
                 bigIntVarInt shouldBe uLongVarInt
+                Buffer().apply { writeAsn1VarInt(bigInteger) }.snapshot().toByteArray() shouldBe bigIntVarInt
+                Buffer().apply { writeAsn1VarInt(long) }.snapshot().toByteArray() shouldBe uLongVarInt
 
-                (uLongVarInt.asList() + Random.nextBytes(8).asList()).decodeAsn1VarBigInt().first shouldBe bigInteger
+                val rnd = Random.nextBytes(8)
+                val src = uLongVarInt.asList() + rnd.asList()
+                src.decodeAsn1VarBigInt().first shouldBe bigInteger
+
+
+                val buffer = src.toByteArray().asBuffer()
+                buffer.decodeAsn1VarBigInt().first shouldBe bigInteger
+                rnd.forEach { it shouldBe buffer.readByte() }
+                buffer.exhausted().shouldBeTrue()
 
             }
         }
@@ -58,8 +92,16 @@ class UVarIntTest : FreeSpec({
         "larger" - {
             checkAll(Arb.bigInt(1, 1024 * 32)) { javaBigInt ->
                 val bigInt = BigInteger.fromByteArray(javaBigInt.toByteArray(), Sign.POSITIVE)
-                (bigInt.toAsn1VarInt().asList() + Random.nextBytes(33)
-                    .asList()).decodeAsn1VarBigInt().first shouldBe bigInt
+                val bigIntVarint = bigInt.toAsn1VarInt()
+                val rnd = Random.nextBytes(33)
+                val src = bigIntVarint.asList() + rnd
+                    .asList()
+                src.decodeAsn1VarBigInt().first shouldBe bigInt
+
+                val buf = src.toByteArray().asBuffer()
+                buf.decodeAsn1VarBigInt().first shouldBe bigInt
+                rnd.forEach { it shouldBe buf.readByte() }
+                buf.exhausted().shouldBeTrue()
             }
         }
     }


### PR DESCRIPTION
We cannot yet remove the iterator-based decoding, because ASN.1 depends on it and there is simpyl no way that an iterator can be wrapped into a source without consuming 8kB right away, thus destroying everything.
Also: it makes for a nice regression test.

I therefore propose to keep it like that and move the iterator-based foo to the test sources for regression testing after the ASN.1 refactor is done. OR: all in one pull request, where it makes sense, because it is not nearly as independent as you assumed.