### PR TITLE
hashToScalar should be mod group order `r`, not mod field order/modulus `p`

### DIFF
--- a/supreme/src/androidMain/kotlin/at/asitplus/signum/supreme/sign/VerifierImpl.kt
+++ b/supreme/src/androidMain/kotlin/at/asitplus/signum/supreme/sign/VerifierImpl.kt
@@ -1,5 +1,6 @@
 package at.asitplus.signum.supreme.sign
 
+import at.asitplus.catchingUnwrappedAs
 import at.asitplus.signum.indispensable.CryptoPublicKey
 import at.asitplus.signum.indispensable.CryptoSignature
 import at.asitplus.signum.indispensable.RSAPadding
@@ -9,7 +10,6 @@ import at.asitplus.signum.indispensable.jcaAlgorithmComponent
 import at.asitplus.signum.indispensable.jcaSignatureBytes
 import at.asitplus.signum.supreme.dsl.DSL
 import at.asitplus.signum.supreme.UnsupportedCryptoException
-import at.asitplus.wrapping
 import java.security.Signature
 
 /**
@@ -32,7 +32,7 @@ internal actual fun checkAlgorithmKeyCombinationSupportedByECDSAPlatformVerifier
             (signatureAlgorithm: SignatureAlgorithm.ECDSA, publicKey: CryptoPublicKey.EC,
              config: PlatformVerifierConfiguration)
 {
-    wrapping(asA=::UnsupportedCryptoException) {
+    catchingUnwrappedAs(a=::UnsupportedCryptoException) {
         getSigInstance("${signatureAlgorithm.digest.jcaAlgorithmComponent}withECDSA", config.provider)
             .initVerify(publicKey.getJcaPublicKey().getOrThrow())
     }.getOrThrow()
@@ -70,7 +70,7 @@ internal actual fun checkAlgorithmKeyCombinationSupportedByRSAPlatformVerifier
             (signatureAlgorithm: SignatureAlgorithm.RSA, publicKey: CryptoPublicKey.RSA,
              config: PlatformVerifierConfiguration)
 {
-    wrapping(asA=::UnsupportedCryptoException) {
+    catchingUnwrappedAs(a=::UnsupportedCryptoException) {
         getRSAInstance(signatureAlgorithm, config)
             .initVerify(publicKey.getJcaPublicKey().getOrThrow())
     }.getOrThrow()

--- a/supreme/src/commonMain/kotlin/at/asitplus/signum/ecmath/RFC9380.kt
+++ b/supreme/src/commonMain/kotlin/at/asitplus/signum/ecmath/RFC9380.kt
@@ -39,8 +39,11 @@ private inline val ECCurve.L get() = when(this) {
     ECCurve.SECP_521_R_1 -> 98
 }
 
-/** per RFC9794 4.7.2. */
-fun ECCurve.randomScalar() = SecureRandom().nextBytesOf(this.L).let { BigInteger.fromByteArray(it, Sign.POSITIVE).toModularBigInteger(this.order) }
+/** per RFC9794 4.7.2.
+ * @param L security parameter controlling the drift from uniform;
+ *            defaults to `log2(modulus) * (3/2)`, which is the value used in RFC9794 */
+fun ECCurve.randomScalar(L: Int = this.L) = SecureRandom().nextBytesOf(L)
+    .let { BigInteger.fromByteArray(it, Sign.POSITIVE).toModularBigInteger(this.order) }
 
 private inline fun clearCofactorTrivial(p: ECPoint) = p.curve.cofactor * p
 

--- a/supreme/src/commonMain/kotlin/at/asitplus/signum/ecmath/RFC9380.kt
+++ b/supreme/src/commonMain/kotlin/at/asitplus/signum/ecmath/RFC9380.kt
@@ -309,7 +309,8 @@ fun ECCurve.hashToScalar(domain: ByteArray, L: Int = this.L) = RFC9380.HashToECS
  * @param domain a suitable _domain separation tag_ (DST) for your use case;
  *                   this should be unique to this particular use case within your application!
  *                   see [RFC9380 3.1 Domain Separation Requirements](https://www.rfc-editor.org/rfc/rfc9380#name-domain-separation-requireme)
- *                      for guidance */
+ *                      for guidance
+ * @return a function mapping arbitrary bytes to a point on the curve */
 inline fun ECCurve.hashToCurve(domain: ByteArray) = when (this) {
     ECCurve.SECP_256_R_1 -> RFC9380.`P256_XMD∶SHA-256_SSWU_RO_`(domain)
     ECCurve.SECP_384_R_1 -> RFC9380.`P384_XMD∶SHA-384_SSWU_RO_`(domain)

--- a/supreme/src/commonTest/kotlin/at/asitplus/signum/ecmath/RFC9380Test.kt
+++ b/supreme/src/commonTest/kotlin/at/asitplus/signum/ecmath/RFC9380Test.kt
@@ -672,19 +672,13 @@ Q.y     = 0068889ea2e1442245fe42bfda9e58266828c0263119f35a61631a
                 }
                 registerTest(TestName("hash_to_field"), false, null) {
                     val htfA = RFC9380.hash_to_field(suiteInfo.curve.nativeDigest, suiteInfo.curve, suiteInfo.dstB)
-                    val htfB = suiteInfo.curve.hashToScalar(suiteInfo.dstB)
                     if (test.u1 != null) {
-                        val uA = htfA(test.msg.encodeToByteArray(), 2)
-                        val uB = htfB(test.msg.encodeToByteArray(), 2)
-                        uA[0].toString(16).padStart(test.u0.length, '0') shouldBe test.u0
-                        uB[0].toString(16).padStart(test.u0.length, '0') shouldBe test.u0
-                        uA[1].toString(16).padStart(test.u1.length, '0') shouldBe test.u1
-                        uB[1].toString(16).padStart(test.u1.length, '0') shouldBe test.u1
+                        val u = htfA(test.msg.encodeToByteArray(), 2)
+                        u[0].toString(16).padStart(test.u0.length, '0') shouldBe test.u0
+                        u[1].toString(16).padStart(test.u1.length, '0') shouldBe test.u1
                     } else {
-                        val uA = htfA(test.msg.encodeToByteArray())
-                        val uB = htfB(test.msg.encodeToByteArray())
-                        uA.toString(16).padStart(test.u0.length, '0') shouldBe test.u0
-                        uB.toString(16).padStart(test.u0.length, '0') shouldBe test.u0
+                        val u = htfA(test.msg.encodeToByteArray())
+                        u.toString(16).padStart(test.u0.length, '0') shouldBe test.u0
                     }
                 }
                 registerTest(TestName("map_to_curve"), false, null) {

--- a/supreme/src/commonTest/kotlin/at/asitplus/signum/ecmath/RFC9380Test.kt
+++ b/supreme/src/commonTest/kotlin/at/asitplus/signum/ecmath/RFC9380Test.kt
@@ -671,7 +671,8 @@ Q.y     = 0068889ea2e1442245fe42bfda9e58266828c0263119f35a61631a
                     result.y.toString(16).padStart(test.Py.length, '0') shouldBe test.Py
                 }
                 registerTest(TestName("hash_to_field"), false, null) {
-                    val htfA = RFC9380.hash_to_field(suiteInfo.curve.nativeDigest, suiteInfo.curve, suiteInfo.dstB)
+                    val htfA = RFC9380.hash_to_field(
+                        RFC9380.expand_message_xmd(suiteInfo.curve.nativeDigest), suiteInfo.curve, suiteInfo.dstB)
                     if (test.u1 != null) {
                         val u = htfA(test.msg.encodeToByteArray(), 2)
                         u[0].toString(16).padStart(test.u0.length, '0') shouldBe test.u0

--- a/supreme/src/jvmMain/kotlin/at/asitplus/signum/supreme/sign/VerifierImpl.kt
+++ b/supreme/src/jvmMain/kotlin/at/asitplus/signum/supreme/sign/VerifierImpl.kt
@@ -1,5 +1,6 @@
 package at.asitplus.signum.supreme.sign
 
+import at.asitplus.catchingUnwrappedAs
 import at.asitplus.signum.indispensable.CryptoPublicKey
 import at.asitplus.signum.indispensable.CryptoSignature
 import at.asitplus.signum.indispensable.RSAPadding
@@ -10,7 +11,6 @@ import at.asitplus.signum.indispensable.jcaPSSParams
 import at.asitplus.signum.indispensable.jcaSignatureBytes
 import at.asitplus.signum.supreme.dsl.DSL
 import at.asitplus.signum.supreme.UnsupportedCryptoException
-import at.asitplus.wrapping
 import java.security.Signature
 
 /**
@@ -33,7 +33,7 @@ internal actual fun checkAlgorithmKeyCombinationSupportedByECDSAPlatformVerifier
             (signatureAlgorithm: SignatureAlgorithm.ECDSA, publicKey: CryptoPublicKey.EC,
              config: PlatformVerifierConfiguration)
 {
-    wrapping(asA=::UnsupportedCryptoException) {
+    catchingUnwrappedAs(a=::UnsupportedCryptoException) {
         getSigInstance("${signatureAlgorithm.digest.jcaAlgorithmComponent}withECDSA", config.provider)
             .initVerify(publicKey.getJcaPublicKey().getOrThrow())
     }.getOrThrow()
@@ -73,7 +73,7 @@ private fun getRSAInstance(alg: SignatureAlgorithm.RSA, config: PlatformVerifier
 internal actual fun checkAlgorithmKeyCombinationSupportedByRSAPlatformVerifier
             (signatureAlgorithm: SignatureAlgorithm.RSA, publicKey: CryptoPublicKey.RSA,
              config: PlatformVerifierConfiguration) {
-    wrapping(asA=::UnsupportedCryptoException) {
+    catchingUnwrappedAs(a=::UnsupportedCryptoException) {
         getRSAInstance(signatureAlgorithm, config)
             .initVerify(publicKey.getJcaPublicKey().getOrThrow())
     }.getOrThrow()


### PR DESCRIPTION
See title, I got this wrong when tacking `hashToScalar` onto #169.