### PR TITLE
release 3.15.0

### DIFF
--- a/.github/workflows/publish-dry-run.yml
+++ b/.github/workflows/publish-dry-run.yml
@@ -16,6 +16,11 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
+      - name: Set up Homebrew
+        id: set-up-homebrew
+        uses: Homebrew/actions/setup-homebrew@master
+      - name: Install deps
+        run: brew install cairo freetype libffi libjpeg libpng zlib
       - name: Publish to Maven Local
         run: ./gradlew clean publishAllPublicationsToMavenLocal
         env:
@@ -39,5 +44,8 @@ jobs:
         with:
           python-version: 3.x
       - run: pip install mkdocs-material==9.5.40
+      - run: pip install mkdocs-material[imaging]==9.5.40
       - name: Build Dokka HTML
-        run: ./gradlew mkDocsBuild
+        run: |
+          export DYLD_FALLBACK_LIBRARY_PATH=/opt/homebrew/lib
+          ./gradlew mkDocsSite

--- a/.github/workflows/publish-pages-only.yml
+++ b/.github/workflows/publish-pages-only.yml
@@ -23,8 +23,16 @@ jobs:
         with:
           python-version: 3.x
       - run: pip install mkdocs-material==9.5.40
+      - run: pip install mkdocs-material[imaging]==9.5.40
+      - name: Set up Homebrew
+        id: set-up-homebrew
+        uses: Homebrew/actions/setup-homebrew@master
+      - name: Install deps
+        run: brew install cairo freetype libffi libjpeg libpng zlib
       - name: Build Dokka HTML
-        run: ./gradlew mkDocsBuild
+        run: |
+          export DYLD_FALLBACK_LIBRARY_PATH=/opt/homebrew/lib
+          ./gradlew mkDocsSite
       - name: Setup Pages
         uses: actions/configure-pages@v3
       - name: Upload artifact

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,8 +42,16 @@ jobs:
         with:
           python-version: 3.x
       - run: pip install mkdocs-material==9.5.40
+      - run: pip install mkdocs-material[imaging]==9.5.40
+      - name: Set up Homebrew
+        id: set-up-homebrew
+        uses: Homebrew/actions/setup-homebrew@master
+      - name: Install deps
+        run: brew install cairo freetype libffi libjpeg libpng zlib
       - name: Build Dokka HTML
-        run: ./gradlew mkDocsBuild
+        run: |
+          export DYLD_FALLBACK_LIBRARY_PATH=/opt/homebrew/lib
+          ./gradlew mkDocsSite
       - name: Setup Pages
         uses: actions/configure-pages@v3
       - name: Upload artifact

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 3.0
 
-### NEXT
+### 3.15.0 (Supreme 0.7.1)
 * **Note: We are deprecating and will soon be removing the debug-only serialization for cryptographic datatypes like certificates, public keys, etc.**
     * We support robust ASN.1 encoding and mapping from/to JOSE and COSE datatypes and our ASN.1 structures support pretty printing.
     * -> There is no need for this misleading serialization support for debugging anymore

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,3 +53,9 @@ tasks.register<Exec>("mkDocsBuild") {
     workingDir("${rootDir}/docs")
     commandLine("mkdocs", "build", "--clean", "--strict")
 }
+
+tasks.register<Copy>("mkDocsSite") {
+    dependsOn("mkDocsBuild")
+    into(rootDir.resolve("docs/site/assets/images/social"))
+    from(rootDir.resolve("docs/docs/assets/images/social"))
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,8 +2,8 @@ kotlin.code.style=official
 kotlin.js.compiler=ir
 org.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8
 
-artifactVersion=3.14.1-SNAPSHOT
-supremeVersion=0.7.1-SNAPSHOT
+artifactVersion=3.15.0
+supremeVersion=0.7.1
 
 # This is not a well-defined property, the ASP convention plugin respects it, though
 jdk.version=17

--- a/indispensable/src/jvmTest/kotlin/at/asitplus/signum/indispensable/pki/X509CertParserTest.kt
+++ b/indispensable/src/jvmTest/kotlin/at/asitplus/signum/indispensable/pki/X509CertParserTest.kt
@@ -16,6 +16,7 @@ import io.matthewnelson.encoding.base16.Base16
 import io.matthewnelson.encoding.base64.Base64
 import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArray
 import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
+import kotlinx.io.UnsafeIoApi
 import kotlinx.io.readByteArray
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonArray
@@ -30,6 +31,7 @@ import kotlin.random.Random
 import kotlin.random.nextInt
 import java.security.cert.X509Certificate as JcaCertificate
 
+@OptIn(UnsafeIoApi::class)
 class X509CertParserTest : FreeSpec({
 
     "Manual" {


### PR DESCRIPTION
* **Note: We are deprecating and will soon be removing the debug-only serialization for cryptographic datatypes like certificates, public keys, etc.**
    * We support robust ASN.1 encoding and mapping from/to JOSE and COSE datatypes and our ASN.1 structures support pretty printing.
    * -> There is no need for this misleading serialization support for debugging anymore
    * `@Serializable` suggests deserialization from JSON, CBOR, etc. works, which was never universally true
    * Getting native ASN.1 serialization for kotlinx-serialization is now a no-brainer given we support every primitive required.
    * This note will be prepended to the changelog entries until the `@Serialization` annotations have been removed.
        * This will happen by Indispensable 4.0.0 / Supreme 1.0.0, if not before then.
* Introduce support for ASN.1 REAL
* Add built-in ASN.1 ENUMERATED support
* Rename `ObjectIdentifier.parse` -> `ObjectIdentifier.decodeFromAsn1ContentBytes` in accordance with other similar functions
* Update data classes for Wallet Attestation from [OpenID4VC HAIP](https://openid.net/specs/openid4vc-high-assurance-interoperability-profile-1_0.html) and [OpenID4VCI](https://openid.net/specs/openid4vc-high-assurance-interoperability-profile-1_0.html):
    * Deprecate `authenticationLevel` (`aal`) in `JsonWebToken`, removed from standards
    * Deprecate `key_type`, `user_authentication` in `ConfirmationClaim`, removed from standards
    * Deprecate types `WalletAttestationUserAuthentication`, `WalletAttestationKeyType`, removed from standards
    * Add `wallet_name`, `wallet_link`, `status` to `JsonWebToken`, used in Key Attestation JWT
    * Add `KeyAttestationJwt` from OpenID4VCI
* Add dedicated Android targets (SDK 30 / JDK 1.8) to all modules
* Fix internal deprecations
* Raise deprecation level to ERROR for deprecated functions:
    * `Asn1Element.Companion.parseAll`
    * `Asn1Element.Companion.parse`
    * `Asn1Element.Companion.decodeFromDerHexString`
    * `Asn1Element.asPrimitiveOctetString`
    * `CryptoPublicKey.fromJcaPublicKey`
    * `CryptoPublicKey.RSA.fromJcaPublicKey`
    * `CryptoPublicKey.EC.fromJcaPublicKey`
    * `CryptoSignature.invoke`
    * `CryptoPublicKey.RSA(n: ByteArray, e: ByteArray)`
    * `CryptoPublicKey.EC(curve: ECCurve, x: ByteArray, usePositiveY: Boolean)`
    * `CryptoPublicKey.EC(curve: ECCurve, x: ByteArray, y: ByteArray)`
    * `ECCurve.keyLengthBits`
    * `ECCurve.coordinateLengthBytes`
    * `ECCurve.signatureLengthBytes`