### PR TITLE
remove debug-only serialization from cryptographic datatypes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 3.0
 
 ### NEXT
-* **Note: All debug-only serialization for cryptographic datatypes like certificates, public keys, etc. was removed!**
+* **Note: All debug-only kotlinx.serialization for cryptographic datatypes like certificates, public keys, etc. was removed!**
     * We support robust ASN.1 encoding and mapping from/to JOSE and COSE datatypes and our ASN.1 structures support pretty printing.
     * -> There is no need for this misleading serialization support for debugging anymore.
     * `@Serializable` suggests deserialization from JSON, CBOR, etc. works, which was never universally true.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,8 +80,6 @@
     * `ECCurve.coordinateLengthBytes`
     * `ECCurve.signatureLengthBytes`
 
-
-
 ### 3.14.0 (Supreme 0.7.0)
 
 * Certificate Improvements:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
     * `@Serializable` suggests deserialization from JSON, CBOR, etc. works, which was never universally true.
     * Getting native ASN.1 serialization for kotlinx-serialization is now a no-brainer given we support every primitive required.
     * **Serializers like `X509CertificateBase64UrlSerializer` are here to stay because those are universally useful!**
+    * `ObjectIdSerializer` was renamed to `ObjectIdentifierStringSerializer`
 * HMAC Support
     * **This finally cleans up the `RSAorHMAC` mess, which is a breaking change**
     * Introduce umbrella `DataIntegrityAlgorithms`, which is the parent of `SignatureAlgorithm` and `MessageAuthenticationCode`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,12 @@
 ## 3.0
 
 ### NEXT
-* **Note: We are deprecating and will soon be removing the debug-only serialization for cryptographic datatypes like certificates, public keys, etc.**
+* **Note: All debug-only serialization for cryptographic datatypes like certificates, public keys, etc. was removed!**
     * We support robust ASN.1 encoding and mapping from/to JOSE and COSE datatypes and our ASN.1 structures support pretty printing.
-    * -> There is no need for this misleading serialization support for debugging anymore
-    * `@Serializable` suggests deserialization from JSON, CBOR, etc. works, which was never universally true
+    * -> There is no need for this misleading serialization support for debugging anymore.
+    * `@Serializable` suggests deserialization from JSON, CBOR, etc. works, which was never universally true.
     * Getting native ASN.1 serialization for kotlinx-serialization is now a no-brainer given we support every primitive required.
-    * This note will be prepended to the changelog entries until the `@Serialization` annotations have been removed.
-        * This will happen by Indispensable 4.0.0 / Supreme 1.0.0, if not before then.
+    * **Serializers like `X509CertificateBase64UrlSerializer` are here to stay because those are universally useful!**
 * HMAC Support
     * **This finally cleans up the `RSAorHMAC` mess, which is a breaking change**
     * Introduce umbrella `DataIntegrityAlgorithms`, which is the parent of `SignatureAlgorithm` and `MessageAuthenticationCode`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ If you plan on contributing changes to this repository's contents, please
 1. Fork it
 2. Create a branch with a descriptive name (e.g. `feature/timeTravel` or `fix/gravitationalConstant`)
 3. Commit your changes to your branch
-4. Open a pull request
+4. Open a pull request against `development`
 
 We will then review the changes, provide feedback.
 Once we agree that the PR is ready, we will approve it, and your PR will be merged.

--- a/docs/docs/indispensable-asn1.md
+++ b/docs/docs/indispensable-asn1.md
@@ -139,7 +139,7 @@ An alternative exists, taking a `Tag` instead of an `Ulong`. in both cases a tag
 the content of the ASN.1 primitive. Moreover, a non-throwing `decodeOrNull` variant is present.
 In addition, the following self-describing shorthands are defined:
 
-| Function                                    | Description                                                                         |
+| Function                                    | Descrption                                                                          |
 |---------------------------------------------|-------------------------------------------------------------------------------------|
 | `Asn1Primitive.decodeToBoolean()`           | throws                                                                              |
 | `Asn1Primitive.decodeToBooleanOrNull()`     | returns `null` on error                                                             |

--- a/docs/docs/indispensable-asn1.md
+++ b/docs/docs/indispensable-asn1.md
@@ -139,7 +139,7 @@ An alternative exists, taking a `Tag` instead of an `Ulong`. in both cases a tag
 the content of the ASN.1 primitive. Moreover, a non-throwing `decodeOrNull` variant is present.
 In addition, the following self-describing shorthands are defined:
 
-| Function                                    | Descrption                                                                          |
+| Function                                    | Description                                                                         |
 |---------------------------------------------|-------------------------------------------------------------------------------------|
 | `Asn1Primitive.decodeToBoolean()`           | throws                                                                              |
 | `Asn1Primitive.decodeToBooleanOrNull()`     | returns `null` on error                                                             |

--- a/indispensable-asn1/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/Asn1Elements.kt
+++ b/indispensable-asn1/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/Asn1Elements.kt
@@ -22,7 +22,6 @@ import kotlin.native.ObjCName
 /**
  * Base ASN.1 data class. Can either be a primitive (holding a value), or a structure (holding other ASN.1 elements)
  */
-@Serializable(with = Asn1EncodableSerializer::class)
 sealed class Asn1Element(
     val tag: Tag
 ) {
@@ -254,7 +253,6 @@ sealed class Asn1Element(
     override fun hashCode(): Int = tag.hashCode()
 
 
-    @Serializable
     @ConsistentCopyVisibility
     data class Tag internal constructor(
         val tagValue: ULong,
@@ -437,18 +435,6 @@ inline fun <reified T : Asn1Element> T.assertTag(tag: Asn1Element.Tag): T {
 @Throws(Asn1TagMismatchException::class)
 inline fun <reified T : Asn1Element> T.assertTag(tagNumber: ULong): T = assertTag(tag withNumber tagNumber)
 
-object Asn1EncodableSerializer : KSerializer<Asn1Element> {
-    override val descriptor = PrimitiveSerialDescriptor("Asn1Encodable", PrimitiveKind.STRING)
-
-    override fun deserialize(decoder: Decoder): Asn1Element {
-        return Asn1Element.parse(decoder.decodeString().hexToByteArray(HexFormat.UpperCase))
-    }
-
-    override fun serialize(encoder: Encoder, value: Asn1Element) {
-        encoder.encodeString(value.derEncoded.toHexString(HexFormat.UpperCase))
-    }
-
-}
 
 /**
  * ASN.1 structure. Contains no data itself, but holds zero or more [children]
@@ -714,7 +700,6 @@ class Asn1CustomStructure private constructor(
  * @param children the elements to put into this sequence
  */
 @Suppress("SERIALIZER_TYPE_INCOMPATIBLE")
-@Serializable(with = Asn1EncodableSerializer::class)
 class Asn1EncapsulatingOctetString(children: List<Asn1Element>) :
     Asn1Structure(Tag.OCTET_STRING, children, sortChildren = false, shouldBeSorted = false),
     Asn1OctetString {

--- a/indispensable-asn1/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/Asn1Integer.kt
+++ b/indispensable-asn1/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/Asn1Integer.kt
@@ -35,7 +35,7 @@ fun Asn1Integer(number: ULong) =
  * It has a [sign] though, and supports [twosComplement] representation and converting [fromTwosComplement].
  * Hence, it directly interoperates with [Kotlin MP BigNum](https://github.com/ionspin/kotlin-multiplatform-bignum) and the JVM BigInteger.
  */
-@Serializable(with = Asn1IntegerSerializer::class)
+@Serializable(with = Asn1IntegerSerializer::class) //this here stays, as it might be useful in general
 sealed class Asn1Integer(internal val uint: VarUInt, val sign: Sign): Asn1Encodable<Asn1Primitive> {
 
     override fun encodeToTlv(): Asn1Primitive = encodeToAsn1Primitive()

--- a/indispensable-asn1/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/Asn1Real.kt
+++ b/indispensable-asn1/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/Asn1Real.kt
@@ -1,3 +1,5 @@
+@file:Suppress("SERIALIZER_TYPE_INCOMPATIBLE")
+
 package at.asitplus.signum.indispensable.asn1
 
 import at.asitplus.signum.indispensable.asn1.encoding.*
@@ -44,6 +46,7 @@ sealed interface Asn1Real : Asn1Encodable<Asn1Primitive> {
     object NegativeInfinity : Asn1Real
 
     @Serializable(with = Asn1RealSerializer::class)
+    @ConsistentCopyVisibility
     data class Finite internal constructor(val normalizedMantissa: Asn1Integer, val normalizedExponent: Long) :
         Asn1Real
 

--- a/indispensable-asn1/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/Asn1String.kt
+++ b/indispensable-asn1/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/Asn1String.kt
@@ -8,7 +8,6 @@ import kotlinx.serialization.Serializable
 /**
  * ASN.! String class used as wrapper do discriminate between different ASN.1 string types
  */
-@Serializable
 sealed class Asn1String : Asn1Encodable<Asn1Primitive> {
     abstract val tag: ULong
     abstract val value: String
@@ -16,8 +15,6 @@ sealed class Asn1String : Asn1Encodable<Asn1Primitive> {
     /**
      * UTF8 STRING (verbatim String)
      */
-    @Serializable
-    @SerialName("UTF8String")
     class UTF8(override val value: String) : Asn1String() {
         override val tag = BERTags.UTF8_STRING.toULong()
     }
@@ -25,8 +22,6 @@ sealed class Asn1String : Asn1Encodable<Asn1Primitive> {
     /**
      * UNIVERSAL STRING (unchecked)
      */
-    @Serializable
-    @SerialName("UniversalString")
     class Universal(override val value: String) : Asn1String() {
         override val tag = BERTags.UNIVERSAL_STRING.toULong()
     }
@@ -34,8 +29,6 @@ sealed class Asn1String : Asn1Encodable<Asn1Primitive> {
     /**
      * VISIBLE STRING (no checks)
      */
-    @Serializable
-    @SerialName("VisibleString")
     class Visible(override val value: String) : Asn1String() {
         override val tag = BERTags.VISIBLE_STRING.toULong()
     }
@@ -43,8 +36,6 @@ sealed class Asn1String : Asn1Encodable<Asn1Primitive> {
     /**
      * IA5 STRING (no checks)
      */
-    @Serializable
-    @SerialName("IA5String")
     class IA5(override val value: String) : Asn1String() {
         override val tag = BERTags.IA5_STRING.toULong()
     }
@@ -52,8 +43,6 @@ sealed class Asn1String : Asn1Encodable<Asn1Primitive> {
     /**
      * TELETEX STRING (no checks)
      */
-    @Serializable
-    @SerialName("TeletexString")
     class Teletex(override val value: String) : Asn1String() {
         override val tag = BERTags.T61_STRING.toULong()
     }
@@ -61,8 +50,6 @@ sealed class Asn1String : Asn1Encodable<Asn1Primitive> {
     /**
      * BMP STRING (no checks)
      */
-    @Serializable
-    @SerialName("BMPString")
     class BMP(override val value: String) : Asn1String() {
         override val tag = BERTags.BMP_STRING.toULong()
     }
@@ -71,9 +58,6 @@ sealed class Asn1String : Asn1Encodable<Asn1Primitive> {
      * PRINTABLE STRING (checked)
      * @throws Asn1Exception if illegal characters are provided
      */
-    @Serializable
-    @SerialName("PrintableString")
-
     class Printable @Throws(Asn1Exception::class) constructor(override val value: String) : Asn1String() {
         init {
             Regex("[a-zA-Z0-9 '()+,-./:=?]*").matchEntire(value)
@@ -87,8 +71,6 @@ sealed class Asn1String : Asn1Encodable<Asn1Primitive> {
      * NUMERIC STRING (checked)
      * @throws Asn1Exception if illegal characters are provided
      */
-    @Serializable
-    @SerialName("NumericString")
     class Numeric @Throws(Asn1Exception::class) constructor(override val value: String) : Asn1String() {
         init {
             Regex("[0-9 ]*").matchEntire(value)

--- a/indispensable-asn1/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/Asn1Time.kt
+++ b/indispensable-asn1/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/Asn1Time.kt
@@ -17,7 +17,6 @@ import kotlinx.serialization.encoding.Encoder
  * @param instant the timestamp to encode
  * @param formatOverride to force either  GENERALIZED TIME or UTC TIME
  */
-@Serializable(with = Asn1TimeSerializer::class)
 class Asn1Time(instant: Instant, formatOverride: Format? = null) : Asn1Encodable<Asn1Primitive> {
 
     val instant = Instant.fromEpochSeconds(instant.epochSeconds)
@@ -78,17 +77,4 @@ class Asn1Time(instant: Instant, formatOverride: Format? = null) : Asn1Encodable
          */
         GENERALIZED
     }
-}
-
-
-object Asn1TimeSerializer : KSerializer<Asn1Time> {
-    override val descriptor = PrimitiveSerialDescriptor("Asn1Time", PrimitiveKind.STRING)
-
-    override fun deserialize(decoder: Decoder) =
-        Asn1Time.decodeFromTlv(Asn1Element.parseFromDerHexString(decoder.decodeString()) as Asn1Primitive)
-
-    override fun serialize(encoder: Encoder, value: Asn1Time) {
-        encoder.encodeString(value.encodeToTlv().toDerHexString())
-    }
-
 }

--- a/indispensable-asn1/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/ObjectIdentifier.kt
+++ b/indispensable-asn1/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/ObjectIdentifier.kt
@@ -4,7 +4,6 @@ import at.asitplus.signum.indispensable.asn1.VarUInt.Companion.decodeAsn1VarBigU
 import at.asitplus.signum.indispensable.asn1.encoding.decode
 import at.asitplus.signum.indispensable.asn1.encoding.toAsn1VarInt
 import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializable
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
 import kotlinx.serialization.encoding.Decoder
@@ -199,4 +198,16 @@ interface Identifiable {
 @Throws(Asn1Exception::class)
 fun Asn1Primitive.readOid() = runRethrowing {
     decode(Asn1Element.Tag.OID) { ObjectIdentifier.decodeFromAsn1ContentBytes(it) }
+}
+
+object ObjectIdentifierStringSerializer : KSerializer<ObjectIdentifier> {
+    override val descriptor = PrimitiveSerialDescriptor("OID", PrimitiveKind.STRING)
+
+    override fun deserialize(decoder: Decoder): ObjectIdentifier =
+        ObjectIdentifier(decoder.decodeString())
+
+    override fun serialize(encoder: Encoder, value: ObjectIdentifier) {
+        encoder.encodeString(value.toString())
+    }
+
 }

--- a/indispensable-asn1/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/ObjectIdentifier.kt
+++ b/indispensable-asn1/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/ObjectIdentifier.kt
@@ -19,7 +19,6 @@ import kotlin.uuid.Uuid
  * @param nodes OID Tree nodes passed in order (e.g. 1u, 2u, 96u, …)
  * @throws Asn1Exception if less than two nodes are supplied, the first node is >2 or the second node is >39
  */
-@Serializable(with = ObjectIdSerializer::class)
 class ObjectIdentifier @Throws(Asn1Exception::class) private constructor(
     bytes: ByteArray?,
     nodes: List<VarUInt>?
@@ -184,18 +183,6 @@ class ObjectIdentifier @Throws(Asn1Exception::class) private constructor(
         }
     }
 }
-
-object ObjectIdSerializer : KSerializer<ObjectIdentifier> {
-    override val descriptor = PrimitiveSerialDescriptor("OID", PrimitiveKind.STRING)
-
-    override fun deserialize(decoder: Decoder): ObjectIdentifier = ObjectIdentifier(decoder.decodeString())
-
-    override fun serialize(encoder: Encoder, value: ObjectIdentifier) {
-        encoder.encodeString(value.toString())
-    }
-
-}
-
 
 /**
  * Adds [oid] to the implementing class

--- a/indispensable-asn1/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/encoding/Asn1Decoding.kt
+++ b/indispensable-asn1/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/encoding/Asn1Decoding.kt
@@ -62,6 +62,7 @@ fun Asn1Element.Companion.parse(source: ByteArray): Asn1Element =
 )
 @Throws(Asn1Exception::class)
 fun Asn1Element.Companion.parseAll(input: ByteIterator): List<Asn1Element> =
+    @OptIn(UnsafeIoApi::class)
     mutableListOf<Byte>().also { while (input.hasNext()) it.add(input.nextByte()) }.toByteArray().wrapInUnsafeSource()
         .readFullyToAsn1Elements().first
 

--- a/indispensable-asn1/src/jvmTest/kotlin/at/asitplus/signum/indispensable/asn1/OidTest.kt
+++ b/indispensable-asn1/src/jvmTest/kotlin/at/asitplus/signum/indispensable/asn1/OidTest.kt
@@ -482,7 +482,6 @@ class OldOIDObjectIdentifier @Throws(Asn1Exception::class) constructor(@Transien
 }
 
 
-@Serializable(with = ObjectIdSerializer::class)
 class BigIntObjectIdentifier @Throws(Asn1Exception::class) private constructor(
     bytes: ByteArray?,
     nodes: List<BigInteger>?

--- a/indispensable-asn1/src/jvmTest/kotlin/at/asitplus/signum/indispensable/asn1/RealTest.kt
+++ b/indispensable-asn1/src/jvmTest/kotlin/at/asitplus/signum/indispensable/asn1/RealTest.kt
@@ -9,6 +9,8 @@ import io.kotest.datatest.withData
 import io.kotest.matchers.longs.shouldBeGreaterThan
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
 
 
 @OptIn(ExperimentalStdlibApi::class)
@@ -25,6 +27,17 @@ class RealTest : FreeSpec({
 
             double.encodeToAsn1Primitive().derEncoded shouldBe bytes
             Asn1Element.parse(bytes).asPrimitive().decodeToDouble() shouldBe double
+
+            val real = Json.encodeToString(own)
+            println(real)
+            Json.decodeFromString<Asn1Real>(" $real") shouldBe own
+            Json.decodeFromString<Asn1Real>(" $real ") shouldBe own
+            Json.decodeFromString<Asn1Real>("$real ") shouldBe own
+            Json.decodeFromString<Asn1Real>(real.replace(" *","*")) shouldBe own
+            Json.decodeFromString<Asn1Real>(real.replace(" * ","*")) shouldBe own
+            Json.decodeFromString<Asn1Real>(real.replace("^"," ^")) shouldBe own
+            Json.decodeFromString<Asn1Real>(real.replace("^"," ^ ")) shouldBe own
+            Json.decodeFromString<Asn1Real>(real) shouldBe own
         }
     }
 
@@ -41,7 +54,13 @@ class RealTest : FreeSpec({
                 this.shouldBeInstanceOf<Asn1Real.Finite>()
                 this.normalizedMantissa shouldBe wrongScaledMantissa
                 this.normalizedExponent shouldBe exponent
+
+                val real = Json.encodeToString(this)
+                println(real)
+                Json.decodeFromString<Asn1Real>(real) shouldBe this
             }
+
+
         }
 
         withData(
@@ -57,6 +76,10 @@ class RealTest : FreeSpec({
 
             double.encodeToAsn1Primitive().derEncoded shouldBe bytes
             Asn1Element.parse(bytes).asPrimitive().decodeToDouble() shouldBe double
+
+            val real = Json.encodeToString(own)
+            println(real)
+            Json.decodeFromString<Asn1Real>(real) shouldBe own
         }
     }
 

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JsonWebKey.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JsonWebKey.kt
@@ -12,6 +12,7 @@ import at.asitplus.signum.indispensable.SpecializedCryptoPublicKey
 import at.asitplus.signum.indispensable.asn1.Asn1Integer
 import at.asitplus.signum.indispensable.io.Base64UrlStrict
 import at.asitplus.signum.indispensable.io.ByteArrayBase64UrlSerializer
+import at.asitplus.signum.indispensable.io.CertificateChainBase64UrlSerializer
 import at.asitplus.signum.indispensable.josef.io.JwsCertificateSerializer
 import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
 import at.asitplus.signum.indispensable.pki.CertificateChain
@@ -135,6 +136,7 @@ data class JsonWebKey(
      * OPTIONAL.
      */
     @SerialName("x5c")
+    @Serializable(with = CertificateChainBase64UrlSerializer::class)
     val certificateChain: CertificateChain? = null,
 
     /**

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JweHeader.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JweHeader.kt
@@ -2,6 +2,7 @@ package at.asitplus.signum.indispensable.josef
 
 import at.asitplus.catching
 import at.asitplus.signum.indispensable.io.ByteArrayBase64UrlSerializer
+import at.asitplus.signum.indispensable.io.CertificateChainBase64UrlSerializer
 import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
 import at.asitplus.signum.indispensable.pki.CertificateChain
 import kotlinx.serialization.SerialName
@@ -180,6 +181,7 @@ data class JweHeader(
      * See [JwsHeader.certificateChain]
      */
     @SerialName("x5c")
+    @Serializable(with = CertificateChainBase64UrlSerializer::class)
     val certificateChain: CertificateChain? = null,
 
     /**

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsAlgorithm.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsAlgorithm.kt
@@ -203,7 +203,6 @@ fun DataIntegrityAlgorithm.toJwsAlgorithm(): KmmResult<JwsAlgorithm> = catching 
     when (this) {
         is SignatureAlgorithm -> toJwsAlgorithm().getOrThrow()
         is MessageAuthenticationCode -> toJwsAlgorithm().getOrThrow()
-        else -> throw IllegalArgumentException("Algorithm $this not supported by JWS")
     }
 }
 

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsHeader.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsHeader.kt
@@ -67,7 +67,7 @@ data class JwsHeader(
      * implementations.
      */
     @SerialName("alg")
-    val algorithm: JwsAlgorithm<*>,
+    val algorithm: JwsAlgorithm,
 
     /**
      * The "cty" (content type) Header Parameter is used by JWS applications

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsHeader.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsHeader.kt
@@ -66,7 +66,7 @@ data class JwsHeader(
      * implementations.
      */
     @SerialName("alg")
-    val algorithm: JwsAlgorithm,
+    val algorithm: JwsAlgorithm<*>,
 
     /**
      * The "cty" (content type) Header Parameter is used by JWS applications
@@ -213,13 +213,6 @@ data class JwsHeader(
      */
     @SerialName("jwt")
     val attestationJwt: String? = null,
-
-    /**
-     * OpenID4VCI: Optional. JOSE Header containing a key attestation as described in Appendix D.
-     * See [keyAttestationParsed].
-     */
-    @SerialName("key_attestation")
-    val keyAttestation: String? = null,
 ) {
 
     fun serialize() = joseCompliantSerializer.encodeToString(this)
@@ -250,7 +243,6 @@ data class JwsHeader(
             if (!certificateSha256Thumbprint.contentEquals(other.certificateSha256Thumbprint)) return false
         } else if (other.certificateSha256Thumbprint != null) return false
         if (attestationJwt != other.attestationJwt) return false
-        if (keyAttestation != other.keyAttestation) return false
 
         return true
     }
@@ -270,7 +262,6 @@ data class JwsHeader(
         result = 31 * result + (certificateSha1Thumbprint?.contentHashCode() ?: 0)
         result = 31 * result + (certificateSha256Thumbprint?.contentHashCode() ?: 0)
         result = 31 * result + (attestationJwt?.hashCode() ?: 0)
-        result = 31 * result + (keyAttestation?.hashCode() ?: 0)
         return result
     }
 
@@ -284,12 +275,6 @@ data class JwsHeader(
             ?: certificateChain?.leaf?.publicKey
     }
 
-    val keyAttestationParsed: JwsSigned<KeyAttestationJwt>? by lazy {
-        keyAttestation?.let {
-            JwsSigned.deserialize<KeyAttestationJwt>(KeyAttestationJwt.serializer(), it, joseCompliantSerializer)
-                .getOrNull()
-        }
-    }
 
     companion object {
         fun deserialize(it: String) = catching {

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsHeader.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsHeader.kt
@@ -6,6 +6,7 @@ import at.asitplus.catching
 import at.asitplus.signum.indispensable.CryptoPublicKey
 import at.asitplus.signum.indispensable.io.ByteArrayBase64Serializer
 import at.asitplus.signum.indispensable.io.ByteArrayBase64UrlSerializer
+import at.asitplus.signum.indispensable.io.CertificateChainBase64UrlSerializer
 import at.asitplus.signum.indispensable.josef.io.InstantLongSerializer
 import at.asitplus.signum.indispensable.josef.io.JwsCertificateSerializer
 import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
@@ -100,6 +101,7 @@ data class JwsHeader(
      * failure occurs.  Use of this Header Parameter is OPTIONAL.
      */
     @SerialName("x5c")
+    @Serializable(with = CertificateChainBase64UrlSerializer::class)
     val certificateChain: CertificateChain? = null,
 
     /**

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsHeader.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsHeader.kt
@@ -213,6 +213,13 @@ data class JwsHeader(
      */
     @SerialName("jwt")
     val attestationJwt: String? = null,
+
+    /**
+     * OpenID4VCI: Optional. JOSE Header containing a key attestation as described in Appendix D.
+     * See [keyAttestationParsed].
+     */
+    @SerialName("key_attestation")
+    val keyAttestation: String? = null,
 ) {
 
     fun serialize() = joseCompliantSerializer.encodeToString(this)
@@ -243,6 +250,7 @@ data class JwsHeader(
             if (!certificateSha256Thumbprint.contentEquals(other.certificateSha256Thumbprint)) return false
         } else if (other.certificateSha256Thumbprint != null) return false
         if (attestationJwt != other.attestationJwt) return false
+        if (keyAttestation != other.keyAttestation) return false
 
         return true
     }
@@ -262,6 +270,7 @@ data class JwsHeader(
         result = 31 * result + (certificateSha1Thumbprint?.contentHashCode() ?: 0)
         result = 31 * result + (certificateSha256Thumbprint?.contentHashCode() ?: 0)
         result = 31 * result + (attestationJwt?.hashCode() ?: 0)
+        result = 31 * result + (keyAttestation?.hashCode() ?: 0)
         return result
     }
 
@@ -275,6 +284,12 @@ data class JwsHeader(
             ?: certificateChain?.leaf?.publicKey
     }
 
+    val keyAttestationParsed: JwsSigned<KeyAttestationJwt>? by lazy {
+        keyAttestation?.let {
+            JwsSigned.deserialize<KeyAttestationJwt>(KeyAttestationJwt.serializer(), it, joseCompliantSerializer)
+                .getOrNull()
+        }
+    }
 
     companion object {
         fun deserialize(it: String) = catching {

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsSigned.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsSigned.kt
@@ -59,7 +59,7 @@ data class JwsSigned<out P : Any>(
     companion object {
         /**
          * Deserializes the input, expected to contain a valid JWS (three Base64-URL strings joined by `.`),
-         * into a [JwsSigned] with `ByteArray` as the type of the payload.
+         * into a [JwsSigned] with [ByteArray] as the type of the payload.
          */
         @Suppress("NOTHING_TO_INLINE")
         inline fun deserialize(input: String): KmmResult<JwsSigned<ByteArray>> = catching {

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsSigned.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsSigned.kt
@@ -116,7 +116,7 @@ data class JwsSigned<out P : Any>(
          * Called by JWS signing implementations to get the string that will be
          * used as the input for signature calculation
          */
-        @Suppress("unused")
+        @Suppress("unused", "NOTHING_TO_INLINE")
         inline fun <T : Any> prepareJwsSignatureInput(
             header: JwsHeader,
             payload: T,

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/CryptoPublicKey.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/CryptoPublicKey.kt
@@ -21,7 +21,6 @@ private const val PEM_BOUNDARY = "PUBLIC KEY"
 /**
  * Representation of a public key structure
  */
-@Serializable
 sealed class CryptoPublicKey : PemEncodable<Asn1Sequence>, Identifiable {
 
     /**
@@ -255,7 +254,6 @@ sealed class CryptoPublicKey : PemEncodable<Asn1Sequence>, Identifiable {
      * The properties and constructor params are exactly what their names suggest
      * @param preferCompressedRepresentation indicates whether to use point compression where applicable
      */
-    @Serializable
     @SerialName("EC")
     @ConsistentCopyVisibility
     data class EC private constructor(

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/CryptoSignature.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/CryptoSignature.kt
@@ -210,7 +210,11 @@ sealed interface CryptoSignature : Asn1Encodable<Asn1Element> {
                 return fromRS(r, s)
             }
 
-            @Deprecated("use fromRawBytes", ReplaceWith("CryptoSignature.EC.fromRawBytes(input)"))
+            @Deprecated(
+                "use fromRawBytes",
+                ReplaceWith("CryptoSignature.EC.fromRawBytes(input)"),
+                DeprecationLevel.ERROR
+            )
             operator fun invoke(input: ByteArray): DefiniteLength = fromRawBytes(input)
 
         }

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/CryptoSignature.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/CryptoSignature.kt
@@ -210,11 +210,7 @@ sealed interface CryptoSignature : Asn1Encodable<Asn1Element> {
                 return fromRS(r, s)
             }
 
-            @Deprecated(
-                "use fromRawBytes",
-                ReplaceWith("CryptoSignature.EC.fromRawBytes(input)"),
-                DeprecationLevel.ERROR
-            )
+            @Deprecated("use fromRawBytes", ReplaceWith("CryptoSignature.EC.fromRawBytes(input)"))
             operator fun invoke(input: ByteArray): DefiniteLength = fromRawBytes(input)
 
         }

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/ECCurve.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/ECCurve.kt
@@ -21,6 +21,7 @@ import kotlinx.serialization.encoding.Encoder
 inline fun UInt.ceilDiv(other: UInt) =
     (floorDiv(other)) + (if (rem(other) != 0u) 1u else 0u)
 
+@Suppress("NOTHING_TO_INLINE")
 inline fun Int.ceilDiv(other: Int) =
     (floorDiv(other)) + (if (rem(other) != 0) 1 else 0)
 

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/pki/Pkcs10CertificationRequest.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/pki/Pkcs10CertificationRequest.kt
@@ -20,7 +20,6 @@ import kotlinx.serialization.Serializable
  * @param publicKey nomen est omen
  * @param attributes nomen est omen
  */
-@Serializable
 data class TbsCertificationRequest(
     val version: Int = 0,
     val subjectName: List<RelativeDistinguishedName>,
@@ -112,7 +111,6 @@ data class TbsCertificationRequest(
 /**
  * Very simple implementation of a PKCS#10 Certification Request
  */
-@Serializable
 data class Pkcs10CertificationRequest(
     val tbsCsr: TbsCertificationRequest,
     val signatureAlgorithm: X509SignatureAlgorithm,

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/pki/Pkcs10CertificationRequestAttribute.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/pki/Pkcs10CertificationRequestAttribute.kt
@@ -4,7 +4,6 @@ import at.asitplus.signum.indispensable.asn1.*
 import at.asitplus.signum.indispensable.asn1.encoding.Asn1
 import kotlinx.serialization.Serializable
 
-@Serializable
 data class Pkcs10CertificationRequestAttribute(
     override val oid: ObjectIdentifier,
     val value: List<Asn1Element>

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/pki/RelativeDistinguishedName.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/pki/RelativeDistinguishedName.kt
@@ -10,7 +10,6 @@ import kotlinx.serialization.Serializable
 /**
  * X.500 Name (used in X.509 Certificates)
  */
-@Serializable
 data class RelativeDistinguishedName(val attrsAndValues: List<AttributeTypeAndValue>) : Asn1Encodable<Asn1Set> {
 
     constructor(singleItem: AttributeTypeAndValue) : this(listOf(singleItem))
@@ -32,14 +31,11 @@ data class RelativeDistinguishedName(val attrsAndValues: List<AttributeTypeAndVa
 }
 
 //TODO: value should be Asn1Primitive???
-@Serializable
 sealed class AttributeTypeAndValue : Asn1Encodable<Asn1Sequence>, Identifiable {
     abstract val value: Asn1Element
 
     override fun toString() = value.toString()
 
-    @Serializable
-    @SerialName("CN")
     class CommonName(override val value: Asn1Element) : AttributeTypeAndValue() {
         override val oid = OID
 
@@ -50,8 +46,6 @@ sealed class AttributeTypeAndValue : Asn1Encodable<Asn1Sequence>, Identifiable {
         }
     }
 
-    @Serializable
-    @SerialName("C")
     class Country(override val value: Asn1Element) : AttributeTypeAndValue() {
         override val oid = OID
 
@@ -62,8 +56,6 @@ sealed class AttributeTypeAndValue : Asn1Encodable<Asn1Sequence>, Identifiable {
         }
     }
 
-    @Serializable
-    @SerialName("O")
     class Organization(override val value: Asn1Element) : AttributeTypeAndValue() {
         override val oid = OID
 
@@ -74,8 +66,6 @@ sealed class AttributeTypeAndValue : Asn1Encodable<Asn1Sequence>, Identifiable {
         }
     }
 
-    @Serializable
-    @SerialName("OU")
     class OrganizationalUnit(override val value: Asn1Element) : AttributeTypeAndValue() {
         override val oid = OID
 
@@ -86,8 +76,6 @@ sealed class AttributeTypeAndValue : Asn1Encodable<Asn1Sequence>, Identifiable {
         }
     }
 
-    @Serializable
-    @SerialName("?")
     class Other(override val oid: ObjectIdentifier, override val value: Asn1Element) : AttributeTypeAndValue() {
         constructor(oid: ObjectIdentifier, str: Asn1String) : this(
             oid,

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/pki/X509Certificate.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/pki/X509Certificate.kt
@@ -7,6 +7,7 @@ import at.asitplus.signum.indispensable.X509SignatureAlgorithm
 import at.asitplus.signum.indispensable.asn1.*
 import at.asitplus.signum.indispensable.asn1.encoding.*
 import at.asitplus.signum.indispensable.io.Base64Strict
+import at.asitplus.signum.indispensable.io.Base64UrlStrict
 import at.asitplus.signum.indispensable.io.ByteArrayBase64Serializer
 import at.asitplus.signum.indispensable.io.TransformingSerializerTemplate
 import at.asitplus.signum.indispensable.pki.AlternativeNames.Companion.findIssuerAltNames
@@ -136,6 +137,10 @@ constructor(
         result = 31 * result + (subjectUniqueID?.hashCode() ?: 0)
         result = 31 * result + (extensions?.hashCode() ?: 0)
         return result
+    }
+
+    override fun toString(): String {
+        return "TbsCertificate(${encodeToDerOrNull()?.let { it.encodeToString(Base64UrlStrict) }})"
     }
 
     companion object : Asn1Decodable<Asn1Sequence, TbsCertificate> {
@@ -273,6 +278,10 @@ data class X509Certificate @Throws(IllegalArgumentException::class) constructor(
         result = 31 * result + signatureAlgorithm.hashCode()
         result = 31 * result + signature.hashCode()
         return result
+    }
+
+    override fun toString(): String {
+        return "X509Certificate(${encodeToDerOrNull()?.let { it.encodeToString(Base64UrlStrict) }})"
     }
 
     val publicKey: CryptoPublicKey get() = tbsCertificate.publicKey

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/pki/X509Certificate.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/pki/X509Certificate.kt
@@ -25,7 +25,6 @@ import kotlinx.serialization.builtins.serializer
  * Very simple implementation of the meat of an X.509 Certificate:
  * The structure that gets signed
  */
-@Serializable
 data class TbsCertificate
 @Throws(Asn1Exception::class)
 constructor(
@@ -241,7 +240,6 @@ fun CryptoSignature.Companion.fromX509Encoded(alg: X509SignatureAlgorithm, it: A
 /**
  * Very simple implementation of an X.509 Certificate
  */
-@Serializable
 data class X509Certificate @Throws(IllegalArgumentException::class) constructor(
     val tbsCertificate: TbsCertificate,
     val signatureAlgorithm: X509SignatureAlgorithm,

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/pki/X509Certificate.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/pki/X509Certificate.kt
@@ -8,7 +8,6 @@ import at.asitplus.signum.indispensable.asn1.*
 import at.asitplus.signum.indispensable.asn1.encoding.*
 import at.asitplus.signum.indispensable.io.Base64Strict
 import at.asitplus.signum.indispensable.io.Base64UrlStrict
-import at.asitplus.signum.indispensable.io.ByteArrayBase64Serializer
 import at.asitplus.signum.indispensable.io.TransformingSerializerTemplate
 import at.asitplus.signum.indispensable.pki.AlternativeNames.Companion.findIssuerAltNames
 import at.asitplus.signum.indispensable.pki.AlternativeNames.Companion.findSubjectAltNames
@@ -18,7 +17,6 @@ import at.asitplus.signum.indispensable.pki.TbsCertificate.Companion.Tags.SUBJEC
 import io.matthewnelson.encoding.base64.Base64
 import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArray
 import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
-import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
 import kotlinx.serialization.builtins.serializer
 
@@ -30,16 +28,14 @@ data class TbsCertificate
 @Throws(Asn1Exception::class)
 constructor(
     val version: Int? = 2,
-    @Serializable(with = ByteArrayBase64Serializer::class) val serialNumber: ByteArray,
+    val serialNumber: ByteArray,
     val signatureAlgorithm: X509SignatureAlgorithm,
     val issuerName: List<RelativeDistinguishedName>,
     val validFrom: Asn1Time,
     val validUntil: Asn1Time,
     val subjectName: List<RelativeDistinguishedName>,
     val publicKey: CryptoPublicKey,
-    @Serializable(with = Asn1BitStringSerializer::class)
     val issuerUniqueID: Asn1BitString? = null,
-    @Serializable(with = Asn1BitStringSerializer::class)
     val subjectUniqueID: Asn1BitString? = null,
     val extensions: List<X509CertificateExtension>? = null,
 ) : Asn1Encodable<Asn1Sequence> {

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/pki/X509CertificateExtension.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/pki/X509CertificateExtension.kt
@@ -8,7 +8,6 @@ import kotlinx.serialization.Serializable
 /**
  * X.509 Certificate Extension
  */
-@Serializable
 @ConsistentCopyVisibility
 data class X509CertificateExtension @Throws(Asn1Exception::class) private constructor(
     override val oid: ObjectIdentifier,

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/symmetric/SealedBoxCreation.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/symmetric/SealedBoxCreation.kt
@@ -95,6 +95,7 @@ sealed class SealedBoxBuilder<A : AuthCapability<out K>, I : NonceTrait, out K :
         SealedBoxBuilder<A, NonceTrait.Required, K>(algorithm) {
         class Awaiting<A : AuthCapability<out K>, K : KeyType> internal constructor(algorithm: SymmetricEncryptionAlgorithm<A, NonceTrait.Required, K>) :
             WithNonce<A, K>(algorithm) {
+            @Suppress("UNCHECKED_CAST")
             fun withNonce(nonce: ByteArray): Having<A, K> = when (algorithm.isAuthenticated()) {
                 true -> Having.Authenticated<AuthCapability.Authenticated<*>, KeyType>(
                     algorithm as SymmetricEncryptionAlgorithm<AuthCapability.Authenticated<*>, NonceTrait.Required, KeyType>,

--- a/indispensable/src/iosMain/kotlin/CommonCryptoExtensions.kt
+++ b/indispensable/src/iosMain/kotlin/CommonCryptoExtensions.kt
@@ -120,8 +120,6 @@ fun CryptoPrivateKey.WithPublicKey<*>.toSecKey(): KmmResult<OwnedCFValue<SecKeyR
                     kSecAttrKeySizeInBits mapsTo this@toSecKey.publicKey.bits.number.toInt()
                     asPKCS1.encodeToDer()
                 }
-
-                else -> TODO("Unreachable")
             }
         }
         corecall {

--- a/supreme/src/commonMain/kotlin/at/asitplus/signum/supreme/sign/SignatureInput.kt
+++ b/supreme/src/commonMain/kotlin/at/asitplus/signum/supreme/sign/SignatureInput.kt
@@ -64,5 +64,4 @@ class SignatureInput private constructor (
 val SignatureAlgorithm.preHashedSignatureFormat: SignatureInputFormat get() = when(this) {
     is SignatureAlgorithm.RSA -> this.digest
     is SignatureAlgorithm.ECDSA -> this.digest
-    else -> TODO("HMAC unsupported")
 }


### PR DESCRIPTION
symmetric encryption and rsa or hmac separation already introduces breaking changes all over the place. While we're at it, we can go ahead and break even more stuff. better now than a separate breaking release