### PR TITLE
Fix Jose cert serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## 3.0
 
 ### 3.16.3 / 0.8.3 indispensable-only Hotfix
+* Fix erroneous Base64URL encoding in JOSE data classes
+    * `toString()` of `X509Certificate` and `TbsCertificate` have also been adapted to use Base64 Strict
+* Add missing serializers in addition to Base64Url encoding:
+    * `X509CertificateBase64Serializer`
+    * `CertificateChainBase64Serializer`
 * More targets:
     * watchosSimulatorArm64
     * watchosX64

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JsonWebKey.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JsonWebKey.kt
@@ -12,7 +12,7 @@ import at.asitplus.signum.indispensable.SpecializedCryptoPublicKey
 import at.asitplus.signum.indispensable.asn1.Asn1Integer
 import at.asitplus.signum.indispensable.io.Base64UrlStrict
 import at.asitplus.signum.indispensable.io.ByteArrayBase64UrlSerializer
-import at.asitplus.signum.indispensable.io.CertificateChainBase64UrlSerializer
+import at.asitplus.signum.indispensable.io.CertificateChainBase64Serializer
 import at.asitplus.signum.indispensable.josef.io.JwsCertificateSerializer
 import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
 import at.asitplus.signum.indispensable.josef.io.sha256
@@ -136,7 +136,7 @@ data class JsonWebKey(
      * OPTIONAL.
      */
     @SerialName("x5c")
-    @Serializable(with = CertificateChainBase64UrlSerializer::class)
+    @Serializable(with = CertificateChainBase64Serializer::class)
     val certificateChain: CertificateChain? = null,
 
     /**

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JweHeader.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JweHeader.kt
@@ -2,7 +2,7 @@ package at.asitplus.signum.indispensable.josef
 
 import at.asitplus.catching
 import at.asitplus.signum.indispensable.io.ByteArrayBase64UrlSerializer
-import at.asitplus.signum.indispensable.io.CertificateChainBase64UrlSerializer
+import at.asitplus.signum.indispensable.io.CertificateChainBase64Serializer
 import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
 import at.asitplus.signum.indispensable.pki.CertificateChain
 import kotlinx.serialization.SerialName
@@ -181,7 +181,7 @@ data class JweHeader(
      * See [JwsHeader.certificateChain]
      */
     @SerialName("x5c")
-    @Serializable(with = CertificateChainBase64UrlSerializer::class)
+    @Serializable(with = CertificateChainBase64Serializer::class)
     val certificateChain: CertificateChain? = null,
 
     /**

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsHeader.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsHeader.kt
@@ -6,7 +6,7 @@ import at.asitplus.catching
 import at.asitplus.signum.indispensable.CryptoPublicKey
 import at.asitplus.signum.indispensable.io.ByteArrayBase64Serializer
 import at.asitplus.signum.indispensable.io.ByteArrayBase64UrlSerializer
-import at.asitplus.signum.indispensable.io.CertificateChainBase64UrlSerializer
+import at.asitplus.signum.indispensable.io.CertificateChainBase64Serializer
 import at.asitplus.signum.indispensable.josef.io.InstantLongSerializer
 import at.asitplus.signum.indispensable.josef.io.JwsCertificateSerializer
 import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
@@ -101,7 +101,7 @@ data class JwsHeader(
      * failure occurs.  Use of this Header Parameter is OPTIONAL.
      */
     @SerialName("x5c")
-    @Serializable(with = CertificateChainBase64UrlSerializer::class)
+    @Serializable(with = CertificateChainBase64Serializer::class)
     val certificateChain: CertificateChain? = null,
 
     /**

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/io/Encoding.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/io/Encoding.kt
@@ -85,6 +85,13 @@ object X509CertificateBase64UrlSerializer: TransformingSerializerTemplate<X509Ce
     decodeAs = { X509Certificate.decodeFromDer(it) } // workaround iOS compilation bug KT-71498
 )
 
+/** De-/serializes X509Certificate as Base64-encoded String */
+object X509CertificateBase64Serializer: TransformingSerializerTemplate<X509Certificate, ByteArray>(
+    parent = ByteArrayBase64Serializer,
+    encodeAs = X509Certificate::encodeToDer,
+    decodeAs = { X509Certificate.decodeFromDer(it) } // workaround iOS compilation bug KT-71498
+)
+
 /** De-/serializes a public key as a Base64Url-encoded IOS encoding public key */
 object IosPublicKeySerializer: TransformingSerializerTemplate<CryptoPublicKey, ByteArray>(
     parent = ByteArrayBase64UrlSerializer,
@@ -107,5 +114,10 @@ sealed class ListSerializerTemplate<ValueT>(
 
 }
 
+/** De-/serializes X509Certificate as collection of Base64Url-encoded Strings */
 object CertificateChainBase64UrlSerializer: ListSerializerTemplate<X509Certificate>(
     using = X509CertificateBase64UrlSerializer)
+
+/** De-/serializes X509Certificate as collection of Base64-encoded Strings */
+object CertificateChainBase64Serializer: ListSerializerTemplate<X509Certificate>(
+    using = X509CertificateBase64Serializer)

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/pki/X509Certificate.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/pki/X509Certificate.kt
@@ -7,7 +7,6 @@ import at.asitplus.signum.indispensable.X509SignatureAlgorithm
 import at.asitplus.signum.indispensable.asn1.*
 import at.asitplus.signum.indispensable.asn1.encoding.*
 import at.asitplus.signum.indispensable.io.Base64Strict
-import at.asitplus.signum.indispensable.io.Base64UrlStrict
 import at.asitplus.signum.indispensable.io.TransformingSerializerTemplate
 import at.asitplus.signum.indispensable.pki.AlternativeNames.Companion.findIssuerAltNames
 import at.asitplus.signum.indispensable.pki.AlternativeNames.Companion.findSubjectAltNames
@@ -135,8 +134,11 @@ constructor(
         return result
     }
 
+    /**
+     * Debug String representation. Uses Base64 encoded DER representation
+     */
     override fun toString(): String {
-        return "TbsCertificate(${encodeToDerOrNull()?.let { it.encodeToString(Base64UrlStrict) }})"
+        return "TbsCertificate(${encodeToDerOrNull()?.let { it.encodeToString(Base64Strict) }})"
     }
 
     companion object : Asn1Decodable<Asn1Sequence, TbsCertificate> {
@@ -276,8 +278,11 @@ data class X509Certificate @Throws(IllegalArgumentException::class) constructor(
         return result
     }
 
+    /**
+     * Debug String representation. Uses Base64 encoded DER representation
+     */
     override fun toString(): String {
-        return "X509Certificate(${encodeToDerOrNull()?.let { it.encodeToString(Base64UrlStrict) }})"
+        return "X509Certificate(${encodeToDerOrNull()?.let { it.encodeToString(Base64Strict) }})"
     }
 
     val publicKey: CryptoPublicKey get() = tbsCertificate.publicKey


### PR DESCRIPTION
* Fix erroneous Base64URL encoding in JOSE data classes, adding missing serializers in addition to Base64Url encoding:
    * `X509CertificateBase64Serializer`
    * `CertificateChainBase64Serializer`

@tlenz: No other places except for attestation use the base64 url serializer (according to intelliJ). please double-check!
I'll then directly push this into the 3.16.3 release