### PR TITLE
Release/3.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## 3.0
 
-### NEXT
+### 3.13.0 (Supreme 0.6.4)
 
+* Fix COSE key serialization
 * Refactor `Asn1Integer` to use `UByteArray` internally instead of a list
 * Fix ASN.1 decoding flaw for a very specific length encoding
 * Performance optimization: Instantiate fewer `KmmResults`

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,8 +2,8 @@ kotlin.code.style=official
 kotlin.js.compiler=ir
 org.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8
 
-artifactVersion=3.13.0-SNAPSHOT
-supremeVersion=0.7.0-SNAPSHOT
+artifactVersion=3.13.0
+supremeVersion=0.6.4
 
 # This is not a well-defined property, the ASP convention plugin respects it, though
 jdk.version=17


### PR DESCRIPTION
* Fix COSE key serialization
* Refactor `Asn1Integer` to use `UByteArray` internally instead of a list
* Fix ASN.1 decoding flaw for a very specific length encoding
* Performance optimization: Instantiate fewer `KmmResults`
* Move `PemEncodable`/`PemDecodable` from _indispensable_ to _indispensable-asn1_ module.
* More comprehensive PEM encoding/decoding support:
    * `CryptoPublicKey`
      * Note that PKCS1 encoding of RSA keys is not supported as it is discouraged (decoding is supported)
      * ANSI encoding and decoding is also unsupported, because decoding requires context and encoding this way is incomplete
    * `X509Certificate`
    * CSR (`Pkcs10CertificationRequest`)
* Change `CoseHeader.certificateChain` (CBOR element 33 `x5chain`) from a single byte array to a list of byte arrays, acc. to specification
* Remove `CoseHeader.coseKey`, which has been an unofficial addition from OID4VCI, but has been removed since
