### PR TITLE
correct type bounds for base signing provider

### DIFF
--- a/indispensable/src/commonTest/kotlin/SymmetricEncryptionTest.kt
+++ b/indispensable/src/commonTest/kotlin/SymmetricEncryptionTest.kt
@@ -1,17 +1,13 @@
-package at.asitplus.signum
-
 import at.asitplus.signum.indispensable.SecretExposure
 import at.asitplus.signum.indispensable.symmetric.SymmetricEncryptionAlgorithm
 import at.asitplus.signum.indispensable.symmetric.SymmetricKey
 import at.asitplus.signum.indispensable.symmetric.preferredMacKeyLength
 import at.asitplus.signum.indispensable.symmetric.randomKey
-
 import io.kotest.core.spec.style.FreeSpec
 import io.kotest.datatest.withData
 import io.kotest.matchers.shouldBe
 
 class SymmetricEncryptionTest: FreeSpec({
-   
     withData(nameFn={ "Key generation: $it" }, SymmetricEncryptionAlgorithm.entries) { alg ->
         val key = alg.randomKey()
 

--- a/supreme/src/androidMain/kotlin/at/asitplus/signum/supreme/sign/EphemeralKeysImpl.kt
+++ b/supreme/src/androidMain/kotlin/at/asitplus/signum/supreme/sign/EphemeralKeysImpl.kt
@@ -25,8 +25,8 @@ import java.security.interfaces.RSAPrivateKey
 import java.security.spec.ECGenParameterSpec
 import java.security.spec.RSAKeyGenParameterSpec
 
-actual class EphemeralSigningKeyConfiguration internal actual constructor(): EphemeralSigningKeyConfigurationBase()
-actual class EphemeralSignerConfiguration internal actual constructor(): EphemeralSignerConfigurationBase()
+actual class EphemeralSigningKeyConfiguration actual constructor(): EphemeralSigningKeyConfigurationBase()
+actual class EphemeralSignerConfiguration actual constructor(): EphemeralSignerConfigurationBase()
 
 sealed class AndroidEphemeralSigner (internal val privateKey: PrivateKey) : Signer {
     override val mayRequireUserUnlock = false
@@ -92,7 +92,7 @@ internal sealed interface AndroidEphemeralKey {
 }
 
 internal actual fun makeEphemeralKey(configuration: EphemeralSigningKeyConfiguration) : EphemeralKey =
-    when (val alg = configuration._algSpecific.v) {
+    when (val alg = configuration.ec.v) {
         is SigningKeyConfiguration.ECConfiguration -> {
             KeyPairGenerator.getInstance(KeyProperties.KEY_ALGORITHM_EC).run {
                 initialize(ECGenParameterSpec(alg.curve.jcaName))

--- a/supreme/src/androidMain/kotlin/at/asitplus/signum/supreme/sign/VerifierImpl.kt
+++ b/supreme/src/androidMain/kotlin/at/asitplus/signum/supreme/sign/VerifierImpl.kt
@@ -16,7 +16,7 @@ import java.security.Signature
  * Configures JVM-specific properties.
  * @see provider
  */
-actual class PlatformVerifierConfiguration internal actual constructor() : DSL.Data() {
+actual class PlatformVerifierConfiguration actual constructor() : DSL.Data() {
     /** The JCA provider to use, or none. */
     var provider: String? = null
 }

--- a/supreme/src/commonMain/kotlin/at/asitplus/signum/supreme/dsl/ConfigurationDSL.kt
+++ b/supreme/src/commonMain/kotlin/at/asitplus/signum/supreme/dsl/ConfigurationDSL.kt
@@ -10,7 +10,7 @@ import kotlin.reflect.KProperty
 object DSL {
     /** Resolve a DSL lambda to a concrete configuration */
     fun <S: DSL.Data, T: S> resolve(factory: ()->T, config: DSLConfigureFn<S>): T =
-        (if (config == null) factory() else factory().apply(config)).also(DSL.Data::validate)
+        (if (config == null) factory() else factory().apply(config)).also(DSL.Data::doValidate)
 
     /** A collection of equivalent DSL configuration structures which shadow each other.
      * @see getProperty */
@@ -59,7 +59,7 @@ object DSL {
          * This constructs a new specialized child, configures it using the specified block,
          * and stores it in the underlying generalized storage.
          */
-        internal constructor(private val factory: ()->S) : Invokable<T,S> {
+        constructor(private val factory: ()->S) : Invokable<T,S> {
             override val v: T get() = this@Generalized.v
             override operator fun invoke(configure: S.()->Unit) { _v = resolve(factory, configure) }
         }
@@ -110,9 +110,9 @@ object DSL {
 
         /**
          * Specifies a generalized holder of type T.
-         * Use as `internal val _subHolder = subclassOf<GeneralTypeOfSub>()`.
+         * Use as `protected val _subHolder = subclassOf<GeneralTypeOfSub>()`.
          *
-         * The generalized holder itself cannot be invoked, and should be marked `internal`.
+         * The generalized holder itself cannot be invoked, and should be marked `protected`.
          * Defaults to `null`.
          *
          * Specialized invokable accessors can be spun off via `.option(::SpecializedClass)`.
@@ -122,9 +122,9 @@ object DSL {
             Generalized<T?>(null)
         /**
          * Specifies a generalized holder of type T.
-         * Use as `internal val _subHolder = subclassOf<GeneralTypeOfSub>(SpecializedClass())`.
+         * Use as `protected val _subHolder = subclassOf<GeneralTypeOfSub>(SpecializedClass())`.
          *
-         * The generalized holder itself cannot be invoked, and should be marked `internal`.
+         * The generalized holder itself cannot be invoked, and should be marked `protected`.
          * Defaults to the specified `default`.
          *
          * Specialized invokable accessors can be spun off via `.option(::SpecializedClass)`.
@@ -169,7 +169,9 @@ object DSL {
          * Invoked by `DSL.resolve()` after the configuration block runs.
          * Can be used for sanity checks.
          */
-        internal open fun validate() {}
+        protected open fun validate() {}
+
+        internal fun doValidate() = validate()
     }
 }
 

--- a/supreme/src/commonMain/kotlin/at/asitplus/signum/supreme/os/SigningProvider.kt
+++ b/supreme/src/commonMain/kotlin/at/asitplus/signum/supreme/os/SigningProvider.kt
@@ -251,7 +251,7 @@ val PlatformSigningProvider get() = getPlatformSigningProvider(null)
  * @see SigningProvider */
 interface SigningProviderI<out SignerT: Signer.WithAlias,
         out SignerConfigT: SignerConfiguration,
-        out KeyConfigT: PlatformSigningKeyConfigurationBase<*>> {
+        out KeyConfigT: SigningProviderSigningKeyConfigurationBase<*>> {
     suspend fun createSigningKey(alias: String, configure: DSLConfigureFn<KeyConfigT> = null): KmmResult<SignerT>
     suspend fun getSignerForKey(alias: String, configure: DSLConfigureFn<SignerConfigT> = null): KmmResult<SignerT>
     suspend fun deleteSigningKey(alias: String): KmmResult<Unit>

--- a/supreme/src/commonMain/kotlin/at/asitplus/signum/supreme/os/SigningProvider.kt
+++ b/supreme/src/commonMain/kotlin/at/asitplus/signum/supreme/os/SigningProvider.kt
@@ -18,12 +18,12 @@ import at.asitplus.signum.supreme.sign.SigningKeyConfiguration
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
-open class SigningProviderSigningKeyConfigurationBase<SignerConfigurationT: SignerConfiguration> internal constructor() : SigningKeyConfiguration() {
+open class SigningProviderSigningKeyConfigurationBase<SignerConfigurationT: SignerConfiguration>() : SigningKeyConfiguration() {
     /** Configure the signer that will be returned from [createSigningKey][SigningProviderI.createSigningKey] */
     open val signer = integratedReceiver<SignerConfigurationT>()
 }
-open class PlatformSigningKeyConfigurationBase<SignerConfigurationT: PlatformSignerConfigurationBase> internal constructor(): SigningProviderSigningKeyConfigurationBase<SignerConfigurationT>() {
-    open class AttestationConfiguration internal constructor(): DSL.Data() {
+open class PlatformSigningKeyConfigurationBase<SignerConfigurationT: PlatformSignerConfigurationBase>(): SigningProviderSigningKeyConfigurationBase<SignerConfigurationT>() {
+    open class AttestationConfiguration(): DSL.Data() {
         /** The server-provided attestation challenge */
         lateinit var challenge: ByteArray
         override fun validate() {
@@ -31,7 +31,7 @@ open class PlatformSigningKeyConfigurationBase<SignerConfigurationT: PlatformSig
         }
     }
 
-    open class ProtectionFactorConfiguration internal constructor(): DSL.Data() {
+    open class ProtectionFactorConfiguration(): DSL.Data() {
         /** Whether a biometric factor (fingerprint, facial recognition, ...) can authorize this key */
         var biometry = true
         /** Whether additional biometric factors can be added without invalidating the key */
@@ -45,7 +45,7 @@ open class PlatformSigningKeyConfigurationBase<SignerConfigurationT: PlatformSig
         }
     }
 
-    open class ProtectionConfiguration internal constructor(): DSL.Data() {
+    open class ProtectionConfiguration(): DSL.Data() {
         /** The timeout before this key will need to be unlocked again. */
         var timeout: Duration = 0.seconds
         /** Which authentication factors can authorize this key;
@@ -69,28 +69,28 @@ open class PlatformSigningKeyConfigurationBase<SignerConfigurationT: PlatformSig
     /** Require that this key is stored in some kind of hardware-backed storage, such as Android Keymaster or Apple Secure Enclave. */
     open val hardware = childOrNull(::SecureHardwareConfiguration)
 
-    open class RSAPurposeConfiguration internal constructor(): DSL.Data() {
+    open class RSAPurposeConfiguration(): DSL.Data() {
         /** Whether this key can be used for signing data */
         var signing = true
         /** Whether this key can be used for encrypting data*/
         var decrypting = false
     }
 
-    open class RSAConfiguration internal constructor(): SigningKeyConfiguration.RSAConfiguration() {
+    open class RSAConfiguration(): SigningKeyConfiguration.RSAConfiguration() {
         open val purposes = childOrDefault(::RSAPurposeConfiguration)
     }
 
     override val rsa = _algSpecific.option(::RSAConfiguration)
 
 
-    open class ECPurposeConfiguration internal constructor(): DSL.Data() {
+    open class ECPurposeConfiguration(): DSL.Data() {
         /** Whether this key can be used for signing data */
         var signing = true
         /** Whether this key can be used for ECDH key agreement */
         var keyAgreement = false
     }
 
-    open class ECConfiguration internal constructor(): SigningKeyConfiguration.ECConfiguration() {
+    open class ECConfiguration(): SigningKeyConfiguration.ECConfiguration() {
         open val purposes = childOrDefault(::ECPurposeConfiguration)
     }
 
@@ -118,7 +118,7 @@ internal inline val SigningKeyConfiguration.AlgorithmSpecific.allowsKeyAgreement
         else -> false
     }
 
-open class ECSignerConfiguration internal constructor(): DSL.Data() {
+open class ECSignerConfiguration(): DSL.Data() {
     /**
      * Explicitly specify the digest to sign over.
      * Omit to default to the only supported digest.
@@ -128,10 +128,11 @@ open class ECSignerConfiguration internal constructor(): DSL.Data() {
      *
      * @see SigningKeyConfiguration.ECConfiguration.digests
      */
-    var digest: Digest? = null; set(v) { digestSpecified = true; field = v }
-    internal var digestSpecified = false
+    var digest: Digest? = null; set(v) { _digestSpecified = true; field = v }
+    protected var _digestSpecified = false; private set
+    internal val digestSpecified get() = _digestSpecified
 }
-open class RSASignerConfiguration internal constructor(): DSL.Data() {
+open class RSASignerConfiguration(): DSL.Data() {
     /**
      * Explicitly specify the digest to sign over.
      * Omit to default to a reasonable default choice.
@@ -142,7 +143,8 @@ open class RSASignerConfiguration internal constructor(): DSL.Data() {
      * @see SigningKeyConfiguration.RSAConfiguration.digests
      */
     lateinit var digest: Digest
-    internal val digestSpecified get() = this::digest.isInitialized
+    protected val _digestSpecified get() = this::digest.isInitialized
+    internal val digestSpecified get() = _digestSpecified
 
     /**
      * Explicitly specify the padding to use.
@@ -154,11 +156,12 @@ open class RSASignerConfiguration internal constructor(): DSL.Data() {
      * @see SigningKeyConfiguration.RSAConfiguration.paddings
      */
     lateinit var padding: RSAPadding
-    internal val paddingSpecified get() = this::padding.isInitialized
+    protected val _paddingSpecified get() = this::padding.isInitialized
+    internal val paddingSpecified get() = _paddingSpecified
 
 
 }
-open class SignerConfiguration internal constructor(): DSL.Data() {
+open class SignerConfiguration(): DSL.Data() {
     /** Algorithm-specific configuration for a returned ECDSA signer. Ignored for RSA keys. */
     open val ec = childOrDefault(::ECSignerConfiguration)
     /** Algorithm-specific configuration for a returned RSA signer. Ignored for ECDSA keys. */
@@ -180,12 +183,12 @@ open class UnlockPromptConfiguration: DSL.Data() {
         const val defaultCancelText = "Cancel"
     }
 }
-open class PlatformSignerConfigurationBase internal constructor(): SignerConfiguration() {
+open class PlatformSignerConfigurationBase(): SignerConfiguration() {
     /** Configure the authorization prompt that will be shown to the user. */
     open val unlockPrompt = childOrDefault(::UnlockPromptConfiguration)
 }
 
-open class PlatformSigningProviderSignerSigningConfigurationBase internal constructor(): DSL.Data() {
+open class PlatformSigningProviderSignerSigningConfigurationBase(): DSL.Data() {
     open val unlockPrompt = childOrDefault(::UnlockPromptConfiguration)
 }
 
@@ -214,7 +217,7 @@ interface PlatformSigningProviderSigner
     }
 }
 
-open class PlatformSigningProviderConfigurationBase internal constructor(): DSL.Data()
+open class PlatformSigningProviderConfigurationBase(): DSL.Data()
 internal expect fun getPlatformSigningProvider(configure: DSLConfigureFn<PlatformSigningProviderConfigurationBase>): PlatformSigningProviderI<*,*,*>
 
 /** KT-71089 workaround

--- a/supreme/src/commonMain/kotlin/at/asitplus/signum/supreme/sign/EphemeralKeys.kt
+++ b/supreme/src/commonMain/kotlin/at/asitplus/signum/supreme/sign/EphemeralKeys.kt
@@ -18,23 +18,23 @@ internal expect fun makeEphemeralKey(configuration: EphemeralSigningKeyConfigura
 internal expect fun makePrivateKeySigner(key: CryptoPrivateKey.EC.WithPublicKey, algorithm: SignatureAlgorithm.ECDSA) : Signer.ECDSA
 internal expect fun makePrivateKeySigner(key: CryptoPrivateKey.RSA, algorithm: SignatureAlgorithm.RSA) : Signer.RSA
 
-open class EphemeralSigningKeyConfigurationBase internal constructor(): SigningKeyConfiguration() {
-    class ECConfiguration internal constructor(): SigningKeyConfiguration.ECConfiguration() {
+open class EphemeralSigningKeyConfigurationBase(): SigningKeyConfiguration() {
+    class ECConfiguration(): SigningKeyConfiguration.ECConfiguration() {
         init { digests = (Digest.entries.asSequence() + sequenceOf<Digest?>(null)).toSet() }
     }
     override val ec = _algSpecific.option(::ECConfiguration)
-    class RSAConfiguration internal constructor(): SigningKeyConfiguration.RSAConfiguration() {
+    class RSAConfiguration(): SigningKeyConfiguration.RSAConfiguration() {
         init { digests = Digest.entries.toSet(); paddings = RSAPadding.entries.toSet() }
     }
     override val rsa = _algSpecific.option(::RSAConfiguration)
 }
 
 @Suppress("NOTHING_TO_INLINE")
-expect class EphemeralSigningKeyConfiguration internal constructor(): EphemeralSigningKeyConfigurationBase
+expect class EphemeralSigningKeyConfiguration(): EphemeralSigningKeyConfigurationBase
 
 typealias EphemeralSignerConfigurationBase = SignerConfiguration
 @Suppress("NOTHING_TO_INLINE")
-expect class EphemeralSignerConfiguration internal constructor(): SignerConfiguration
+expect class EphemeralSignerConfiguration(): SignerConfiguration
 
 /**
  * An ephemeral keypair, not stored in any kind of persistent storage.

--- a/supreme/src/commonMain/kotlin/at/asitplus/signum/supreme/sign/Signer.kt
+++ b/supreme/src/commonMain/kotlin/at/asitplus/signum/supreme/sign/Signer.kt
@@ -20,10 +20,10 @@ import com.ionspin.kotlin.bignum.integer.BigInteger
  * @see ec
  * @see rsa
  */
-open class SigningKeyConfiguration internal constructor() : DSL.Data() {
+open class SigningKeyConfiguration() : DSL.Data() {
     sealed class AlgorithmSpecific : DSL.Data()
 
-    internal val _algSpecific = subclassOf<AlgorithmSpecific>(default = ECConfiguration())
+    protected val _algSpecific = subclassOf<AlgorithmSpecific>(default = ECConfiguration())
 
     /** Generates an elliptic-curve key. */
     open val ec = _algSpecific.option(::ECConfiguration)
@@ -31,7 +31,7 @@ open class SigningKeyConfiguration internal constructor() : DSL.Data() {
     /** Generates an RSA key. */
     open val rsa = _algSpecific.option(::RSAConfiguration)
 
-    open class ECConfiguration internal constructor() : AlgorithmSpecific() {
+    open class ECConfiguration() : AlgorithmSpecific() {
         /** The [ECCurve] on which to generate the key. Defaults to [P-256][ECCurve.SECP_256_R_1] */
         var curve: ECCurve = ECCurve.SECP_256_R_1
 
@@ -42,7 +42,7 @@ open class SigningKeyConfiguration internal constructor() : DSL.Data() {
             set(v) { _digests = v }
     }
 
-    open class RSAConfiguration internal constructor() : AlgorithmSpecific() {
+    open class RSAConfiguration() : AlgorithmSpecific() {
         companion object {
             val F0 = BigInteger(3);
             val F4 = BigInteger(65537)

--- a/supreme/src/commonMain/kotlin/at/asitplus/signum/supreme/sign/Verifier.kt
+++ b/supreme/src/commonMain/kotlin/at/asitplus/signum/supreme/sign/Verifier.kt
@@ -54,7 +54,7 @@ sealed interface Verifier {
 fun Verifier.verify(data: ByteArray, sig: CryptoSignature) =
     verify(SignatureInput(data), sig)
 
-expect class PlatformVerifierConfiguration internal constructor(): DSL.Data
+expect class PlatformVerifierConfiguration(): DSL.Data
 typealias ConfigurePlatformVerifier = DSLConfigureFn<PlatformVerifierConfiguration>
 
 /** A distinguishing interface for verifiers that delegate to the underlying platform (JCA, CryptoKit, ...) */

--- a/supreme/src/commonTest/kotlin/at/asitplus/signum/supreme/dsl/DSLInheritanceDemonstration.kt
+++ b/supreme/src/commonTest/kotlin/at/asitplus/signum/supreme/dsl/DSLInheritanceDemonstration.kt
@@ -5,10 +5,10 @@ import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
 
 /* All options classes need to inherit from DSL.Data; it is also annotated with a DSL marker */
-private open class GenericOptions internal constructor(): DSL.Data() {
+private open class GenericOptions(): DSL.Data() {
     var genericSimpleValue: String = "default value"
 
-    open class GenericSubOptions internal constructor(): DSL.Data() {
+    open class GenericSubOptions(): DSL.Data() {
         var genericSubValue: Int = 42
     }
     /* expose GenericSubOptions as a nested DSL child */
@@ -16,13 +16,13 @@ private open class GenericOptions internal constructor(): DSL.Data() {
 }
 
 /* This is a more specific version of GenericOptions */
-private class SpecificOptions internal constructor(): GenericOptions() {
+private class SpecificOptions(): GenericOptions() {
     init {
         genericSimpleValue = "overridden default value"
     }
     var specificSimpleValue: String = "another default value"
 
-    class SpecificSubOptions internal constructor(): GenericSubOptions() {
+    class SpecificSubOptions(): GenericSubOptions() {
         var anotherSpecificSubValue: String? = null
     }
     /* this shadows the subValue member on the superclass with a more specific version */

--- a/supreme/src/commonTest/kotlin/at/asitplus/signum/supreme/dsl/DSLVarianceDemonstration.kt
+++ b/supreme/src/commonTest/kotlin/at/asitplus/signum/supreme/dsl/DSLVarianceDemonstration.kt
@@ -9,16 +9,16 @@ private enum class Preparation { SHAKEN, STIRRED; }
 private class Settings: DSL.Data() {
     /* we want you to choose a particular kind of smoothie flavor with particular parameters... */
     sealed class SmoothieFlavor constructor(): DSL.Data()
-    class BananaFlavor internal constructor(): SmoothieFlavor() {
+    class BananaFlavor(): SmoothieFlavor() {
         var preparation = Preparation.STIRRED
     }
-    class StrawberryFlavor internal constructor(): SmoothieFlavor() {
+    class StrawberryFlavor(): SmoothieFlavor() {
         var nBerries = 5
     }
     /* we define a holder that can hold any flavor */
     /* "internal" because the generic accessor shouldn't be visible to users */
     /* this is null by default; a default could be explicitly specified, making this non-nullable */
-    internal val _flavor = subclassOf<SmoothieFlavor>()
+    protected val _flavor = subclassOf<SmoothieFlavor>()
     /* and then we define user-visible accessors for the different flavors */
     val banana = _flavor.option(::BananaFlavor)
     val strawberry = _flavor.option(::StrawberryFlavor)
@@ -54,9 +54,9 @@ open class DSLVarianceDemonstration : FreeSpec({
 private fun doWithConfiguration(configure: (Settings.()->Unit)? = null) {
     val config = DSL.resolve(::Settings, configure)
 
-    // we can access the result through the generic accessor
+    // we can access the result through any accessor
     // non-null was checked in the validator already
-    when (val flavor = config._flavor.v!!) {
+    when (val flavor = config.banana.v!!) {
         is Settings.BananaFlavor -> {
             flavor.preparation shouldBe Preparation.SHAKEN
         }

--- a/supreme/src/iosMain/kotlin/at/asitplus/signum/supreme/sign/EphemeralKeysImpl.kt
+++ b/supreme/src/iosMain/kotlin/at/asitplus/signum/supreme/sign/EphemeralKeysImpl.kt
@@ -11,8 +11,8 @@ import platform.CoreFoundation.CFRelease
 import platform.Foundation.NSData
 import platform.Security.*
 
-actual class EphemeralSigningKeyConfiguration internal actual constructor() : EphemeralSigningKeyConfigurationBase()
-actual class EphemeralSignerConfiguration internal actual constructor() : EphemeralSignerConfigurationBase()
+actual class EphemeralSigningKeyConfiguration actual constructor() : EphemeralSigningKeyConfigurationBase()
+actual class EphemeralSignerConfiguration actual constructor() : EphemeralSignerConfigurationBase()
 
 internal fun performKeyAgreement(privateKey: SecKeyRef?, publicValue: KeyAgreementPublicValue.ECDH) =
     corecall {
@@ -84,7 +84,7 @@ internal sealed interface IosEphemeralKey {
 internal actual fun makeEphemeralKey(configuration: EphemeralSigningKeyConfiguration): EphemeralKey {
     memScoped {
         val attr = createCFDictionary {
-            when (val alg = configuration._algSpecific.v) {
+            when (val alg = configuration.ec.v) {
                 is SigningKeyConfiguration.ECConfiguration -> {
                     kSecAttrKeyType mapsTo kSecAttrKeyTypeEC
                     kSecAttrKeySizeInBits mapsTo alg.curve.coordinateLength.bits.toInt()
@@ -108,7 +108,7 @@ internal actual fun makeEphemeralKey(configuration: EphemeralSigningKeyConfigura
             }
         }.takeFromCF<NSData>().toByteArray()
 
-        return when (val alg = configuration._algSpecific.v) {
+        return when (val alg = configuration.ec.v) {
             is SigningKeyConfiguration.ECConfiguration ->
                 IosEphemeralKey.EC(
                     privateKey,

--- a/supreme/src/iosMain/kotlin/at/asitplus/signum/supreme/sign/VerifierImpl.kt
+++ b/supreme/src/iosMain/kotlin/at/asitplus/signum/supreme/sign/VerifierImpl.kt
@@ -13,7 +13,7 @@ import platform.Security.errSecVerifyFailed
 /**
  * Configures iOS-specific properties.
  */
-actual class PlatformVerifierConfiguration internal actual constructor() : DSL.Data()
+actual class PlatformVerifierConfiguration actual constructor() : DSL.Data()
 
 @Throws(UnsupportedCryptoException::class)
 internal actual fun checkAlgorithmKeyCombinationSupportedByECDSAPlatformVerifier

--- a/supreme/src/jvmMain/kotlin/at/asitplus/signum/supreme/sign/EphemeralKeysImpl.kt
+++ b/supreme/src/jvmMain/kotlin/at/asitplus/signum/supreme/sign/EphemeralKeysImpl.kt
@@ -14,13 +14,13 @@ import java.security.spec.ECGenParameterSpec
 import java.security.spec.RSAKeyGenParameterSpec
 import javax.crypto.KeyAgreement
 
-actual class EphemeralSigningKeyConfiguration internal actual constructor(): EphemeralSigningKeyConfigurationBase() {
+actual class EphemeralSigningKeyConfiguration actual constructor(): EphemeralSigningKeyConfigurationBase() {
     var provider: String? = null
 }
 interface JvmEphemeralSignerCompatibleConfiguration {
     var provider: String?
 }
-actual class EphemeralSignerConfiguration internal actual constructor(): EphemeralSignerConfigurationBase(), JvmEphemeralSignerCompatibleConfiguration {
+actual class EphemeralSignerConfiguration actual constructor(): EphemeralSignerConfigurationBase(), JvmEphemeralSignerCompatibleConfiguration {
     override var provider: String? = null
 }
 
@@ -101,7 +101,7 @@ internal sealed interface JVMEphemeralKey {
 }
 
 internal actual fun makeEphemeralKey(configuration: EphemeralSigningKeyConfiguration) : EphemeralKey =
-    when (val alg = configuration._algSpecific.v) {
+    when (val alg = configuration.ec.v) {
         is SigningKeyConfiguration.ECConfiguration -> {
             getKPGInstance("EC", configuration.provider).run {
                 initialize(ECGenParameterSpec(alg.curve.jcaName))

--- a/supreme/src/jvmMain/kotlin/at/asitplus/signum/supreme/sign/VerifierImpl.kt
+++ b/supreme/src/jvmMain/kotlin/at/asitplus/signum/supreme/sign/VerifierImpl.kt
@@ -17,7 +17,7 @@ import java.security.Signature
  * Configures JVM-specific properties.
  * @see provider
  */
-actual class PlatformVerifierConfiguration internal actual constructor() : DSL.Data() {
+actual class PlatformVerifierConfiguration actual constructor() : DSL.Data() {
     /** The JCA provider to use, or none. */
     var provider: String? = null
 }


### PR DESCRIPTION
`PlatformSigningProvider` should require `PlatformSigningKeyConfigurationBase`, but `SigningProvider` should only require `SigningProviderSigningKeyConfigurationBase`.