### PR TITLE
Parse EC curves as nullable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 3.0
 
+### NEXT
+
+ * Parse not-implemented EC curves as `null`, e.g. in Json Web Keys
+
 ### 3.15.1 (Supreme 0.7.2)
 
 * Fix decoding `did:key:` key identifiers containing a `#`

--- a/indispensable-josef/src/jvmTest/kotlin/at/asitplus/signum/indispensable/josef/JwkTest.kt
+++ b/indispensable-josef/src/jvmTest/kotlin/at/asitplus/signum/indispensable/josef/JwkTest.kt
@@ -12,6 +12,7 @@ import com.ionspin.kotlin.bignum.integer.BigInteger
 import com.ionspin.kotlin.bignum.integer.Sign
 import io.kotest.core.spec.style.FreeSpec
 import io.kotest.datatest.withData
+import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.property.azstring
@@ -68,6 +69,28 @@ class JwkTest : FreeSpec({
         val parsed = JsonWebKey.deserialize(serialized).getOrThrow()
 
         parsed shouldBe jwk
+    }
+
+    "Deserialize BP keys" {
+        val input = """
+            {
+              "alg": "ECDH-ES",
+              "crv": "BP-256",
+              "kid": "9d1db5b5-0a76-11f0-858d-026b3e565740",
+              "kty": "EC",
+              "use": "enc",
+              "x": "fk-0X35Cj8-8TDmfEn8grS5f2x7AzmAnkxc17i8Lae8",
+              "y": "XIj2dcra7tC9cQ6HRlM1kae5fGVQyoIj_bOFlpA4w5k"
+            }
+        """.trimIndent()
+
+        val parsed = JsonWebKey.deserialize(input).getOrThrow()
+
+        parsed.algorithm shouldBe JweAlgorithm.ECDH_ES
+        parsed.curve.shouldBeNull()
+        parsed.keyId shouldBe "9d1db5b5-0a76-11f0-858d-026b3e565740"
+        parsed.type shouldBe JwkType.EC
+        parsed.publicKeyUse shouldBe "enc"
     }
 
     "Serialize and deserialize Algos" - {

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/ECCurve.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/ECCurve.kt
@@ -212,19 +212,18 @@ enum class ECCurve(
 
 }
 
-object ECCurveSerializer : KSerializer<ECCurve> {
+object ECCurveSerializer : KSerializer<ECCurve?> {
 
     override val descriptor: SerialDescriptor =
         PrimitiveSerialDescriptor("EcCurveSerializer", PrimitiveKind.STRING)
 
-    override fun serialize(encoder: Encoder, value: ECCurve) {
-        encoder.encodeString(value.jwkName)
+    override fun serialize(encoder: Encoder, value: ECCurve?) {
+        value?.jwkName?.let { encoder.encodeString(it) } ?: encoder.encodeNull()
     }
 
-    override fun deserialize(decoder: Decoder): ECCurve {
+    override fun deserialize(decoder: Decoder): ECCurve? {
         val decoded = decoder.decodeString()
         return ECCurve.entries.firstOrNull { it.jwkName == decoded }
-            ?: throw SerializationException("Unsupported EC Curve Type $decoded")
     }
 
 }


### PR DESCRIPTION
Otherwise our Wallet can't parse this JWK:

```
{
  "alg": "ECDH-ES",
  "crv": "BP-256",
  "kid": "9d1db5b5-0a76-11f0-858d-026b3e565740",
  "kty": "EC",
  "use": "enc",
  "x": "fk-0X35Cj8-8TDmfEn8grS5f2x7AzmAnkxc17i8Lae8",
  "y": "XIj2dcra7tC9cQ6HRlM1kae5fGVQyoIj_bOFlpA4w5k"
}
```