### PR TITLE
Release 3.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## 3.0
 
-### 3.12.0
-* Fix COSE signature verification:
+### 3.12.0 (Supreme 0.6.2)
+* Fix COSE signature verification (This is breaking change in `indispensable-cosef`):
     * Introduce class `CoseSignedBytes` which holds the bytes as transmitted on the wire
     * Add property `wireFormat` to `CoseSigned` to hold those bytes
     * Create new `CoseSigned` objects by calling `CoseSigned.create()` instead of using a constructor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 3.0
 
 ### 3.12.0 (Supreme 0.6.2)
-* Fix COSE signature verification (This is breaking change in `indispensable-cosef`):
+* Fix COSE signature verification (this is breaking change in `indispensable-cosef`):
     * Introduce class `CoseSignedBytes` which holds the bytes as transmitted on the wire
     * Add property `wireFormat` to `CoseSigned` to hold those bytes
     * Create new `CoseSigned` objects by calling `CoseSigned.create()` instead of using a constructor

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,8 +2,8 @@ kotlin.code.style=official
 kotlin.js.compiler=ir
 org.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8
 
-artifactVersion=3.12.0-SNAPSHOT
-supremeVersion=0.6.2-SNAPSHOT
+artifactVersion=3.12.0
+supremeVersion=0.6.2
 
 # This is not a well-defined property, the ASP convention plugin respects it, though
 jdk.version=17


### PR DESCRIPTION
* Fix COSE signature verification (This is breaking change in `indispensable-cosef`):
    * Introduce class `CoseSignedBytes` which holds the bytes as transmitted on the wire
    * Add property `wireFormat` to `CoseSigned` to hold those bytes
    * Create new `CoseSigned` objects by calling `CoseSigned.create()` instead of using a constructor
    * Prepare COSE signature input by calling `CoseSigned.prepare()`
    * In `CoseSigned`, member `protectedHeader` is now a `CoseHeader`, not a `ByteStringWrapper<CoseHeader>`
    * In `CoseSigned`, member `rawSignature` (`ByteArray`) is now `signature` (`CryptoSignature.RawByteEncodable`)

Targeting develop for linear history; will then be rebased into main