### PR TITLE
Release 3.16.3 / 0.8.3 indispensable-only Hotfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## 3.0
 
+### 3.16.3 / 0.8.3 indispensable-only Hotfix
+* More targets:
+    * watchosSimulatorArm64
+    * watchosX64
+    * watchosArm32
+    * watchosArm64
+    * androidNativeX64
+    * androidNativeX86
+    * androidNativeArm32
+    * androidNativeArm64
+* Drop OKIO dependency from `indispensable-josef` which was only ever used for to compute a SHA-256 thumbprint and replace it by a pure kotlin SHA-256 implementation
+
+
 ### 3.16.2 / 0.8.3 Supreme-Only Hotfix
 * Set minimum iOS version to 15
 * Fix Swift compat linker errors

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## 3.0
 
 ### 3.16.3 / 0.8.3 indispensable-only Hotfix
+* Fix erroneous Base64URL encoding in JOSE data classes
+    * `toString()` of `X509Certificate` and `TbsCertificate` have also been adapted to use Base64 Strict
+* Add missing serializers in addition to Base64Url encoding:
+    * `X509CertificateBase64Serializer`
+    * `CertificateChainBase64Serializer`
 * More targets:
     * watchosSimulatorArm64
     * watchosX64

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ action!
 * Exposes Multibase Encoder/Decoder as an API dependency including [Matthew Nelson's smashing Base16, Base32, and Base64 encoders](https://github.com/05nelsonm/encoding)
 * **ASN.1 Parser and Encoder including a DSL to generate ASN.1 structures**
   * Parse, create, explore certificates, public keys, CSRs, and **arbitrary ASN.1* structures* on all supported platforms
-  * Powerful, expressive, type-safe ASN.1 DSL on all KMP targets except `watchosDeviceArm64`!
+  * Powerful, expressive, type-safe ASN.1 DSL on all KMP targets
 
 This last bit means that you can share ASN.1-related logic across platforms.
 The very first bit means that you can create and verify signatures on the JVM, Android and on iOS, using platform-native

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ action!
 * Exposes Multibase Encoder/Decoder as an API dependency including [Matthew Nelson's smashing Base16, Base32, and Base64 encoders](https://github.com/05nelsonm/encoding)
 * **ASN.1 Parser and Encoder including a DSL to generate ASN.1 structures**
   * Parse, create, explore certificates, public keys, CSRs, and **arbitrary ASN.1* structures* on all supported platforms
-  * Powerful, expressive, type-safe ASN.1 DSL on all KMP targets!
+  * Powerful, expressive, type-safe ASN.1 DSL on all KMP targets except `watchosDeviceArm64`!
 
 This last bit means that you can share ASN.1-related logic across platforms.
 The very first bit means that you can create and verify signatures on the JVM, Android and on iOS, using platform-native

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -45,7 +45,7 @@ types and platform-native functionality related to crypto and PKI applications:
   including [Matthew Nelson's smashing Base16, Base32, and Base64 encoders](https://github.com/05nelsonm/encoding)
 * **ASN.1 Parser and Encoder including a DSL to generate ASN.1 structures**
     * Parse, create, explore certificates, public keys, CSRs, and **arbitrary ASN.1* structures* on all supported platforms
-    * Powerful, expressive, type-safe ASN.1 DSL on all KMP targets!
+    * Powerful, expressive, type-safe ASN.1 DSL on all KMP targets except `watchosDeviceArm64`!
     * Parse, create, explore certificates, public keys, CSRs, and **arbitrary ASN.1* structures* on all supported platforms
 
 This last bit means that you can share ASN.1-related logic across platforms.

--- a/docs/docs/indispensable-asn1.md
+++ b/docs/docs/indispensable-asn1.md
@@ -22,7 +22,7 @@ This in short, you can work with arbitrary ASN.1 structures anywhere!
 
 ## Using it in your Projects
 
-This library was built for [Kotlin Multiplatform](https://kotlinlang.org/docs/multiplatform.html). Currently, it supports all KMP targets except `watchosDeviceArm64`.
+This library was built for [Kotlin Multiplatform](https://kotlinlang.org/docs/multiplatform.html). Currently, it supports all KMP targets.
 
 Simply declare the desired dependency to get going:
 

--- a/docs/docs/indispensable-asn1.md
+++ b/docs/docs/indispensable-asn1.md
@@ -22,8 +22,7 @@ This in short, you can work with arbitrary ASN.1 structures anywhere!
 
 ## Using it in your Projects
 
-This library was built for [Kotlin Multiplatform](https://kotlinlang.org/docs/multiplatform.html). Currently, it targets
-the JVM, Android and iOS.
+This library was built for [Kotlin Multiplatform](https://kotlinlang.org/docs/multiplatform.html). Currently, it supports all KMP targets except `watchosDeviceArm64`.
 
 Simply declare the desired dependency to get going:
 

--- a/docs/docs/indispensable-cosef.md
+++ b/docs/docs/indispensable-cosef.md
@@ -19,8 +19,7 @@ The preconfigured serializer ensuring compliant serialization of all COSE-relate
 
 ## Using it in your Projects
 
-This library was built for [Kotlin Multiplatform](https://kotlinlang.org/docs/multiplatform.html). Currently, it targets
-the JVM, Android and iOS.
+This library was built for [Kotlin Multiplatform](https://kotlinlang.org/docs/multiplatform.html). Currently, it supports all KMP targets except `watchosDeviceArm64`.
 
 Simply declare the desired dependency to get going:
 

--- a/docs/docs/indispensable-josef.md
+++ b/docs/docs/indispensable-josef.md
@@ -18,8 +18,7 @@ The preconfigured serializer ensuring compliant serialization of all JOSE-relate
 
 ## Using it in your Projects
 
-This library was built for [Kotlin Multiplatform](https://kotlinlang.org/docs/multiplatform.html). Currently, it targets
-the JVM, Android and iOS.
+This library was built for [Kotlin Multiplatform](https://kotlinlang.org/docs/multiplatform.html). Currently, it supports all KMP targets except `watchosDeviceArm64`.
 
 Simply declare the desired dependency to get going:
 

--- a/docs/docs/indispensable.md
+++ b/docs/docs/indispensable.md
@@ -26,7 +26,7 @@ types and functionality related to crypto and PKI applications:
 * Exposes Multibase Encoder/Decoder as an API dependency
   including [Matthew Nelson's smashing Base16, Base32, and Base64 encoders](https://github.com/05nelsonm/encoding)
 
-In effect, you can work with X509 Certificates, public keys, CSRs and arbitrary ASN.1 structures on the JVM, Android, and iOS.
+In effect, you can work with X509 Certificates, public keys, CSRs and arbitrary ASN.1 structures on all KMP targets except `watchosDeviceArm64`!
 
 !!! tip
     **Do check out the full API docs [here](dokka/indispensable/index.html)**!

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ kotlin.code.style=official
 kotlin.js.compiler=ir
 org.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8
 
-artifactVersion=3.16.2
+artifactVersion=3.16.3
 supremeVersion=0.8.3
 
 # This is not a well-defined property, the ASP convention plugin respects it, though

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,16 +1,15 @@
 [versions]
 core = "1.5.0"
 kotlinxIoCore = "0.5.4"
-multibase = "1.2.1"
+multibase = "1.2.2"
 kotestExtensionsAndroid = "0.1.3"
 kotestRunnerAndroid = "1.1.1"
-okio = "3.9.0"
 bignum = "0.3.10"
 jose = "9.31"
 kotlinpoet = "1.16.0"
 runner = "1.5.2"
 secureRandom = "0.3.2"
-kmmresult= "1.9.2"
+kmmresult = "1.9.3"
 
 [libraries]
 bignum = { group = "com.ionspin.kotlin", name = "bignum", version.ref = "bignum" }
@@ -18,7 +17,6 @@ core = { module = "androidx.test:core", version.ref = "core" }
 kotest-extensions-android = { module = "br.com.colman:kotest-extensions-android", version.ref = "kotestExtensionsAndroid" }
 kotest-runner-android = { module = "br.com.colman:kotest-runner-android", version.ref = "kotestRunnerAndroid" }
 kotlinx-io-core = { module = "org.jetbrains.kotlinx:kotlinx-io-core", version.ref = "kotlinxIoCore" }
-okio = { group = "com.squareup.okio", name = "okio", version.ref = "okio" }
 jose = { group = "com.nimbusds", name = "nimbus-jose-jwt", version.ref = "jose" }
 kotlinpoet = { group = "com.squareup", name = "kotlinpoet", version.ref = "kotlinpoet" }
 rules = { module = "androidx.test:rules", version.ref = "core" }

--- a/indispensable-asn1/build.gradle.kts
+++ b/indispensable-asn1/build.gradle.kts
@@ -170,6 +170,17 @@ kotlin {
     iosX64()
     iosArm64()
     iosSimulatorArm64()
+    watchosSimulatorArm64()
+    watchosX64()
+    watchosArm32()
+    watchosArm64()
+    tvosSimulatorArm64()
+    tvosX64()
+    tvosArm64()
+    androidNativeX64()
+    androidNativeX86()
+    androidNativeArm32()
+    androidNativeArm64()
 
     listOf(
         js(IR).apply { browser { testTask { enabled = false } } },

--- a/indispensable-asn1/build.gradle.kts
+++ b/indispensable-asn1/build.gradle.kts
@@ -174,6 +174,7 @@ kotlin {
     watchosX64()
     watchosArm32()
     watchosArm64()
+    watchosDeviceArm64()
     tvosSimulatorArm64()
     tvosX64()
     tvosArm64()
@@ -216,7 +217,7 @@ kotlin {
         commonTest {
             dependencies {
                 implementation(kotest("property"))
-                implementation(project(":indispensable"))
+            //TMP commented out just for release    implementation(project(":indispensable"))
             }
         }
     }

--- a/indispensable-asn1/build.gradle.kts
+++ b/indispensable-asn1/build.gradle.kts
@@ -174,7 +174,7 @@ kotlin {
     watchosX64()
     watchosArm32()
     watchosArm64()
-    watchosDeviceArm64()
+    //watchosDeviceArm64() //TODO for release: enable this target
     tvosSimulatorArm64()
     tvosX64()
     tvosArm64()
@@ -217,7 +217,7 @@ kotlin {
         commonTest {
             dependencies {
                 implementation(kotest("property"))
-            //TMP commented out just for release    implementation(project(":indispensable"))
+               implementation(project(":indispensable")) //TODO for releases comment out this dependency
             }
         }
     }

--- a/indispensable-cosef/build.gradle.kts
+++ b/indispensable-cosef/build.gradle.kts
@@ -23,6 +23,17 @@ kotlin {
     iosX64()
     iosArm64()
     iosSimulatorArm64()
+    watchosSimulatorArm64()
+    watchosX64()
+    watchosArm32()
+    watchosArm64()
+    tvosSimulatorArm64()
+    tvosX64()
+    tvosArm64()
+    androidNativeX64()
+    androidNativeX86()
+    androidNativeArm32()
+    androidNativeArm64()
 
     listOf(
         js(IR).apply { browser { testTask { enabled = false } } },

--- a/indispensable-josef/build.gradle.kts
+++ b/indispensable-josef/build.gradle.kts
@@ -23,6 +23,17 @@ kotlin {
     iosX64()
     iosArm64()
     iosSimulatorArm64()
+    watchosSimulatorArm64()
+    watchosX64()
+    watchosArm32()
+    watchosArm64()
+    tvosSimulatorArm64()
+    tvosX64()
+    tvosArm64()
+    androidNativeX64()
+    androidNativeX86()
+    androidNativeArm32()
+    androidNativeArm64()
 
     listOf(
         js(IR).apply { browser { testTask { enabled = false } } },
@@ -44,7 +55,6 @@ kotlin {
             dependencies {
                 api(project(":indispensable"))
                 implementation(project(":internals"))
-                implementation(libs.okio)
                 api(libs.multibase)
                 implementation(libs.bignum) //Intellij bug work-around
             }

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JsonWebKey.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JsonWebKey.kt
@@ -15,6 +15,7 @@ import at.asitplus.signum.indispensable.io.ByteArrayBase64UrlSerializer
 import at.asitplus.signum.indispensable.io.CertificateChainBase64UrlSerializer
 import at.asitplus.signum.indispensable.josef.io.JwsCertificateSerializer
 import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
+import at.asitplus.signum.indispensable.josef.io.sha256
 import at.asitplus.signum.indispensable.pki.CertificateChain
 import at.asitplus.signum.indispensable.symmetric.*
 import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
@@ -22,7 +23,6 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.UseSerializers
 import kotlinx.serialization.json.Json
-import okio.ByteString.Companion.toByteString
 
 /**
  * JSON Web Key as per [RFC 7517](https://datatracker.ietf.org/doc/html/rfc7517#section-4).
@@ -196,7 +196,7 @@ data class JsonWebKey(
     val jwkThumbprint: String by lazy {
         val jsonEncoded = Json.encodeToString(this.toMinimalJsonWebKey().getOrNull() ?: this)
         val thumbprint = jsonEncoded
-            .encodeToByteArray().toByteString().sha256().toByteArray().encodeToString(Base64UrlStrict)
+            .encodeToByteArray().sha256().encodeToString(Base64UrlStrict)
         "urn:ietf:params:oauth:jwk-thumbprint:sha256:${thumbprint}"
     }
 

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JsonWebKey.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JsonWebKey.kt
@@ -12,7 +12,7 @@ import at.asitplus.signum.indispensable.SpecializedCryptoPublicKey
 import at.asitplus.signum.indispensable.asn1.Asn1Integer
 import at.asitplus.signum.indispensable.io.Base64UrlStrict
 import at.asitplus.signum.indispensable.io.ByteArrayBase64UrlSerializer
-import at.asitplus.signum.indispensable.io.CertificateChainBase64UrlSerializer
+import at.asitplus.signum.indispensable.io.CertificateChainBase64Serializer
 import at.asitplus.signum.indispensable.josef.io.JwsCertificateSerializer
 import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
 import at.asitplus.signum.indispensable.josef.io.sha256
@@ -136,7 +136,7 @@ data class JsonWebKey(
      * OPTIONAL.
      */
     @SerialName("x5c")
-    @Serializable(with = CertificateChainBase64UrlSerializer::class)
+    @Serializable(with = CertificateChainBase64Serializer::class)
     val certificateChain: CertificateChain? = null,
 
     /**

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JweHeader.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JweHeader.kt
@@ -2,7 +2,7 @@ package at.asitplus.signum.indispensable.josef
 
 import at.asitplus.catching
 import at.asitplus.signum.indispensable.io.ByteArrayBase64UrlSerializer
-import at.asitplus.signum.indispensable.io.CertificateChainBase64UrlSerializer
+import at.asitplus.signum.indispensable.io.CertificateChainBase64Serializer
 import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
 import at.asitplus.signum.indispensable.pki.CertificateChain
 import kotlinx.serialization.SerialName
@@ -181,7 +181,7 @@ data class JweHeader(
      * See [JwsHeader.certificateChain]
      */
     @SerialName("x5c")
-    @Serializable(with = CertificateChainBase64UrlSerializer::class)
+    @Serializable(with = CertificateChainBase64Serializer::class)
     val certificateChain: CertificateChain? = null,
 
     /**

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsHeader.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsHeader.kt
@@ -6,7 +6,7 @@ import at.asitplus.catching
 import at.asitplus.signum.indispensable.CryptoPublicKey
 import at.asitplus.signum.indispensable.io.ByteArrayBase64Serializer
 import at.asitplus.signum.indispensable.io.ByteArrayBase64UrlSerializer
-import at.asitplus.signum.indispensable.io.CertificateChainBase64UrlSerializer
+import at.asitplus.signum.indispensable.io.CertificateChainBase64Serializer
 import at.asitplus.signum.indispensable.josef.io.InstantLongSerializer
 import at.asitplus.signum.indispensable.josef.io.JwsCertificateSerializer
 import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
@@ -101,7 +101,7 @@ data class JwsHeader(
      * failure occurs.  Use of this Header Parameter is OPTIONAL.
      */
     @SerialName("x5c")
-    @Serializable(with = CertificateChainBase64UrlSerializer::class)
+    @Serializable(with = CertificateChainBase64Serializer::class)
     val certificateChain: CertificateChain? = null,
 
     /**

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/io/sha256.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/io/sha256.kt
@@ -1,0 +1,168 @@
+//public domain code copied and slightly adapted from https://github.com/asyncant/sha256-kt/blob/master/src/commonMain/kotlin/com/asyncant/crypto/Sha256.kt to get rid of okio dependency
+/* *******************************************************************************************************************
+ * SHA-256 hash algorithm implementation.
+ *
+ * Original C implementation by Brad Conte (brad@bradconte.com), https://github.com/B-Con/crypto-algorithms.
+ * Ported to Kotlin and modified by asyncant.
+ *
+ * Like the original C implementation, this code is released into the public domain.
+ *
+ * ***************************************************************************************************************** */
+package at.asitplus.signum.indispensable.josef.io
+
+internal fun ByteArray.sha256(): ByteArray {
+    val ctx = Sha256Ctx()
+    sha256Update(ctx, this)
+    return sha256Final(ctx)
+}
+
+private val k = longArrayOf(
+    0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+    0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+    0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+    0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+    0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+    0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+    0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+    0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2
+).map { it.toInt() }.toIntArray()
+
+private class Sha256Ctx {
+    var data: ByteArray = ByteArray(64)
+    var state: IntArray = IntArray(8)
+    var dataLength: Int = 0
+    var bitLength: Long = 0
+
+    init {
+        state[0] = 0x6a09e667
+        state[1] = 0xbb67ae85.toInt()
+        state[2] = 0x3c6ef372
+        state[3] = 0xa54ff53a.toInt()
+        state[4] = 0x510e527f
+        state[5] = 0x9b05688c.toInt()
+        state[6] = 0x1f83d9ab
+        state[7] = 0x5be0cd19
+    }
+}
+
+private fun sha256Transform(ctx: Sha256Ctx, data: ByteArray, offset: Int) {
+    var a: Int
+    var b: Int
+    var c: Int
+    var d: Int
+    var e: Int
+    var f: Int
+    var g: Int
+    var h: Int
+    var t1: Int
+    var t2: Int
+    val m = IntArray(64)
+
+    for (i in 0 until 16) {
+        val j = offset + i * 4
+        m[i] = ((data[j].toInt() and 0xFF shl 24) or
+                (data[j + 1].toInt() and 0xFF shl 16) or
+                (data[j + 2].toInt() and 0xFF shl 8) or
+                (data[j + 3].toInt() and 0xFF))
+    }
+
+    for (i in 16 until 64) {
+        m[i] = sig1(m[i - 2]) + m[i - 7] + sig0(m[i - 15]) + m[i - 16]
+    }
+    a = ctx.state[0]
+    b = ctx.state[1]
+    c = ctx.state[2]
+    d = ctx.state[3]
+    e = ctx.state[4]
+    f = ctx.state[5]
+    g = ctx.state[6]
+    h = ctx.state[7]
+
+    for (i in 0 until 64) {
+        t1 = h + ep1(e) + ch(e, f, g) + k[i] + m[i]
+        t2 = ep0(a) + maj(a, b, c)
+        h = g
+        g = f
+        f = e
+        e = d + t1
+        d = c
+        c = b
+        b = a
+        a = t1 + t2
+    }
+
+    ctx.state[0] += a
+    ctx.state[1] += b
+    ctx.state[2] += c
+    ctx.state[3] += d
+    ctx.state[4] += e
+    ctx.state[5] += f
+    ctx.state[6] += g
+    ctx.state[7] += h
+}
+
+private fun sha256Update(ctx: Sha256Ctx, data: ByteArray) {
+    val total = data.size - 64
+    for (i in 0..total step 64) {
+        sha256Transform(ctx, data, i)
+        ctx.bitLength += 512
+    }
+    ctx.dataLength = data.size % 64
+    val offset = (data.size / 64) * 64
+    for (i in 0 until ctx.dataLength) ctx.data[i] = data[offset + i]
+}
+
+private fun sha256Final(ctx: Sha256Ctx): ByteArray {
+    // Pad whatever data is left in the buffer.
+    if (ctx.dataLength < 56) {
+        ctx.data[ctx.dataLength] = 0x80.toByte()
+        for (i in ctx.dataLength + 1 until 56) ctx.data[i] = 0
+    } else {
+        ctx.data[ctx.dataLength] = 0x80.toByte()
+        for (i in ctx.dataLength + 1 until 64) ctx.data[i] = 0
+        sha256Transform(ctx, ctx.data, 0)
+        for (i in 0 until 56) ctx.data[i] = 0
+    }
+
+    // Append to the padding the total message's length in bits and transform.
+    ctx.bitLength += ctx.dataLength * 8
+    ctx.data[63] = (ctx.bitLength and 0xFF).toByte()
+    ctx.data[62] = ((ctx.bitLength ushr 8) and 0xFF).toByte()
+    ctx.data[61] = ((ctx.bitLength ushr 16) and 0xFF).toByte()
+    ctx.data[60] = ((ctx.bitLength ushr 24) and 0xFF).toByte()
+    ctx.data[59] = ((ctx.bitLength ushr 32) and 0xFF).toByte()
+    ctx.data[58] = ((ctx.bitLength ushr 40) and 0xFF).toByte()
+    ctx.data[57] = ((ctx.bitLength ushr 48) and 0xFF).toByte()
+    ctx.data[56] = ((ctx.bitLength ushr 56) and 0xFF).toByte()
+    sha256Transform(ctx, ctx.data, 0)
+
+    // Since this implementation uses little endian byte ordering and SHA uses big endian,
+    // reverse all the bytes when copying the final state to the output hash.
+    val hash = ByteArray(32)
+
+    for (i in 0 until 4) {
+        hash[i] = ((ctx.state[0] ushr (24 - i * 8)) and 0xFF).toByte()
+        hash[i + 4] = ((ctx.state[1] ushr (24 - i * 8)) and 0xFF).toByte()
+        hash[i + 8] = ((ctx.state[2] ushr (24 - i * 8)) and 0xFF).toByte()
+        hash[i + 12] = ((ctx.state[3] ushr (24 - i * 8)) and 0xFF).toByte()
+        hash[i + 16] = ((ctx.state[4] ushr (24 - i * 8)) and 0xFF).toByte()
+        hash[i + 20] = ((ctx.state[5] ushr (24 - i * 8)) and 0xFF).toByte()
+        hash[i + 24] = ((ctx.state[6] ushr (24 - i * 8)) and 0xFF).toByte()
+        hash[i + 28] = ((ctx.state[7] ushr (24 - i * 8)) and 0xFF).toByte()
+    }
+    return hash
+}
+
+private fun maj(x: Int, y: Int, z: Int) = (x and y) xor (x and z) xor (y and z)
+
+private fun ep0(x: Int) = rotateRight(x, 2) xor rotateRight(x, 13) xor rotateRight(x, 22)
+
+private fun ch(x: Int, y: Int, z: Int) = (x and y) xor (x.inv() and z)
+
+private fun ep1(x: Int) = rotateRight(x, 6) xor rotateRight(x, 11) xor rotateRight(x, 25)
+
+private fun sig0(x: Int) = rotateRight(x, 7) xor rotateRight(x, 18) xor (x ushr 3)
+
+private fun sig1(x: Int) = rotateRight(x, 17) xor rotateRight(x, 19) xor (x ushr 10)
+
+private fun rotateRight(a: Int, b: Int) = a ushr b or (a shl (32 - b))

--- a/indispensable-josef/src/commonTest/kotlin/at/asitplus/signum/indispensable/josef/Sha256Test.kt
+++ b/indispensable-josef/src/commonTest/kotlin/at/asitplus/signum/indispensable/josef/Sha256Test.kt
@@ -1,0 +1,38 @@
+//adapted from this public domain code: https://github.com/asyncant/sha256-kt/blob/master/src/commonTest/kotlin/com/asyncant/crypto/sha256JvmTest.kt
+package at.asitplus.signum.indispensable.josef
+
+import at.asitplus.signum.indispensable.josef.io.sha256
+import io.kotest.core.spec.style.FreeSpec
+import io.kotest.matchers.shouldBe
+
+
+/** Origin: https://www.di-mgt.com.au/sha_testvectors.html */
+class Sha256Test : FreeSpec({
+
+    "Testvectors" {
+        val emptyStringHash = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        byteArrayOf().sha256().toHexString() shouldBe emptyStringHash
+
+        val abcHash = "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        "abc".encodeToByteArray().sha256().toHexString() shouldBe abcHash
+
+        val abc448BitsHash = "248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1"
+
+        "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq".encodeToByteArray().sha256().toHexString() shouldBe
+                abc448BitsHash
+
+
+        val abc896BitsHash = "cf5b16a778af8380036ce59e7b0492370b249b11e8f07a51afac45037afee9d1"
+        val abc896Bits =
+            "abcdefghbcdefghicdefghijdefghijkefghijklfghijklmghijklmnhijklmnoijklmnopjklmnopqklmnopqrlmnopqr" +
+                    "smnopqrstnopqrstu"
+
+        abc896BitsHash shouldBe
+                abc896Bits.encodeToByteArray().sha256().toHexString()
+        val aOneMillionHash = "cdc76e5c9914fb9281a1c7e284d73e67f1809a48a497200e046d39ccc7112cd0"
+        "a".repeat(1000000).encodeToByteArray().sha256().toHexString() shouldBe aOneMillionHash
+
+    }
+})
+
+internal fun ByteArray.toHexString() = fold("") { str, it -> str + (0xFF and it.toInt()).toString(16).padStart(2, '0') }

--- a/indispensable/build.gradle.kts
+++ b/indispensable/build.gradle.kts
@@ -34,7 +34,17 @@ kotlin {
     iosX64()
     iosArm64()
     iosSimulatorArm64()
-
+    watchosSimulatorArm64()
+    watchosX64()
+    watchosArm32()
+    watchosArm64()
+    tvosSimulatorArm64()
+    tvosX64()
+    tvosArm64()
+    androidNativeX64()
+    androidNativeX86()
+    androidNativeArm32()
+    androidNativeArm64()
     listOf(
         js(IR).apply { browser { testTask { enabled = false } } },
         @OptIn(ExperimentalWasmDsl::class)

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/io/Encoding.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/io/Encoding.kt
@@ -85,6 +85,13 @@ object X509CertificateBase64UrlSerializer: TransformingSerializerTemplate<X509Ce
     decodeAs = { X509Certificate.decodeFromDer(it) } // workaround iOS compilation bug KT-71498
 )
 
+/** De-/serializes X509Certificate as Base64-encoded String */
+object X509CertificateBase64Serializer: TransformingSerializerTemplate<X509Certificate, ByteArray>(
+    parent = ByteArrayBase64Serializer,
+    encodeAs = X509Certificate::encodeToDer,
+    decodeAs = { X509Certificate.decodeFromDer(it) } // workaround iOS compilation bug KT-71498
+)
+
 /** De-/serializes a public key as a Base64Url-encoded IOS encoding public key */
 object IosPublicKeySerializer: TransformingSerializerTemplate<CryptoPublicKey, ByteArray>(
     parent = ByteArrayBase64UrlSerializer,
@@ -107,5 +114,10 @@ sealed class ListSerializerTemplate<ValueT>(
 
 }
 
+/** De-/serializes X509Certificate as collection of Base64Url-encoded Strings */
 object CertificateChainBase64UrlSerializer: ListSerializerTemplate<X509Certificate>(
     using = X509CertificateBase64UrlSerializer)
+
+/** De-/serializes X509Certificate as collection of Base64-encoded Strings */
+object CertificateChainBase64Serializer: ListSerializerTemplate<X509Certificate>(
+    using = X509CertificateBase64Serializer)

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/pki/X509Certificate.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/pki/X509Certificate.kt
@@ -7,7 +7,6 @@ import at.asitplus.signum.indispensable.X509SignatureAlgorithm
 import at.asitplus.signum.indispensable.asn1.*
 import at.asitplus.signum.indispensable.asn1.encoding.*
 import at.asitplus.signum.indispensable.io.Base64Strict
-import at.asitplus.signum.indispensable.io.Base64UrlStrict
 import at.asitplus.signum.indispensable.io.TransformingSerializerTemplate
 import at.asitplus.signum.indispensable.pki.AlternativeNames.Companion.findIssuerAltNames
 import at.asitplus.signum.indispensable.pki.AlternativeNames.Companion.findSubjectAltNames
@@ -135,8 +134,11 @@ constructor(
         return result
     }
 
+    /**
+     * Debug String representation. Uses Base64 encoded DER representation
+     */
     override fun toString(): String {
-        return "TbsCertificate(${encodeToDerOrNull()?.let { it.encodeToString(Base64UrlStrict) }})"
+        return "TbsCertificate(${encodeToDerOrNull()?.let { it.encodeToString(Base64Strict) }})"
     }
 
     companion object : Asn1Decodable<Asn1Sequence, TbsCertificate> {
@@ -276,8 +278,11 @@ data class X509Certificate @Throws(IllegalArgumentException::class) constructor(
         return result
     }
 
+    /**
+     * Debug String representation. Uses Base64 encoded DER representation
+     */
     override fun toString(): String {
-        return "X509Certificate(${encodeToDerOrNull()?.let { it.encodeToString(Base64UrlStrict) }})"
+        return "X509Certificate(${encodeToDerOrNull()?.let { it.encodeToString(Base64Strict) }})"
     }
 
     val publicKey: CryptoPublicKey get() = tbsCertificate.publicKey

--- a/internals/build.gradle.kts
+++ b/internals/build.gradle.kts
@@ -31,6 +31,17 @@ kotlin {
     iosX64()
     iosArm64()
     iosSimulatorArm64()
+    watchosSimulatorArm64()
+    watchosX64()
+    watchosArm32()
+    watchosArm64()
+    tvosSimulatorArm64()
+    tvosX64()
+    tvosArm64()
+    androidNativeX64()
+    androidNativeX86()
+    androidNativeArm32()
+    androidNativeArm64()
 
     listOf(
         js(IR).apply { browser { testTask { enabled = false } } },


### PR DESCRIPTION
* More targets for indispensable modules:
    * watchosSimulatorArm64
    * watchosX64
    * watchosArm32
    * watchosArm64
    * androidNativeX64
    * androidNativeX86
    * androidNativeArm32
    * androidNativeArm64
* Drop OKIO dependency from `indispensable-josef` which was only ever used for to compute a SHA-256 thumbprint and replace it by a pure Kotlin SHA-256 implementation
