### PR TITLE
Release/3.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 3.0
 
-### NEXT
+### 3.12.1 (Supreme 0.6.3)
 
 * Add COSE object creation with detached payload, i.e. setting a `null` payload in `CoseSigned`, and clients are responsible to transport the payload separately
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,8 +2,8 @@ kotlin.code.style=official
 kotlin.js.compiler=ir
 org.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8
 
-artifactVersion=3.13.0-SNAPSHOT
-supremeVersion=0.7.0-SNAPSHOT
+artifactVersion=3.12.1
+supremeVersion=0.6.3
 
 # This is not a well-defined property, the ASP convention plugin respects it, though
 jdk.version=17


### PR DESCRIPTION
* Add COSE object creation with detached payload, i.e. setting a `null` payload in `CoseSigned`, and clients are responsible to transport the payload separately