### PR TITLE
Automatically re-target PRs from `main` to `development`

### DIFF
--- a/.github/workflows/guard-main.yml
+++ b/.github/workflows/guard-main.yml
@@ -6,26 +6,7 @@ on:
     branches:
       - 'main'
 jobs:
-  warn:
-    name: 'Enforce PR target'
-    if: github.head_ref != 'development'
-    runs-on: 'ubuntu-latest'
-    steps:
-      - uses: 'actions/github-script@v6'
-        with:
-          script: |
-            try {
-              const {owner,repo} = context.repo;
-              const pull_number = ${{github.event.pull_request.number}};
-              await github.rest.issues.createComment({
-                issue_number: pull_number,
-                body: "⚠️⚠️ This pull request targets `main`. I am re-targeting it to `development`. ⚠️⚠️",
-                owner, repo});
-              await github.rest.pulls.update({
-                base: 'development',
-                pull_number, owner, repo});
-            } catch (err) {
-              core.setFailed(err);
-            }
+  check-target:
+    uses: a-sit-plus/internal-workflows/.github/workflows/guard-main.yml@main
 permissions:
   pull-requests: write

--- a/.github/workflows/guard-main.yml
+++ b/.github/workflows/guard-main.yml
@@ -1,0 +1,31 @@
+name: 'Verify PR branch target'
+on:
+  pull_request_target:
+    types:
+      - 'opened'
+    branches:
+      - 'main'
+jobs:
+  warn:
+    name: 'Enforce PR target'
+    if: github.head_ref != 'development'
+    runs-on: 'ubuntu-latest'
+    steps:
+      - uses: 'actions/github-script@v6'
+        with:
+          script: |
+            try {
+              const {owner,repo} = context.repo;
+              const pull_number = ${{github.event.pull_request.number}};
+              await github.rest.issues.createComment({
+                issue_number: pull_number,
+                body: "⚠️⚠️ This pull request targets `main`. I am re-targeting it to `development`. ⚠️⚠️",
+                owner, repo});
+              await github.rest.pulls.update({
+                base: 'development',
+                pull_number, owner, repo});
+            } catch (err) {
+              core.setFailed(err);
+            }
+permissions:
+  pull-requests: write


### PR DESCRIPTION
Github CI action that automatically re-targets any PR targeting `main` to target `development` instead, with accompanying warning comment. See iaik-jheher/signum#8 for demonstration.