### PR TITLE
COSE Signed API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### 3.11.0 NEXT
 
+* Add type parameter to `CoseSigned` for its payload
+* Add companion method `CoseSigned.fromObject` to create a `CoseSigned` with a typed payload (outside of the usual `ByteArray`)
+
 ### 3.10.0 (Supreme 0.5.0) More ~~cowbell~~ targets!
 A new artifact, minor breaking changes and a lot more targets ahead!
 

--- a/docs/docs/examples.md
+++ b/docs/docs/examples.md
@@ -69,29 +69,28 @@ val protectedHeader = CoseHeader(
 val payload = byteArrayOf(0xC, 0xA, 0xF, 0xE)
 ```
 
-Both of these are signature inputs, so we'll construct a `CoseSignatureInput` to sign.
+Both of these are signature inputs, so we can construct the signature input:
 
 ```kotlin
-val signatureInput = CoseSignatureInput(
-    contextString = "Signature1",
-    protectedHeader = ByteStringWrapper(protectedHeader),
-    externalAad = byteArrayOf(),
+val signatureInput = CoseSigned.prepareCoseSignatureInput(
+    protectedHeader = protectedHeader,
     payload = payload,
-).serialize()
+    externalAad = byteArrayOf()
+)
 ```
-
 
 Now, everything is ready to be signed:
 
 ```kotlin
 val signature = signer.sign(signatureInput).signature //TODO handle error
 
-val coseSigned = CoseSigned(
-    ByteStringWrapper(protectedHeader),
-    unprotectedHeader = null,
-    payload,
-    signature
-).serialize() // sadly, there's no cwt.io, but you can use cbor.me to explore the signed data
+CoseSigned(
+    protectedHeader = ByteStringWrapper(protectedHeader),
+    unprotectedHeader = unprotectedHeader,
+    payload = payload,
+    signature = signature
+)
+// sadly, there's no cwt.io, but you can use cbor.me to explore the signed data
 ```
 
 ## Create and Parse a Custom-Tagged ASN.1 Structure

--- a/indispensable-cosef/src/commonMain/kotlin/at/asitplus/signum/indispensable/cosef/CoseSigned.kt
+++ b/indispensable-cosef/src/commonMain/kotlin/at/asitplus/signum/indispensable/cosef/CoseSigned.kt
@@ -5,6 +5,7 @@ import at.asitplus.catching
 import at.asitplus.signum.indispensable.*
 import at.asitplus.signum.indispensable.cosef.io.Base16Strict
 import at.asitplus.signum.indispensable.cosef.io.ByteStringWrapper
+import at.asitplus.signum.indispensable.cosef.io.ByteStringWrapperSerializer
 import at.asitplus.signum.indispensable.cosef.io.coseCompliantSerializer
 import at.asitplus.signum.indispensable.pki.X509Certificate
 import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
@@ -50,8 +51,15 @@ data class CoseSigned<P : Any>(
 
     fun serialize(): ByteArray = coseCompliantSerializer.encodeToByteArray(CoseSignedSerializer(), this)
 
-    fun getTypedPayload(deserializationStrategy: DeserializationStrategy<P>): KmmResult<P?> = catching {
-        payload?.let { coseCompliantSerializer.decodeFromByteArray(deserializationStrategy, it) }
+    /**
+     * Decodes the payload of this object into a [ByteStringWrapper] containing an object of type [P].
+     *
+     * Note that this does not work if the payload is directly a [ByteArray].
+     */
+    fun getTypedPayload(deserializer: KSerializer<P>): KmmResult<ByteStringWrapper<P>?> = catching {
+        payload?.let {
+            coseCompliantSerializer.decodeFromByteArray(ByteStringWrapperSerializer(deserializer), it)
+        }
     }
 
     override fun equals(other: Any?): Boolean {

--- a/indispensable-cosef/src/commonMain/kotlin/at/asitplus/signum/indispensable/cosef/CoseSigned.kt
+++ b/indispensable-cosef/src/commonMain/kotlin/at/asitplus/signum/indispensable/cosef/CoseSigned.kt
@@ -7,6 +7,7 @@ import at.asitplus.signum.indispensable.SignatureAlgorithm
 import at.asitplus.signum.indispensable.cosef.io.Base16Strict
 import at.asitplus.signum.indispensable.cosef.io.ByteStringWrapper
 import at.asitplus.signum.indispensable.cosef.io.coseCompliantSerializer
+import at.asitplus.signum.indispensable.io.Base64UrlStrict
 import at.asitplus.signum.indispensable.pki.X509Certificate
 import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
 import kotlinx.serialization.ExperimentalSerializationApi
@@ -85,6 +86,23 @@ data class CoseSigned(
         fun deserialize(it: ByteArray) = catching {
             coseCompliantSerializer.decodeFromByteArray<CoseSigned>(it)
         }
+
+        /**
+         * Called by COSE signing implementations to get the bytes that will be
+         * used as the input for signature calculation of a `COSE_Sign1` object
+         */
+        @Suppress("unused")
+        fun prepareCoseSignatureInput(
+            protectedHeader: CoseHeader,
+            payload: ByteArray?,
+            externalAad: ByteArray = byteArrayOf(),
+        ): ByteArray = CoseSignatureInput(
+            contextString = "Signature1",
+            protectedHeader = ByteStringWrapper(protectedHeader),
+            externalAad = externalAad,
+            payload = payload,
+        ).serialize()
+
     }
 }
 

--- a/indispensable-cosef/src/commonMain/kotlin/at/asitplus/signum/indispensable/cosef/CoseSigned.kt
+++ b/indispensable-cosef/src/commonMain/kotlin/at/asitplus/signum/indispensable/cosef/CoseSigned.kt
@@ -8,9 +8,12 @@ import at.asitplus.signum.indispensable.cosef.io.ByteStringWrapper
 import at.asitplus.signum.indispensable.cosef.io.coseCompliantSerializer
 import at.asitplus.signum.indispensable.pki.X509Certificate
 import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
-import kotlinx.serialization.*
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.Serializable
 import kotlinx.serialization.cbor.ByteString
 import kotlinx.serialization.cbor.CborArray
+import kotlinx.serialization.decodeFromByteArray
+import kotlinx.serialization.encodeToByteArray
 
 /**
  * Representation of a signed COSE_Sign1 object, i.e. consisting of protected header, unprotected header and payload.
@@ -18,7 +21,7 @@ import kotlinx.serialization.cbor.CborArray
  * See [RFC 9052](https://www.rfc-editor.org/rfc/rfc9052.html).
  */
 @OptIn(ExperimentalSerializationApi::class)
-@Serializable
+@Serializable(with = CoseSignedSerializer::class)
 @CborArray
 data class CoseSigned<out P : Any>(
     @ByteString
@@ -27,8 +30,7 @@ data class CoseSigned<out P : Any>(
     @ByteString
     val payload: ByteArray?,
     @ByteString
-    @SerialName("signature")
-    private val rawSignature: ByteArray
+    val rawSignature: ByteArray
 ) {
 
     constructor(
@@ -44,7 +46,7 @@ data class CoseSigned<out P : Any>(
         else CryptoSignature.RSAorHMAC(rawSignature)
     }
 
-    fun serialize() = coseCompliantSerializer.encodeToByteArray(this)
+    fun serialize(): ByteArray = coseCompliantSerializer.encodeToByteArray(CoseSignedSerializer(),this)
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/indispensable-cosef/src/commonMain/kotlin/at/asitplus/signum/indispensable/cosef/CoseSigned.kt
+++ b/indispensable-cosef/src/commonMain/kotlin/at/asitplus/signum/indispensable/cosef/CoseSigned.kt
@@ -21,7 +21,7 @@ import kotlinx.serialization.cbor.CborArray
 @OptIn(ExperimentalSerializationApi::class)
 @Serializable(with = CoseSignedSerializer::class)
 @CborArray
-data class CoseSigned<P : Any>(
+data class CoseSigned<P : Any?>(
     @ByteString
     val protectedHeader: ByteStringWrapper<CoseHeader>,
     val unprotectedHeader: CoseHeader?,

--- a/indispensable-cosef/src/commonMain/kotlin/at/asitplus/signum/indispensable/cosef/CoseSigned.kt
+++ b/indispensable-cosef/src/commonMain/kotlin/at/asitplus/signum/indispensable/cosef/CoseSigned.kt
@@ -112,8 +112,11 @@ data class CoseSigned<P : Any>(
         ) = CoseSigned<P>(
             protectedHeader = ByteStringWrapper(value = protectedHeader),
             unprotectedHeader = unprotectedHeader,
-            payload = if (payload is ByteArray) payload else
-                coseCompliantSerializer.encodeToByteArray(ByteStringWrapper(payload)),
+            payload = when (payload) {
+                is ByteArray -> payload
+                is ByteStringWrapper<*> -> coseCompliantSerializer.encodeToByteArray(payload)
+                else -> coseCompliantSerializer.encodeToByteArray(ByteStringWrapper(payload))
+            },
             rawSignature = signature.rawByteArray
         )
 
@@ -129,8 +132,11 @@ data class CoseSigned<P : Any>(
             contextString = "Signature1",
             protectedHeader = ByteStringWrapper(protectedHeader),
             externalAad = externalAad,
-            payload = if (payload is ByteArray) payload else
-                coseCompliantSerializer.encodeToByteArray(ByteStringWrapper(payload)),
+            payload = when (payload) {
+                is ByteArray -> payload
+                is ByteStringWrapper<*> -> coseCompliantSerializer.encodeToByteArray(payload)
+                else -> coseCompliantSerializer.encodeToByteArray(ByteStringWrapper(payload))
+            },
         ).serialize()
 
 

--- a/indispensable-cosef/src/commonMain/kotlin/at/asitplus/signum/indispensable/cosef/CoseSigned.kt
+++ b/indispensable-cosef/src/commonMain/kotlin/at/asitplus/signum/indispensable/cosef/CoseSigned.kt
@@ -90,6 +90,25 @@ data class CoseSigned<P : Any>(
         }
 
         /**
+         * Creates a [CoseSigned] object from the given parameters,
+         * encapsulating the [payload] into a [ByteStringWrapper].
+         *
+         * This has to be an inline function with a reified type parameter,
+         * so it can't be a constructor (leads to a runtime error).
+         */
+        inline fun <reified P : Any> fromObject(
+            protectedHeader: CoseHeader,
+            unprotectedHeader: CoseHeader?,
+            payload: P,
+            signature: CryptoSignature.RawByteEncodable
+        ) = CoseSigned<P>(
+            protectedHeader = ByteStringWrapper(value = protectedHeader),
+            unprotectedHeader = unprotectedHeader,
+            payload = coseCompliantSerializer.encodeToByteArray(ByteStringWrapper(payload)),
+            rawSignature = signature.rawByteArray
+        )
+
+        /**
          * Called by COSE signing implementations to get the bytes that will be
          * used as the input for signature calculation of a `COSE_Sign1` object
          */

--- a/indispensable-cosef/src/commonMain/kotlin/at/asitplus/signum/indispensable/cosef/CoseSigned.kt
+++ b/indispensable-cosef/src/commonMain/kotlin/at/asitplus/signum/indispensable/cosef/CoseSigned.kt
@@ -31,11 +31,16 @@ data class CoseSigned<P : Any>(
 ) {
 
     constructor(
-        protectedHeader: ByteStringWrapper<CoseHeader>,
+        protectedHeader: CoseHeader,
         unprotectedHeader: CoseHeader?,
         payload: ByteArray?,
         signature: CryptoSignature.RawByteEncodable
-    ) : this(protectedHeader, unprotectedHeader, payload, signature.rawByteArray)
+    ) : this(
+        protectedHeader = ByteStringWrapper(value = protectedHeader),
+        unprotectedHeader = unprotectedHeader,
+        payload = payload,
+        rawSignature = signature.rawByteArray
+    )
 
     val signature: CryptoSignature by lazy {
         if (protectedHeader.value.usesEC() ?: unprotectedHeader?.usesEC() ?: (rawSignature.size < 2048))

--- a/indispensable-cosef/src/commonMain/kotlin/at/asitplus/signum/indispensable/cosef/CoseSigned.kt
+++ b/indispensable-cosef/src/commonMain/kotlin/at/asitplus/signum/indispensable/cosef/CoseSigned.kt
@@ -112,7 +112,8 @@ data class CoseSigned<P : Any>(
         ) = CoseSigned<P>(
             protectedHeader = ByteStringWrapper(value = protectedHeader),
             unprotectedHeader = unprotectedHeader,
-            payload = coseCompliantSerializer.encodeToByteArray(ByteStringWrapper(payload)),
+            payload = if (payload is ByteArray) payload else
+                coseCompliantSerializer.encodeToByteArray(ByteStringWrapper(payload)),
             rawSignature = signature.rawByteArray
         )
 
@@ -120,17 +121,18 @@ data class CoseSigned<P : Any>(
          * Called by COSE signing implementations to get the bytes that will be
          * used as the input for signature calculation of a `COSE_Sign1` object
          */
-        @Suppress("unused")
-        fun prepareCoseSignatureInput(
+        inline fun <reified P : Any> prepareCoseSignatureInput(
             protectedHeader: CoseHeader,
-            payload: ByteArray?,
+            payload: P?,
             externalAad: ByteArray = byteArrayOf(),
         ): ByteArray = CoseSignatureInput(
             contextString = "Signature1",
             protectedHeader = ByteStringWrapper(protectedHeader),
             externalAad = externalAad,
-            payload = payload,
+            payload = if (payload is ByteArray) payload else
+                coseCompliantSerializer.encodeToByteArray(ByteStringWrapper(payload)),
         ).serialize()
+
 
     }
 }

--- a/indispensable-cosef/src/commonMain/kotlin/at/asitplus/signum/indispensable/cosef/CoseSignedSerializer.kt
+++ b/indispensable-cosef/src/commonMain/kotlin/at/asitplus/signum/indispensable/cosef/CoseSignedSerializer.kt
@@ -1,0 +1,44 @@
+package at.asitplus.signum.indispensable.cosef
+
+import at.asitplus.signum.indispensable.cosef.io.ByteStringWrapperSerializer
+import kotlinx.serialization.InternalSerializationApi
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.builtins.ByteArraySerializer
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.descriptors.StructureKind
+import kotlinx.serialization.descriptors.buildSerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.encoding.decodeStructure
+import kotlinx.serialization.encoding.encodeStructure
+
+class CoseSignedSerializer<P : Any> : KSerializer<CoseSigned<P>> {
+
+    @OptIn(InternalSerializationApi::class)
+    override val descriptor: SerialDescriptor = buildSerialDescriptor("CoseSigned", StructureKind.LIST) {
+        element("protectedHeader", ByteStringWrapperSerializer(CoseHeader.serializer()).descriptor)
+        element("unprotectedHeader", CoseHeader.serializer().descriptor)
+        element("payload", ByteArraySerializer().descriptor)
+        element("signature", ByteArraySerializer().descriptor)
+    }
+
+    override fun deserialize(decoder: Decoder): CoseSigned<P> {
+        return decoder.decodeStructure(descriptor) {
+            val protectedHeader = decodeSerializableElement(descriptor, 0, ByteStringWrapperSerializer(CoseHeader.serializer()))
+            val unprotectedHeader = decodeNullableSerializableElement(descriptor, 1, CoseHeader.serializer())
+            val payload = decodeNullableSerializableElement(descriptor, 2, ByteArraySerializer())
+            val signature = decodeSerializableElement(descriptor, 3, ByteArraySerializer())
+            CoseSigned(protectedHeader, unprotectedHeader, payload, signature)
+        }
+    }
+
+    override fun serialize(encoder: Encoder, value: CoseSigned<P>) {
+        encoder.encodeStructure(descriptor) {
+            encodeSerializableElement(descriptor, 0, ByteStringWrapperSerializer(CoseHeader.serializer()), value.protectedHeader)
+            encodeNullableSerializableElement(descriptor, 1, CoseHeader.serializer(), value.unprotectedHeader)
+            encodeNullableSerializableElement(descriptor, 2, ByteArraySerializer(), value.payload)
+            encodeSerializableElement(descriptor, 3, ByteArraySerializer(), value.rawSignature)
+        }
+    }
+
+}

--- a/indispensable-cosef/src/commonMain/kotlin/at/asitplus/signum/indispensable/cosef/CoseSignedSerializer.kt
+++ b/indispensable-cosef/src/commonMain/kotlin/at/asitplus/signum/indispensable/cosef/CoseSignedSerializer.kt
@@ -12,7 +12,7 @@ import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.encoding.decodeStructure
 import kotlinx.serialization.encoding.encodeStructure
 
-class CoseSignedSerializer<P : Any> : KSerializer<CoseSigned<P>> {
+class CoseSignedSerializer<P : Any?> : KSerializer<CoseSigned<P>> {
 
     @OptIn(InternalSerializationApi::class)
     override val descriptor: SerialDescriptor = buildSerialDescriptor("CoseSigned", StructureKind.LIST) {

--- a/indispensable-cosef/src/commonTest/kotlin/at/asitplus/signum/indispensable/cosef/CoseEqualsTest.kt
+++ b/indispensable-cosef/src/commonTest/kotlin/at/asitplus/signum/indispensable/cosef/CoseEqualsTest.kt
@@ -13,60 +13,57 @@ import io.kotest.property.checkAll
 class CoseEqualsTest : FreeSpec({
     "Test Equals" - {
         checkAll(
-            Arb.byteArray(
-                length = Arb.int(0, 10),
-                content = Arb.byte()
-            )
-        ) { s1 ->
-            val signed1 = CoseSigned<ByteArray>(
-                protectedHeader = ByteStringWrapper(CoseHeader()),
+            Arb.byteArray(length = Arb.int(0, 10), content = Arb.byte())
+        ) { bytes ->
+            val bytesSigned1 = CoseSigned<ByteArray>(
+                protectedHeader = ByteStringWrapper<CoseHeader>(CoseHeader()),
                 unprotectedHeader = null,
-                payload = s1,
-                rawSignature = s1
+                payload = bytes,
+                rawSignature = bytes
             )
-            val signed11 = CoseSigned<ByteArray>(
-                protectedHeader = ByteStringWrapper(CoseHeader()),
+            val bytesSigned2 = CoseSigned<ByteArray>(
+                protectedHeader = ByteStringWrapper<CoseHeader>(CoseHeader()),
                 unprotectedHeader = null,
-                payload = s1,
-                rawSignature = s1
+                payload = bytes,
+                rawSignature = bytes
             )
 
-            signed1 shouldBe signed1
-            signed11 shouldBe signed1
-            signed1.hashCode() shouldBe signed1.hashCode()
-            signed1.hashCode() shouldBe signed11.hashCode()
+            bytesSigned1 shouldBe bytesSigned1
+            bytesSigned2 shouldBe bytesSigned1
+            bytesSigned1.hashCode() shouldBe bytesSigned1.hashCode()
+            bytesSigned1.hashCode() shouldBe bytesSigned2.hashCode()
 
-            val s2 = s1.reversedArray().let { it + it + 1 + 3 + 5 }
-            val signed2 = CoseSigned<ByteArray>(
-                protectedHeader = ByteStringWrapper(CoseHeader()),
+            val reversed = bytes.reversedArray().let { it + it + 1 + 3 + 5 }
+            val reversedSigned1 = CoseSigned<ByteArray>(
+                protectedHeader = ByteStringWrapper<CoseHeader>(CoseHeader()),
                 unprotectedHeader = null,
-                payload = s2,
-                rawSignature = s2
+                payload = reversed,
+                rawSignature = reversed
             )
-            val signed22 = CoseSigned<ByteArray>(
-                protectedHeader = ByteStringWrapper(CoseHeader()),
+            val reversedSigned2 = CoseSigned<ByteArray>(
+                protectedHeader = ByteStringWrapper<CoseHeader>(CoseHeader()),
                 unprotectedHeader = null,
-                payload = s2,
-                rawSignature = s2
+                payload = reversed,
+                rawSignature = reversed
             )
 
-            signed22 shouldBe signed22
-            signed22 shouldBe signed2
+            reversedSigned2 shouldBe reversedSigned2
+            reversedSigned2 shouldBe reversedSigned1
 
-            signed2.hashCode() shouldBe signed2.hashCode()
-            signed2.hashCode() shouldBe signed22.hashCode()
+            reversedSigned1.hashCode() shouldBe reversedSigned1.hashCode()
+            reversedSigned1.hashCode() shouldBe reversedSigned2.hashCode()
 
-            signed1 shouldNotBe signed2
-            signed1 shouldNotBe signed22
+            bytesSigned1 shouldNotBe reversedSigned1
+            bytesSigned1 shouldNotBe reversedSigned2
 
-            signed1.hashCode() shouldNotBe signed2.hashCode()
-            signed1.hashCode() shouldNotBe signed22.hashCode()
+            bytesSigned1.hashCode() shouldNotBe reversedSigned1.hashCode()
+            bytesSigned1.hashCode() shouldNotBe reversedSigned2.hashCode()
 
-            signed2 shouldNotBe signed1
-            signed2 shouldNotBe signed11
+            reversedSigned1 shouldNotBe bytesSigned1
+            reversedSigned1 shouldNotBe bytesSigned2
 
-            signed2.hashCode() shouldNotBe signed1.hashCode()
-            signed2.hashCode() shouldNotBe signed11.hashCode()
+            reversedSigned1.hashCode() shouldNotBe bytesSigned1.hashCode()
+            reversedSigned1.hashCode() shouldNotBe bytesSigned2.hashCode()
         }
 
     }

--- a/indispensable-cosef/src/commonTest/kotlin/at/asitplus/signum/indispensable/cosef/CoseEqualsTest.kt
+++ b/indispensable-cosef/src/commonTest/kotlin/at/asitplus/signum/indispensable/cosef/CoseEqualsTest.kt
@@ -18,14 +18,14 @@ class CoseEqualsTest : FreeSpec({
                 content = Arb.byte()
             )
         ) { s1 ->
-            val signed1 = CoseSigned(
-                protectedHeader = ByteStringWrapper<CoseHeader>(CoseHeader()),
+            val signed1 = CoseSigned<ByteArray>(
+                protectedHeader = ByteStringWrapper(CoseHeader()),
                 unprotectedHeader = null,
                 payload = s1,
                 rawSignature = s1
             )
-            val signed11 = CoseSigned(
-                protectedHeader = ByteStringWrapper<CoseHeader>(CoseHeader()),
+            val signed11 = CoseSigned<ByteArray>(
+                protectedHeader = ByteStringWrapper(CoseHeader()),
                 unprotectedHeader = null,
                 payload = s1,
                 rawSignature = s1
@@ -37,14 +37,14 @@ class CoseEqualsTest : FreeSpec({
             signed1.hashCode() shouldBe signed11.hashCode()
 
             val s2 = s1.reversedArray().let { it + it + 1 + 3 + 5 }
-            val signed2 = CoseSigned(
-                protectedHeader = ByteStringWrapper<CoseHeader>(CoseHeader()),
+            val signed2 = CoseSigned<ByteArray>(
+                protectedHeader = ByteStringWrapper(CoseHeader()),
                 unprotectedHeader = null,
                 payload = s2,
                 rawSignature = s2
             )
-            val signed22 = CoseSigned(
-                protectedHeader = ByteStringWrapper<CoseHeader>(CoseHeader()),
+            val signed22 = CoseSigned<ByteArray>(
+                protectedHeader = ByteStringWrapper(CoseHeader()),
                 unprotectedHeader = null,
                 payload = s2,
                 rawSignature = s2

--- a/indispensable-cosef/src/commonTest/kotlin/at/asitplus/signum/indispensable/cosef/CoseEqualsTest.kt
+++ b/indispensable-cosef/src/commonTest/kotlin/at/asitplus/signum/indispensable/cosef/CoseEqualsTest.kt
@@ -1,5 +1,7 @@
 package at.asitplus.signum.indispensable.cosef
 
+import at.asitplus.signum.indispensable.CryptoSignature
+import at.asitplus.signum.indispensable.cosef.io.Base16Strict
 import at.asitplus.signum.indispensable.cosef.io.ByteStringWrapper
 import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
@@ -9,20 +11,20 @@ import io.kotest.property.arbitrary.byte
 import io.kotest.property.arbitrary.byteArray
 import io.kotest.property.arbitrary.int
 import io.kotest.property.checkAll
+import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
+import kotlinx.serialization.Serializable
 
 class CoseEqualsTest : FreeSpec({
-    "Test Equals" - {
-        checkAll(
-            Arb.byteArray(length = Arb.int(0, 10), content = Arb.byte())
-        ) { bytes ->
+    "equals with byte array" {
+        checkAll(Arb.byteArray(length = Arb.int(0, 10), content = Arb.byte())) { bytes ->
             val bytesSigned1 = CoseSigned<ByteArray>(
-                protectedHeader = ByteStringWrapper<CoseHeader>(CoseHeader()),
+                protectedHeader = ByteStringWrapper(CoseHeader()),
                 unprotectedHeader = null,
                 payload = bytes,
                 rawSignature = bytes
             )
             val bytesSigned2 = CoseSigned<ByteArray>(
-                protectedHeader = ByteStringWrapper<CoseHeader>(CoseHeader()),
+                protectedHeader = ByteStringWrapper(CoseHeader()),
                 unprotectedHeader = null,
                 payload = bytes,
                 rawSignature = bytes
@@ -35,13 +37,13 @@ class CoseEqualsTest : FreeSpec({
 
             val reversed = bytes.reversedArray().let { it + it + 1 + 3 + 5 }
             val reversedSigned1 = CoseSigned<ByteArray>(
-                protectedHeader = ByteStringWrapper<CoseHeader>(CoseHeader()),
+                protectedHeader = ByteStringWrapper(CoseHeader()),
                 unprotectedHeader = null,
                 payload = reversed,
                 rawSignature = reversed
             )
             val reversedSigned2 = CoseSigned<ByteArray>(
-                protectedHeader = ByteStringWrapper<CoseHeader>(CoseHeader()),
+                protectedHeader = ByteStringWrapper(CoseHeader()),
                 unprotectedHeader = null,
                 payload = reversed,
                 rawSignature = reversed
@@ -65,6 +67,64 @@ class CoseEqualsTest : FreeSpec({
             reversedSigned1.hashCode() shouldNotBe bytesSigned1.hashCode()
             reversedSigned1.hashCode() shouldNotBe bytesSigned2.hashCode()
         }
+    }
+
+    "equals with data class" {
+        checkAll(Arb.byteArray(length = Arb.int(0, 10), content = Arb.byte())) { bytes ->
+            val payload = DataClass(content = bytes.encodeToString(Base16Strict))
+            val bytesSigned1 = CoseSigned.fromObject<DataClass>(
+                protectedHeader = CoseHeader(),
+                unprotectedHeader = null,
+                payload = payload,
+                signature = CryptoSignature.RSAorHMAC(bytes)
+            )
+            val bytesSigned2 = CoseSigned.fromObject<DataClass>(
+                protectedHeader = CoseHeader(),
+                unprotectedHeader = null,
+                payload = payload,
+                signature = CryptoSignature.RSAorHMAC(bytes)
+            )
+
+            bytesSigned1 shouldBe bytesSigned1
+            bytesSigned2 shouldBe bytesSigned1
+            bytesSigned1.hashCode() shouldBe bytesSigned1.hashCode()
+            bytesSigned1.hashCode() shouldBe bytesSigned2.hashCode()
+
+            val reversed = DataClass(content = bytes.reversedArray().let { it + it + 1 + 3 + 5 }.encodeToString(Base16Strict))
+            val reversedSigned1 = CoseSigned.fromObject<DataClass>(
+                protectedHeader = CoseHeader(),
+                unprotectedHeader = null,
+                payload = reversed,
+                signature = CryptoSignature.RSAorHMAC(bytes)
+            )
+            val reversedSigned2 = CoseSigned.fromObject<DataClass>(
+                protectedHeader = CoseHeader(),
+                unprotectedHeader = null,
+                payload = reversed,
+                signature = CryptoSignature.RSAorHMAC(bytes)
+            ).also { println(it.serialize().encodeToString(Base16Strict))}
+
+            reversedSigned2 shouldBe reversedSigned2
+            reversedSigned2 shouldBe reversedSigned1
+
+            reversedSigned1.hashCode() shouldBe reversedSigned1.hashCode()
+            reversedSigned1.hashCode() shouldBe reversedSigned2.hashCode()
+
+            bytesSigned1 shouldNotBe reversedSigned1
+            bytesSigned1 shouldNotBe reversedSigned2
+
+            bytesSigned1.hashCode() shouldNotBe reversedSigned1.hashCode()
+            bytesSigned1.hashCode() shouldNotBe reversedSigned2.hashCode()
+
+            reversedSigned1 shouldNotBe bytesSigned1
+            reversedSigned1 shouldNotBe bytesSigned2
+
+            reversedSigned1.hashCode() shouldNotBe bytesSigned1.hashCode()
+            reversedSigned1.hashCode() shouldNotBe bytesSigned2.hashCode()
+        }
 
     }
 })
+
+@Serializable
+data class DataClass(val content: String)

--- a/indispensable-cosef/src/commonTest/kotlin/at/asitplus/signum/indispensable/cosef/CoseSerializationTest.kt
+++ b/indispensable-cosef/src/commonTest/kotlin/at/asitplus/signum/indispensable/cosef/CoseSerializationTest.kt
@@ -18,7 +18,7 @@ class CoseSerializationTest : FreeSpec({
 
 
     "Serialization is correct" {
-        val cose = CoseSigned(
+        val cose = CoseSigned<ByteArray>(
             protectedHeader = ByteStringWrapper(CoseHeader(algorithm = CoseAlgorithm.ES256)),
             unprotectedHeader = CoseHeader(),
             payload = "This is the content.".encodeToByteArray(),

--- a/indispensable-cosef/src/commonTest/kotlin/at/asitplus/signum/indispensable/cosef/CoseSerializationTest.kt
+++ b/indispensable-cosef/src/commonTest/kotlin/at/asitplus/signum/indispensable/cosef/CoseSerializationTest.kt
@@ -51,9 +51,6 @@ class CoseSerializationTest : FreeSpec({
     "Serialize header" {
         val header = CoseHeader(algorithm = CoseAlgorithm.ES256, kid = "11".encodeToByteArray())
 
-        header.serialize().encodeToString(Base16Strict).uppercase()
-            .also { println(it) }
-
         val deserialized = CoseHeader.deserialize(header.serialize()).getOrThrow().shouldNotBeNull()
 
         deserialized.algorithm shouldBe header.algorithm
@@ -67,11 +64,9 @@ class CoseSerializationTest : FreeSpec({
         )
 
         val serialized = header.serialize().encodeToString(Base16Strict).uppercase()
-            .also { println(it) }
         serialized shouldContain "COSE_Key".encodeToByteArray().encodeToString(Base16Strict)
 
         val deserialized = CoseHeader.deserialize(header.serialize()).getOrThrow().shouldNotBeNull()
-
         deserialized.algorithm shouldBe header.algorithm
         deserialized.kid shouldBe header.kid
     }
@@ -81,52 +76,48 @@ class CoseSerializationTest : FreeSpec({
                 "742e58408eb33e4ca31d1c465ab05aac34cc6b23d58fef5c083106c4d25a" +
                 "91aef0b0117e2af9a291aa32e14ab834dc56ed2a223444547e01f11d3b09" +
                 "16e5a4c345cacb36"
-        val cose = CoseSigned.deserialize(input.uppercase().decodeToByteArray(Base16Strict))
-            .also { println(it) }
 
-        cose.shouldNotBeNull()
+        val cose = CoseSigned.deserialize(input.uppercase().decodeToByteArray(Base16Strict)).getOrThrow()
+
+        cose.payload shouldBe "This is the content.".encodeToByteArray()
     }
 
     "CoseSignatureInput is correct for ByteArray" {
         val payload = Random.nextBytes(32)
         val header = CoseHeader(algorithm = CoseAlgorithm.ES256)
-        val inputObject = CoseSignatureInput(
+        val inputManual = CoseSignatureInput(
             contextString = "Signature1",
             protectedHeader = ByteStringWrapper(header),
             externalAad = byteArrayOf(),
             payload = payload
         ).serialize().encodeToString(Base16())
-            .also { println(it) }
 
-        val inputMethod = CoseSigned.prepareCoseSignatureInput(
+        val inputLibrary = CoseSigned.prepareCoseSignatureInput(
             protectedHeader = header,
             payload = payload,
-            externalAad = byteArrayOf(),
         ).encodeToString(Base16())
 
-        inputObject.shouldContain("Signature1".encodeToByteArray().encodeToString(Base16()))
-        inputMethod shouldBe inputObject
+        inputManual.shouldContain("Signature1".encodeToByteArray().encodeToString(Base16()))
+        inputLibrary shouldBe inputManual
     }
 
     "CoseSignatureInput is correct for custom types" {
         val payload = DataClass(Random.nextBytes(32).encodeToString(Base16Strict))
         val header = CoseHeader(algorithm = CoseAlgorithm.ES256)
-        val inputObject = CoseSignatureInput(
+        val inputManual = CoseSignatureInput(
             contextString = "Signature1",
             protectedHeader = ByteStringWrapper(header),
             externalAad = byteArrayOf(),
             payload = coseCompliantSerializer.encodeToByteArray(ByteStringWrapper(payload)),
         ).serialize().encodeToString(Base16())
-            .also { println(it) }
 
-        val inputMethod = CoseSigned.prepareCoseSignatureInput(
+        val inputLibrary = CoseSigned.prepareCoseSignatureInput(
             protectedHeader = header,
             payload = payload,
-            externalAad = byteArrayOf(),
         ).encodeToString(Base16())
 
-        inputObject.shouldContain("Signature1".encodeToByteArray().encodeToString(Base16()))
-        inputMethod shouldBe inputObject
+        inputManual.shouldContain("Signature1".encodeToByteArray().encodeToString(Base16()))
+        inputLibrary shouldBe inputManual
     }
 
 

--- a/indispensable-cosef/src/commonTest/kotlin/at/asitplus/signum/indispensable/cosef/CoseSerializationTest.kt
+++ b/indispensable-cosef/src/commonTest/kotlin/at/asitplus/signum/indispensable/cosef/CoseSerializationTest.kt
@@ -1,6 +1,7 @@
 package at.asitplus.signum.indispensable.cosef
 
 import at.asitplus.signum.indispensable.CryptoSignature
+import at.asitplus.signum.indispensable.cosef.io.Base16Strict
 import at.asitplus.signum.indispensable.cosef.io.ByteStringWrapper
 
 import io.kotest.core.spec.style.FreeSpec
@@ -11,8 +12,6 @@ import io.matthewnelson.encoding.base16.Base16
 import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArray
 import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
 import kotlin.random.Random
-
-val Base16Strict = Base16(strict = true)
 
 class CoseSerializationTest : FreeSpec({
 
@@ -71,15 +70,23 @@ class CoseSerializationTest : FreeSpec({
 
 
     "CoseSignatureInput is correct" {
-        val signatureInput = CoseSignatureInput(
+        val payload = Random.nextBytes(32)
+        val inputObject = CoseSignatureInput(
             contextString = "Signature1",
             protectedHeader = ByteStringWrapper(CoseHeader(algorithm = CoseAlgorithm.ES256)),
             externalAad = byteArrayOf(),
-            payload = Random.nextBytes(32)
+            payload = payload
         ).serialize().encodeToString(Base16())
             .also { println(it) }
 
-        signatureInput.shouldContain("Signature1".encodeToByteArray().encodeToString(Base16()))
+        val inputMethod = CoseSigned.prepareCoseSignatureInput(
+            protectedHeader = CoseHeader(algorithm = CoseAlgorithm.ES256),
+            payload = payload,
+            externalAad = byteArrayOf(),
+        ).encodeToString(Base16())
+
+        inputObject.shouldContain("Signature1".encodeToByteArray().encodeToString(Base16()))
+        inputMethod shouldBe inputObject
     }
 
 

--- a/indispensable-cosef/src/commonTest/kotlin/at/asitplus/signum/indispensable/cosef/CoseSerializationTest.kt
+++ b/indispensable-cosef/src/commonTest/kotlin/at/asitplus/signum/indispensable/cosef/CoseSerializationTest.kt
@@ -19,7 +19,7 @@ class CoseSerializationTest : FreeSpec({
 
     "Serialization is correct" {
         val cose = CoseSigned<ByteArray>(
-            protectedHeader = ByteStringWrapper(CoseHeader(algorithm = CoseAlgorithm.ES256)),
+            protectedHeader = CoseHeader(algorithm = CoseAlgorithm.ES256),
             unprotectedHeader = CoseHeader(),
             payload = "This is the content.".encodeToByteArray(),
             signature = CryptoSignature.RSAorHMAC("bar".encodeToByteArray()) //RSAorHMAC because EC expects tuple


### PR DESCRIPTION
Adds a type parameter to `CoseSigned`. While not as thorough as for `JwsSigned`, it's still worth it to provide some form of guidance to clients as which payload to expect.

See also https://github.com/a-sit-plus/vck/pull/165