### PR TITLE
Small Identifier refactoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,23 @@
 
 ## 3.0
 
-### 3.10.0 NEXT (Supreme 0.5.0 NEXT) Breaking Changes Ahead!
+### 3.10.0 (Supreme 0.5.0) More ~~cowbell~~ targets!
+A new artefact, minor breaking changes and a lot more targets ahead!
 
-The public API remains almost unchanged, except for some methods migrating from a ByteIterator to kotlinx-io Source,
-some newly added kotlinx-io helpers and OID changes. The internals have changed substantially, however.
-Be sure to match Signum versions if multiple libraries pull it in as transitive dependency.
-Better safe than sorry!
+The public API remains _almost_ unchanged. Breaking API changes are:
+
+* Some parsing methods migrating from a `ByteIterator` to kotlinx-io `Source`
+* Moving `ensureSize` from package `asn1` to `misc`
+* Change CSR to take an actual `CryptoSignature` instead of a ByteArray
+* Remove Legacy iOS Attestation
+* Add type parameter to `JwsSigned` for its payload
+* Add type parameter to `JweDecrypted` for its payload
+* `JwsSigned.prepareSignatureInput` now returns a raw ByteArray
+
+The internals have changed substantially, however, and some fixes lead to behavioural changes.
+Therefore, be sure to match Signum versions if multiple libraries pull it in as transitive dependency.
+Better safe than sorry!  
+The full list of changes is:
 
 * Discrete ASN.1 module `indispensable-asn1` supporting the following platforms:
     * JVM
@@ -39,7 +50,7 @@ Better safe than sorry!
 * Introduce shorthand to create certificate from TbsCertificate
 * Remove requirement from CSR to have certificate extensions
 * Fix CoseSigned equals
-* Base OIDs on BigInteger instead of UInt
+* Base OIDs on unsigned varint instead of UInt
 * Directly support UUID-based OID creation
 * Implement hash-to-curve and hash-to-scalar as per RFC9380
 * Rename `decodeFromDerHexString` to `parseFromDerHexString`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,13 @@ A new artefact, minor breaking changes and a lot more targets ahead!
 The public API remains _almost_ unchanged. Breaking API changes are:
 
 * Some parsing methods migrating from a `ByteIterator` to kotlinx-io `Source`
-* Moving `ensureSize` from package `asn1` to `misc`
+* Move `ensureSize` from package `asn1` to `misc`
 * Change CSR to take an actual `CryptoSignature` instead of a ByteArray
 * Remove Legacy iOS Attestation
 * Add type parameter to `JwsSigned` for its payload
 * Add type parameter to `JweDecrypted` for its payload
 * `JwsSigned.prepareSignatureInput` now returns a raw ByteArray
+* Move `BitSet` from `io` to `asn1` package
 
 The internals have changed substantially, however, and some fixes lead to behavioural changes.
 Therefore, be sure to match Signum versions if multiple libraries pull it in as transitive dependency.
@@ -55,6 +56,7 @@ The full list of changes is:
 * Implement hash-to-curve and hash-to-scalar as per RFC9380
 * Rename `decodeFromDerHexString` to `parseFromDerHexString`
 * Move `ensureSize` from package `asn1` to `misc`
+* Move `BitSet` from `io` to `asn1` package
 * Use kotlinx-io as primary source for parsing
     * Base number encoding/decoding on kotlinx-io
         * Remove parsing from iterator

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,8 +2,8 @@ kotlin.code.style=official
 kotlin.js.compiler=ir
 org.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8
 
-artifactVersion=3.10.0-SNAPSHOT
-supremeVersion=0.5.0-SNAPSHOT
+artifactVersion=3.10.0
+supremeVersion=0.5.0
 
 # This is not a well-defined property, the ASP convention plugin respects it, though
 jdk.version=17

--- a/indispensable-cosef/src/commonMain/kotlin/at/asitplus/signum/indispensable/cosef/CoseKey.kt
+++ b/indispensable-cosef/src/commonMain/kotlin/at/asitplus/signum/indispensable/cosef/CoseKey.kt
@@ -8,8 +8,6 @@ import at.asitplus.signum.indispensable.SignatureAlgorithm
 import at.asitplus.signum.indispensable.SpecializedCryptoPublicKey
 import at.asitplus.signum.indispensable.asn1.encoding.toTwosComplementByteArray
 import at.asitplus.signum.indispensable.cosef.CoseKey.Companion.deserialize
-import at.asitplus.signum.indispensable.cosef.CoseKeySerializer.CompressedCompoundCoseKeySerialContainer
-import at.asitplus.signum.indispensable.cosef.CoseKeySerializer.UncompressedCompoundCoseKeySerialContainer
 import at.asitplus.signum.indispensable.cosef.io.Base16Strict
 import at.asitplus.signum.indispensable.cosef.io.coseCompliantSerializer
 import at.asitplus.signum.indispensable.io.Base64UrlStrict
@@ -190,7 +188,7 @@ fun CryptoPublicKey.toCoseKey(algorithm: CoseAlgorithm? = null, keyId: ByteArray
                         e = e.toTwosComplementByteArray()
                     ),
                     type = CoseKeyType.RSA,
-                    keyId = didEncoded.encodeToByteArray(),
+                    keyId = keyId,
                     algorithm = algorithm
                 )
             }


### PR DESCRIPTION
Is based on current state of `signum` in `vck`, and because of that the Changelog is not right.