### PR TITLE
release 3.15.2

### DIFF
--- a/.github/workflows/publish-indispensable.yml
+++ b/.github/workflows/publish-indispensable.yml
@@ -1,0 +1,65 @@
+name: Publish Indispensable
+on: workflow_dispatch
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+jobs:
+  build:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+      - name: Publish to Sonatype
+        run: ./gradlew clean internals:publishToSonatype indispensable-asn1:publishToSonatype indispensable:publishToSonatype indispensable-cosef:publishToSonatype indispensable-josef:publishToSonatype closeSonatypeStagingRepository
+        env:
+          ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.PUBLISH_SIGNING_KEYID }}
+          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.PUBLISH_SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.PUBLISH_SIGNING_PASSWORD }}
+          ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.PUBLISH_SONATYPE_USER }}
+          ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.PUBLISH_SONATYPE_PASSWORD }}
+  deploy-docs:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+      - run: pip install mkdocs-material==9.5.40
+      - run: pip install mkdocs-material[imaging]==9.5.40
+      - name: Set up Homebrew
+        id: set-up-homebrew
+        uses: Homebrew/actions/setup-homebrew@master
+      - name: Install deps
+        run: brew install cairo freetype libffi libjpeg libpng zlib
+      - name: Build Dokka HTML
+        run: |
+          export DYLD_FALLBACK_LIBRARY_PATH=/opt/homebrew/lib
+          ./gradlew mkDocsSite
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          # Upload docs folder
+          path: './docs/site'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+

--- a/.github/workflows/publish-supreme.yml
+++ b/.github/workflows/publish-supreme.yml
@@ -1,0 +1,65 @@
+name: Publish Supreme
+on: workflow_dispatch
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+jobs:
+  build:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+      - name: Publish to Sonatype
+        run: ./gradlew clean supreme:publishToSonatype closeSonatypeStagingRepository
+        env:
+          ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.PUBLISH_SIGNING_KEYID }}
+          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.PUBLISH_SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.PUBLISH_SIGNING_PASSWORD }}
+          ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.PUBLISH_SONATYPE_USER }}
+          ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.PUBLISH_SONATYPE_PASSWORD }}
+  deploy-docs:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+      - run: pip install mkdocs-material==9.5.40
+      - run: pip install mkdocs-material[imaging]==9.5.40
+      - name: Set up Homebrew
+        id: set-up-homebrew
+        uses: Homebrew/actions/setup-homebrew@master
+      - name: Install deps
+        run: brew install cairo freetype libffi libjpeg libpng zlib
+      - name: Build Dokka HTML
+        run: |
+          export DYLD_FALLBACK_LIBRARY_PATH=/opt/homebrew/lib
+          ./gradlew mkDocsSite
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          # Upload docs folder
+          path: './docs/site'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,8 +2,8 @@ kotlin.code.style=official
 kotlin.js.compiler=ir
 org.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8
 
-artifactVersion=3.16.0-SNAPSHOT
-supremeVersion=0.8.0-SNAPSHOT
+artifactVersion=3.15.2
+supremeVersion=0.7.2
 
 # This is not a well-defined property, the ASP convention plugin respects it, though
 jdk.version=17


### PR DESCRIPTION
Parse not-implemented EC curves as `null`, e.g. in Json Web Keys.

Only indispensable-* artefacts will be published, as supreme remains unaffected