### PR TITLE
Improve PEM exception text on incorrect usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 3.0
 
+### NEXT
+
+
 ### 3.16.1 (Supreme 0.8.1) Hotfix
 * Generalized, proper COSE to MAC mapping, preventing unexpected behaviour for `HS265_24`
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,8 +2,8 @@ kotlin.code.style=official
 kotlin.js.compiler=ir
 org.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8
 
-artifactVersion=3.16.1
-supremeVersion=0.8.1
+artifactVersion=3.17.0-SNAPSHOT
+supremeVersion=0.9.0-SNAPSHOT
 
 # This is not a well-defined property, the ASP convention plugin respects it, though
 jdk.version=17

--- a/indispensable/src/commonTest/kotlin/Asn1AddonsTest.kt
+++ b/indispensable/src/commonTest/kotlin/Asn1AddonsTest.kt
@@ -1,5 +1,6 @@
 import at.asitplus.signum.indispensable.asn1.*
 import at.asitplus.signum.indispensable.asn1.encoding.parse
+import at.asitplus.signum.indispensable.pki.X509Certificate
 import com.ionspin.kotlin.bignum.integer.BigInteger
 import com.ionspin.kotlin.bignum.integer.Sign
 import io.kotest.common.Platform
@@ -7,6 +8,7 @@ import io.kotest.common.platform
 import io.kotest.core.spec.style.FreeSpec
 import io.kotest.datatest.withData
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.types.shouldBeTypeOf
 import io.kotest.property.Arb
 import io.kotest.property.arbitrary.*
@@ -85,5 +87,16 @@ class Asn1AddonsTest: FreeSpec({
                 }
             }
         }
+    }
+
+    "PemDecodable error messages" {
+        val x = X509Certificate.decodeFromPem("-----BEGIN PUBLIC KEY-----\n" +
+                "MFswDQYJKoZIhvcNAQEBBQADSgAwRwJAXWRPQyGlEY+SXz8Uslhe+MLjTgWd8lf/\n" +
+                "nA0hgCm9JFKC1tq1S73cQ9naClNXsMqY7pwPt1bSY8jYRqHHbdoUvwIDAQAB\n" +
+                "-----END PUBLIC KEY-----")
+            .exceptionOrNull()
+            .shouldBeTypeOf<PemDecodable.UnknownEncapsulationBoundaryException>()
+        x.ebString shouldBe "PUBLIC KEY"
+        x.message shouldContain "CryptoPublicKey.decodeFromPem"
     }
 })


### PR DESCRIPTION
So if you try to fit the proverbial square peg in the proverbial round hole, we non-proverbially tell you what you're doing wrong.