### PR TITLE
replace catching with catchingUnwrapped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 3.0
 
 ### NEXT
+* performance optimization: Instantiate fewer KmmResults
 
 
 ### 3.12.1 (Supreme 0.6.3)

--- a/indispensable-asn1/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/Asn1Elements.kt
+++ b/indispensable-asn1/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/Asn1Elements.kt
@@ -3,6 +3,7 @@
 package at.asitplus.signum.indispensable.asn1
 
 import at.asitplus.catching
+import at.asitplus.catchingUnwrapped
 import at.asitplus.signum.indispensable.asn1.Asn1Element.Tag.Template.Companion.withClass
 import at.asitplus.signum.indispensable.asn1.encoding.*
 import kotlinx.io.Buffer
@@ -489,7 +490,7 @@ sealed class Asn1Structure(
     /**
      * Exception-free version of [nextChild]
      */
-    fun nextChildOrNull() = catching { nextChild() }.getOrNull()
+    fun nextChildOrNull() = catchingUnwrapped { nextChild() }.getOrNull()
 
     /**
      * Returns `true` if more children can be retrieved by [nextChild]. `false` otherwise
@@ -586,12 +587,12 @@ internal constructor(tag: ULong, children: List<Asn1Element>) :
     /**
      * Exception-free version of [verifyTag]
      */
-    fun verifyTagOrNull(tagNumber: ULong) = catching { verifyTag(tagNumber) }.getOrNull()
+    fun verifyTagOrNull(tagNumber: ULong) = catchingUnwrapped { verifyTag(tagNumber) }.getOrNull()
 
     /**
      * Exception-free version of [verifyTag]
      */
-    fun verifyTagOrNull(explicitTag: Tag) = catching { verifyTag(explicitTag) }.getOrNull()
+    fun verifyTagOrNull(explicitTag: Tag) = catchingUnwrapped { verifyTag(explicitTag) }.getOrNull()
 
     override fun prettyPrintHeader(indent: Int) = (" " * indent) + "Tagged" + super.prettyPrintHeader(indent)
 }

--- a/indispensable-asn1/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/Asn1Encodable.kt
+++ b/indispensable-asn1/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/Asn1Encodable.kt
@@ -4,6 +4,7 @@ package at.asitplus.signum.indispensable.asn1
 
 import at.asitplus.KmmResult
 import at.asitplus.catching
+import at.asitplus.catchingUnwrapped
 import at.asitplus.signum.indispensable.asn1.Asn1Element.Tag
 import at.asitplus.signum.indispensable.asn1.encoding.parse
 
@@ -22,7 +23,7 @@ interface Asn1Encodable<A : Asn1Element> {
     /**
      * Exception-free version of [encodeToTlv]
      */
-    fun encodeToTlvOrNull() = catching { encodeToTlv() }.getOrNull()
+    fun encodeToTlvOrNull() = catchingUnwrapped { encodeToTlv() }.getOrNull()
 
     /**
      * Safe version of [encodeToTlv], wrapping the result into a [KmmResult]
@@ -38,7 +39,7 @@ interface Asn1Encodable<A : Asn1Element> {
     /**
      * Exception-free version of [encodeToDer]
      */
-    fun encodeToDerOrNull() = catching { encodeToDer() }.getOrNull()
+    fun encodeToDerOrNull() = catchingUnwrapped { encodeToDer() }.getOrNull()
 
     /**
      * Safe version of [encodeToDer], wrapping the result into a [KmmResult]
@@ -106,7 +107,7 @@ interface Asn1Decodable<A : Asn1Element, T : Asn1Encodable<A>> {
      * Exception-free version of [decodeFromTlv]
      */
     fun decodeFromTlvOrNull(src: A, assertTag: Asn1Element.Tag? = null) =
-        catching { decodeFromTlv(src, assertTag) }.getOrNull()
+        catchingUnwrapped { decodeFromTlv(src, assertTag) }.getOrNull()
 
     /**
      * Safe version of [decodeFromTlv], wrapping the result into a [KmmResult]
@@ -126,11 +127,11 @@ interface Asn1Decodable<A : Asn1Element, T : Asn1Encodable<A>> {
      * Exception-free version of [decodeFromDer]
      */
     fun decodeFromDerOrNull(src: ByteArray, assertTag: Asn1Element.Tag? = null) =
-        catching { decodeFromDer(src, assertTag) }.getOrNull()
+        catchingUnwrapped { decodeFromDer(src, assertTag) }.getOrNull()
 
     /**
      * Safe version of [decodeFromDer], wrapping the result into a [KmmResult]
      */
     fun decodeFromDerSafe(src: ByteArray, assertTag: Asn1Element.Tag? = null) =
-        catching { decodeFromDer(src, assertTag) }
+        catchingUnwrapped { decodeFromDer(src, assertTag) }
 }

--- a/indispensable-asn1/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/BitSet.kt
+++ b/indispensable-asn1/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/BitSet.kt
@@ -1,6 +1,7 @@
 package at.asitplus.signum.indispensable.asn1
 
 import at.asitplus.catching
+import at.asitplus.catchingUnwrapped
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.descriptors.PrimitiveKind
@@ -244,7 +245,7 @@ class BitSet private constructor(private val buffer: MutableList<Byte>) : Iterab
         /**
          * Exception-free version of [fromBitString]
          */
-        fun fromBitStringOrNull(bitString: String) = catching { fromBitString(bitString) }.getOrNull()
+        fun fromBitStringOrNull(bitString: String) = catchingUnwrapped { fromBitString(bitString) }.getOrNull()
     }
 }
 

--- a/indispensable-asn1/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/encoding/Asn1Decoding.kt
+++ b/indispensable-asn1/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/encoding/Asn1Decoding.kt
@@ -1,6 +1,7 @@
 package at.asitplus.signum.indispensable.asn1.encoding
 
 import at.asitplus.catching
+import at.asitplus.catchingUnwrapped
 import at.asitplus.signum.indispensable.asn1.*
 import at.asitplus.signum.indispensable.asn1.BERTags.BMP_STRING
 import at.asitplus.signum.indispensable.asn1.BERTags.IA5_STRING
@@ -176,7 +177,7 @@ fun Asn1Primitive.decodeToBoolean(assertTag: Asn1Element.Tag = Asn1Element.Tag.B
 
 /** Exception-free version of [decodeToBoolean] */
 fun Asn1Primitive.decodeToBooleanOrNull(assertTag: Asn1Element.Tag = Asn1Element.Tag.BOOL) =
-    catching { decodeToBoolean(assertTag) }.getOrNull()
+    catchingUnwrapped { decodeToBoolean(assertTag) }.getOrNull()
 
 /**
  * decodes this [Asn1Primitive]'s content into an [Int]. [assertTag] defaults to [Asn1Element.Tag.INT], but can be
@@ -189,7 +190,7 @@ fun Asn1Primitive.decodeToInt(assertTag: Asn1Element.Tag = Asn1Element.Tag.INT) 
 
 /** Exception-free version of [decodeToInt] */
 fun Asn1Primitive.decodeToIntOrNull(assertTag: Asn1Element.Tag = Asn1Element.Tag.INT) =
-    catching { decodeToInt(assertTag) }.getOrNull()
+    catchingUnwrapped { decodeToInt(assertTag) }.getOrNull()
 
 /**
  * decodes this [Asn1Primitive]'s content into a [Long]. [assertTag] defaults to [Asn1Element.Tag.INT], but can be
@@ -202,7 +203,7 @@ fun Asn1Primitive.decodeToLong(assertTag: Asn1Element.Tag = Asn1Element.Tag.INT)
 
 /** Exception-free version of [decodeToLong] */
 inline fun Asn1Primitive.decodeToLongOrNull(assertTag: Asn1Element.Tag = Asn1Element.Tag.INT) =
-    catching { decodeToLong(assertTag) }.getOrNull()
+    catchingUnwrapped { decodeToLong(assertTag) }.getOrNull()
 
 /**
  * decodes this [Asn1Primitive]'s content into an [UInt]√. [assertTag] defaults to [Asn1Element.Tag.INT], but can be
@@ -215,7 +216,7 @@ fun Asn1Primitive.decodeToUInt(assertTag: Asn1Element.Tag = Asn1Element.Tag.INT)
 
 /** Exception-free version of [decodeToUInt] */
 inline fun Asn1Primitive.decodeToUIntOrNull(assertTag: Asn1Element.Tag = Asn1Element.Tag.INT) =
-    catching { decodeToUInt(assertTag) }.getOrNull()
+    catchingUnwrapped { decodeToUInt(assertTag) }.getOrNull()
 
 /**
  * decodes this [Asn1Primitive]'s content into an [ULong]. [assertTag] defaults to [Asn1Element.Tag.INT], but can be
@@ -228,7 +229,7 @@ fun Asn1Primitive.decodeToULong(assertTag: Asn1Element.Tag = Asn1Element.Tag.INT
 
 /** Exception-free version of [decodeToULong] */
 inline fun Asn1Primitive.decodeToULongOrNull(assertTag: Asn1Element.Tag = Asn1Element.Tag.INT) =
-    catching { decodeToULong(assertTag) }.getOrNull()
+    catchingUnwrapped { decodeToULong(assertTag) }.getOrNull()
 
 /** Decode the [Asn1Primitive] as a [Asn1Integer]
  * @throws [Asn1Exception] on invalid input */
@@ -238,7 +239,7 @@ fun Asn1Primitive.decodeToAsn1Integer(assertTag: Asn1Element.Tag = Asn1Element.T
 
 /** Exception-free version of [decodeToAsn1Integer] */
 inline fun Asn1Primitive.decodeToAsn1IntegerOrNull(assertTag: Asn1Element.Tag = Asn1Element.Tag.INT) =
-    catching { decodeToAsn1Integer() }.getOrNull()
+    catchingUnwrapped { decodeToAsn1Integer() }.getOrNull()
 
 /**
  * Decodes a [Asn1Integer] from [bytes] assuming the same encoding as the [Asn1Primitive.content] property of an [Asn1Primitive] containing an ASN.1 INTEGER
@@ -274,7 +275,7 @@ fun Asn1Primitive.asAsn1String(): Asn1String = runRethrowing {
 fun Asn1Primitive.decodeToString() = runRethrowing { asAsn1String().value }
 
 /** Exception-free version of [decodeToString] */
-fun Asn1Primitive.decodeToStringOrNull() = catching { decodeToString() }.getOrNull()
+fun Asn1Primitive.decodeToStringOrNull() = catchingUnwrapped { decodeToString() }.getOrNull()
 
 /**
  * decodes this [Asn1Primitive]'s content into an [Instant] if it is encoded as UTC TIME or GENERALIZED TIME
@@ -300,7 +301,7 @@ fun Asn1Primitive.decodeToInstant() =
 /**
  * Exception-free version of [decodeToInstant]
  */
-fun Asn1Primitive.decodeToInstantOrNull() = catching { decodeToInstant() }.getOrNull()
+fun Asn1Primitive.decodeToInstantOrNull() = catchingUnwrapped { decodeToInstant() }.getOrNull()
 
 /**
  * Transforms this [Asn1Primitive]' into an [Asn1BitString], assuming it was encoded as BIT STRING
@@ -320,7 +321,7 @@ fun Asn1Primitive.readNull() = decode(Asn1Element.Tag.NULL) {}
 /**
  * Name seems odd, but this is just an exception-free version of [readNull]
  */
-fun Asn1Primitive.readNullOrNull() = catching { readNull() }.getOrNull()
+fun Asn1Primitive.readNullOrNull() = catchingUnwrapped { readNull() }.getOrNull()
 
 /**
  * Generic decoding function. Verifies that this [Asn1Primitive]'s tag matches [assertTag]
@@ -348,7 +349,7 @@ inline fun <reified T> Asn1Primitive.decode(assertTag: Asn1Element.Tag, transfor
  * Exception-free version of [decode]
  */
 inline fun <reified T> Asn1Primitive.decodeOrNull(tag: ULong, transform: (content: ByteArray) -> T) =
-    catching { decode(tag, transform) }.getOrNull()
+    catchingUnwrapped { decode(tag, transform) }.getOrNull()
 
 /**
  * Decodes an [Instant] from [bytes] assuming the same encoding as the [Asn1Primitive.content] property of an [Asn1Primitive] containing an ASN.1 UTC TIME

--- a/indispensable-asn1/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/encoding/Asn1Encoding.kt
+++ b/indispensable-asn1/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/encoding/Asn1Encoding.kt
@@ -99,7 +99,7 @@ object Asn1 {
      * Exception-free version of [Sequence]
      */
     fun SequenceOrNull(root: Asn1TreeBuilder.() -> Unit) =
-        catching { Sequence(root) }.getOrNull()
+        catchingUnwrapped { Sequence(root) }.getOrNull()
 
 
     /**
@@ -130,13 +130,13 @@ object Asn1 {
     /**
      * Exception-free version of [Set]
      */
-    fun SetOrNull(root: Asn1TreeBuilder.() -> Unit) = catching { Set(root) }.getOrNull()
+    fun SetOrNull(root: Asn1TreeBuilder.() -> Unit) = catchingUnwrapped { Set(root) }.getOrNull()
 
 
     /**
      * Safe version of [Set], wrapping the result into a [KmmResult]
      */
-    fun SetSafe(root: Asn1TreeBuilder.() -> Unit) = catching { Set(root) }
+    fun SetSafe(root: Asn1TreeBuilder.() -> Unit) = catchingUnwrapped { Set(root) }
 
 
     /**
@@ -163,13 +163,13 @@ object Asn1 {
     /**
      * Exception-free version of [SetOf]
      */
-    fun SetOfOrNull(root: Asn1TreeBuilder.() -> Unit) = catching { SetOf(root) }.getOrNull()
+    fun SetOfOrNull(root: Asn1TreeBuilder.() -> Unit) = catchingUnwrapped { SetOf(root) }.getOrNull()
 
 
     /**
      * Safe version of [SetOf], wrapping the result into a [KmmResult]
      */
-    fun SetOfSafe(root: Asn1TreeBuilder.() -> Unit) = catching { SetOf(root) }
+    fun SetOfSafe(root: Asn1TreeBuilder.() -> Unit) = catchingUnwrapped { SetOf(root) }
 
 
     /**

--- a/indispensable-asn1/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/encoding/Asn1Encoding.kt
+++ b/indispensable-asn1/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/encoding/Asn1Encoding.kt
@@ -136,7 +136,7 @@ object Asn1 {
     /**
      * Safe version of [Set], wrapping the result into a [KmmResult]
      */
-    fun SetSafe(root: Asn1TreeBuilder.() -> Unit) = catchingUnwrapped { Set(root) }
+    fun SetSafe(root: Asn1TreeBuilder.() -> Unit) = catching { Set(root) }
 
 
     /**
@@ -169,7 +169,7 @@ object Asn1 {
     /**
      * Safe version of [SetOf], wrapping the result into a [KmmResult]
      */
-    fun SetOfSafe(root: Asn1TreeBuilder.() -> Unit) = catchingUnwrapped { SetOf(root) }
+    fun SetOfSafe(root: Asn1TreeBuilder.() -> Unit) = catching { SetOf(root) }
 
 
     /**

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/Asn1Addons.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/Asn1Addons.kt
@@ -134,7 +134,7 @@ fun Asn1Primitive.decodeToBigInteger(assertTag: Asn1Element.Tag = Asn1Element.Ta
 
 /** Exception-free version of [decodeToBigInteger] */
 inline fun Asn1Primitive.decodeToBigIntegerOrNull(assertTag: Asn1Element.Tag = Asn1Element.Tag.INT) =
-    catching { decodeToBigInteger(assertTag) }.getOrNull()
+    catchingUnwrapped { decodeToBigInteger(assertTag) }.getOrNull()
 
 /**
  * Decodes a [BigInteger] from [bytes] assuming the same encoding as the [Asn1Primitive.content] property of an [Asn1Primitive] containing an ASN.1 INTEGER

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/pki/X509Certificate.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/pki/X509Certificate.kt
@@ -1,6 +1,7 @@
 package at.asitplus.signum.indispensable.pki
 
 import at.asitplus.catching
+import at.asitplus.catchingUnwrapped
 import at.asitplus.signum.indispensable.CryptoPublicKey
 import at.asitplus.signum.indispensable.CryptoSignature
 import at.asitplus.signum.indispensable.X509SignatureAlgorithm
@@ -282,11 +283,11 @@ data class X509Certificate @Throws(IllegalArgumentException::class) constructor(
          * or by decoding from Base64, or by decoding to a String, stripping PEM headers
          * (`-----BEGIN CERTIFICATE-----`) and then decoding from Base64.
          */
-        fun decodeFromByteArray(src: ByteArray): X509Certificate? = catching {
+        fun decodeFromByteArray(src: ByteArray): X509Certificate? = catchingUnwrapped {
             X509Certificate.decodeFromTlv(Asn1Element.parse(src) as Asn1Sequence)
-        }.getOrNull() ?: catching {
+        }.getOrNull() ?: catchingUnwrapped {
             X509Certificate.decodeFromTlv(Asn1Element.parse(src.decodeToByteArray(Base64())) as Asn1Sequence)
-        }.getOrNull() ?: catching {
+        }.getOrNull() ?: catchingUnwrapped {
             X509Certificate.decodeFromTlv(Asn1Element.parse(src.decodeX5c()) as Asn1Sequence)
         }.getOrNull()
 


### PR DESCRIPTION
replace `catching` with `catchingUnwrapped` when the actual KmmResult is discarded to prevent needless instatioation of KmmResult.

See #146