### PR TITLE
kotlinx.datetime 0.7.1 migration

### DIFF
--- a/.github/workflows/test-apple-ios.yml
+++ b/.github/workflows/test-apple-ios.yml
@@ -1,0 +1,28 @@
+name: Test iOS implementation
+on: [push]
+jobs:
+  build:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: 16.2.0
+      - name: Build klibs
+        run: ./gradlew iosArm64MainKlibrary iosSimulatorArm64MainKlibrary
+      - name: Run tests
+        run: ./gradlew iosSimulatorArm64Test
+      - name: Test Report
+        uses: dorny/test-reporter@v1
+        if: success() || failure()
+        with:
+          name: iOS Tests
+          path: indispensable/build/test-results/**/TEST*.xml,indispensable-asn1/build/test-results/**/TEST*.xml,indispensable-cosef/build/test-results/**/TEST*.xml,indispensable-josef/build/test-results/**/TEST*.xml,supreme/build/test-results/**/TEST*.xml
+          reporter: java-junit

--- a/.github/workflows/test-apple-other.yml
+++ b/.github/workflows/test-apple-other.yml
@@ -1,4 +1,4 @@
-name: Test iOS implementation
+name: Test other Apple implementations
 on: [push]
 jobs:
   build:
@@ -18,7 +18,7 @@ jobs:
       - name: Build klibs
         run: ./gradlew iosArm64MainKlibrary iosSimulatorArm64MainKlibrary
       - name: Run tests
-        run: ./gradlew iosSimulatorArm64Test iosX64Test macosArm64Test macosX64Test tvosX64Test tvosSimulatorArm64Test watchosSimulatorArm64Test watchosX64Test -x :supreme:linkDebugTestIosX64 -x :supreme:iosX64Test
+        run: ./gradlew tvosX64Test tvosSimulatorArm64Test watchosSimulatorArm64Test watchosX64Test iosX64Test macosArm64Test macosX64Test -x :supreme:linkDebugTestIosX64 -x :supreme:iosX64Test
       - name: Test Report
         uses: dorny/test-reporter@v1
         if: success() || failure()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,12 +16,15 @@
     * `SymmetricEncryptionAlgorithm.toJweEncryptionAlgorithm` removed* Dependency Updates:
 * `kotlincrypto:secure-random:0.3.2` -> `kotlincrypto.random:crypto-rand:0.5.0`
     * This fixes key generation in WASM/JS
+* Update to kotlinx.datetime 0.7.1.
+    * This moves Instant and Clock to stdlib
+    * (but introduces typealiases for easier migration)
 * Update to latest conventions plugin:
     * Bouncy Castle 1.81!!
     * Serialization 1.8.1
     * Coroutines 1.10.2
     * Ktor 3.1.2
-    * Datetime 0.6.2
+    * Datetime 0.7.1
     * Kotest 6.0.0-SNAPSHOT
 * Deprecate `serialize()` and `deserialize()` methods in data classes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * **RSA encryption** using in-memory keys (no hardware-backed key management yet)
 * Add `SpecializedSymmetricEncryptionAlgorithm`
     * This allows `randomKey()` etc to operate on COSE/JWE algorithms
+* Deprecate `serialize()` and `deserialize()` methods in COSE+ JOSE data classes
 * Clean up some function signatures:
     * `SymmetricKey.toJsonWebKey` now returns `KmmResult`
     * `SymmetricEncryptionAlgorithm.toJweKwAlgorithm` now returns `KmmResult`
@@ -25,8 +26,7 @@
     * Coroutines 1.10.2
     * Ktor 3.1.2
     * Datetime 0.7.1
-    * Kotest 6.0.0-SNAPSHOT
-* Deprecate `serialize()` and `deserialize()` methods in data classes
+    * Kotest 6.0.0.M1
 
 ### 3.16.3 / 0.8.3 indispensable-only Hotfix
 * Fix erroneous Base64URL encoding in JOSE data classes

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,10 +1,11 @@
 import org.jetbrains.dokka.gradle.DokkaMultiModuleTask
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 
 plugins {
     val kotlinVer = System.getenv("KOTLIN_VERSION_ENV")?.ifBlank { null } ?: libs.versions.kotlin.get()
     val kotestVer = System.getenv("KOTEST_VERSION_ENV")?.ifBlank { null } ?: libs.versions.kotest.get()
 
-    id("at.asitplus.gradle.conventions") version "20250628"
+    id("at.asitplus.gradle.conventions") version "20250708"
     id("io.kotest.multiplatform") version kotestVer
     kotlin("multiplatform") version kotlinVer apply false
     kotlin("plugin.serialization") version kotlinVer apply false
@@ -35,6 +36,20 @@ allprojects {
         maven {
             url = uri("https://raw.githubusercontent.com/a-sit-plus/gradle-conventions-plugin/mvn/repo")
             name = "aspConventions"
+        }
+    }
+}
+
+//work around IDEA bug that causes IDEA to believe we're at Kotlin 2.0
+subprojects {
+    afterEvaluate {
+        val kotlinVer =
+            (System.getenv("KOTLIN_VERSION_ENV")?.ifBlank { null } ?: rootProject.libs.versions.kotlin.get()).split(".")
+        extensions.getByType<KotlinMultiplatformExtension>().apply {
+            compilerOptions {
+                apiVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.fromVersion(kotlinVer[0] + "." + kotlinVer[1]))
+                languageVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.fromVersion(kotlinVer[0] + "." + kotlinVer[1]))
+            }
         }
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kotlin = "2.1.20"
+kotlin = "2.1.21"
 agp = "8.10.0"
 core = "1.5.0"
 kotlinxIoCore = "0.5.4"

--- a/indispensable-asn1/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/Asn1Time.kt
+++ b/indispensable-asn1/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/Asn1Time.kt
@@ -3,13 +3,7 @@ package at.asitplus.signum.indispensable.asn1
 import at.asitplus.signum.indispensable.asn1.encoding.encodeToAsn1GeneralizedTimePrimitive
 import at.asitplus.signum.indispensable.asn1.encoding.encodeToAsn1UtcTimePrimitive
 import at.asitplus.signum.indispensable.asn1.encoding.decodeToInstant
-import kotlinx.datetime.Instant
-import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializable
-import kotlinx.serialization.descriptors.PrimitiveKind
-import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
-import kotlinx.serialization.encoding.Decoder
-import kotlinx.serialization.encoding.Encoder
+import kotlin.time.Instant
 
 /**
  * ASN.1 TIME (required since GENERALIZED TIME and UTC TIME exist)

--- a/indispensable-asn1/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/encoding/Asn1Decoding.kt
+++ b/indispensable-asn1/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/encoding/Asn1Decoding.kt
@@ -11,13 +11,13 @@ import at.asitplus.signum.indispensable.asn1.BERTags.T61_STRING
 import at.asitplus.signum.indispensable.asn1.BERTags.UNIVERSAL_STRING
 import at.asitplus.signum.indispensable.asn1.BERTags.UTF8_STRING
 import at.asitplus.signum.indispensable.asn1.BERTags.VISIBLE_STRING
-import kotlinx.datetime.Instant
 import kotlinx.io.Source
 import kotlinx.io.UnsafeIoApi
 import kotlinx.io.readByteArray
 import kotlinx.io.readUByte
 import kotlin.enums.enumEntries
 import kotlin.experimental.and
+import kotlin.time.Instant
 
 
 /**

--- a/indispensable-asn1/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/encoding/Asn1Encoding.kt
+++ b/indispensable-asn1/src/commonMain/kotlin/at/asitplus/signum/indispensable/asn1/encoding/Asn1Encoding.kt
@@ -8,7 +8,7 @@ import at.asitplus.signum.indispensable.asn1.encoding.Asn1.ExplicitlyTagged
 import at.asitplus.signum.indispensable.asn1.encoding.Asn1.Sequence
 import at.asitplus.signum.indispensable.asn1.encoding.Asn1.Set
 import at.asitplus.signum.indispensable.asn1.encoding.Asn1.SetOf
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 
 /**
  * Class Providing a DSL for creating arbitrary ASN.1 structures. You will almost certainly never use it directly, but rather use it as follows:

--- a/indispensable-asn1/src/jvmTest/kotlin/at/asitplus/signum/indispensable/asn1/Asn1EncodingTest.kt
+++ b/indispensable-asn1/src/jvmTest/kotlin/at/asitplus/signum/indispensable/asn1/Asn1EncodingTest.kt
@@ -19,7 +19,7 @@ import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
 import io.kotest.property.arbitrary.boolean
 import io.kotest.property.checkAll
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 
 class Asn1EncodingTest : FreeSpec({
 

--- a/indispensable-asn1/src/jvmTest/kotlin/at/asitplus/signum/indispensable/asn1/Asn1TimeTest.kt
+++ b/indispensable-asn1/src/jvmTest/kotlin/at/asitplus/signum/indispensable/asn1/Asn1TimeTest.kt
@@ -6,8 +6,8 @@ import io.kotest.matchers.shouldNotBe
 import io.kotest.property.Arb
 import io.kotest.property.arbitrary.instant
 import io.kotest.property.checkAll
-import kotlinx.datetime.toKotlinInstant
 import java.time.Instant
+import kotlin.time.toKotlinInstant
 
 class Asn1TimeTest : FreeSpec({
 

--- a/indispensable-asn1/src/jvmTest/kotlin/at/asitplus/signum/indispensable/asn1/OidTest.kt
+++ b/indispensable-asn1/src/jvmTest/kotlin/at/asitplus/signum/indispensable/asn1/OidTest.kt
@@ -13,9 +13,9 @@ import io.kotest.matchers.shouldNotBe
 import io.kotest.property.Arb
 import io.kotest.property.arbitrary.*
 import io.kotest.property.checkAll
-import kotlinx.datetime.Clock
 import kotlinx.serialization.Serializable
 import org.bouncycastle.asn1.ASN1ObjectIdentifier
+import kotlin.time.Clock
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.uuid.ExperimentalUuidApi

--- a/indispensable-cosef/src/commonMain/kotlin/at/asitplus/signum/indispensable/cosef/CborWebToken.kt
+++ b/indispensable-cosef/src/commonMain/kotlin/at/asitplus/signum/indispensable/cosef/CborWebToken.kt
@@ -4,10 +4,10 @@ import at.asitplus.catching
 import at.asitplus.signum.indispensable.cosef.io.Base16Strict
 import at.asitplus.signum.indispensable.cosef.io.coseCompliantSerializer
 import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
-import kotlinx.datetime.Instant
 import kotlinx.serialization.*
 import kotlinx.serialization.cbor.ByteString
 import kotlinx.serialization.cbor.CborLabel
+import kotlin.time.Instant
 
 /**
  * CBOR Web Token (CWT)

--- a/indispensable-cosef/src/commonMain/kotlin/at/asitplus/signum/indispensable/cosef/InstantLongSerializer.kt
+++ b/indispensable-cosef/src/commonMain/kotlin/at/asitplus/signum/indispensable/cosef/InstantLongSerializer.kt
@@ -1,12 +1,12 @@
 package at.asitplus.signum.indispensable.cosef
 
-import kotlinx.datetime.Instant
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
+import kotlin.time.Instant
 
 object InstantLongSerializer : KSerializer<Instant> {
 

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JsonWebToken.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JsonWebToken.kt
@@ -6,11 +6,11 @@ import at.asitplus.catching
 import at.asitplus.signum.indispensable.io.ByteArrayBase64Serializer
 import at.asitplus.signum.indispensable.josef.io.InstantLongSerializer
 import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
-import kotlinx.datetime.Instant
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.UseSerializers
 import kotlinx.serialization.json.JsonObject
+import kotlin.time.Instant
 
 /**
  * Content of a JWT (JsonWebToken), with many optional keys,

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/KeyAttestationJwt.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/KeyAttestationJwt.kt
@@ -3,11 +3,10 @@ package at.asitplus.signum.indispensable.josef
 import at.asitplus.catching
 import at.asitplus.signum.indispensable.josef.io.InstantLongSerializer
 import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
-import kotlinx.datetime.Instant
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.JsonObject
+import kotlin.time.Instant
 
 /**
  * Content of a Key Attestation in JWT format, according to

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/io/InstantLongSerializer.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/io/InstantLongSerializer.kt
@@ -1,12 +1,12 @@
 package at.asitplus.signum.indispensable.josef.io
 
-import kotlinx.datetime.Instant
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
+import kotlin.time.Instant
 
 /**
  * JWS-Compliant [Instant] serializer. An instant is represented as seconds from epoch.

--- a/indispensable-josef/src/jvmTest/kotlin/at/asitplus/signum/indispensable/josef/JwkTest.kt
+++ b/indispensable-josef/src/jvmTest/kotlin/at/asitplus/signum/indispensable/josef/JwkTest.kt
@@ -22,10 +22,10 @@ import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.property.azstring
 import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
-import kotlinx.datetime.Clock
 import java.security.KeyPairGenerator
 import java.security.interfaces.ECPublicKey
 import kotlin.random.Random
+import kotlin.time.Clock
 
 class JwkTest : FreeSpec({
     "EC" - {

--- a/indispensable/src/jvmTest/kotlin/at/asitplus/signum/indispensable/pki/X509CertificateJvmTest.kt
+++ b/indispensable/src/jvmTest/kotlin/at/asitplus/signum/indispensable/pki/X509CertificateJvmTest.kt
@@ -12,7 +12,6 @@ import io.kotest.matchers.types.shouldBeInstanceOf
 import io.matthewnelson.encoding.base16.Base16
 import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
 import kotlinx.coroutines.launch
-import kotlinx.datetime.toKotlinInstant
 import org.bouncycastle.asn1.x500.X500Name
 import org.bouncycastle.asn1.x509.ExtendedKeyUsage
 import org.bouncycastle.asn1.x509.KeyPurposeId
@@ -31,6 +30,7 @@ import java.util.*
 import kotlin.math.absoluteValue
 import kotlin.random.Random
 import kotlin.time.Duration.Companion.days
+import kotlin.time.toKotlinInstant
 
 class X509CertificateJvmTest : FreeSpec({
 

--- a/supreme/src/commonTest/kotlin/at/asitplus/signum/supreme/sign/EphemeralSignerCommonTests.kt
+++ b/supreme/src/commonTest/kotlin/at/asitplus/signum/supreme/sign/EphemeralSignerCommonTests.kt
@@ -19,8 +19,8 @@ import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNot
 import io.kotest.matchers.types.shouldBeInstanceOf
-import kotlinx.datetime.Clock
 import kotlin.random.Random
+import kotlin.time.Clock
 import kotlin.time.Duration.Companion.days
 
 interface SignatureTestSuite {

--- a/supreme/src/commonTest/kotlin/at/asitplus/signum/supreme/symmetric/00SymmetricTest.kt
+++ b/supreme/src/commonTest/kotlin/at/asitplus/signum/supreme/symmetric/00SymmetricTest.kt
@@ -20,9 +20,9 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNot
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.types.shouldBeInstanceOf
-import kotlinx.datetime.Clock
 import kotlin.random.Random
 import kotlin.random.nextUInt
+import kotlin.time.Clock
 
 @OptIn(HazardousMaterials::class)
 @ExperimentalStdlibApi

--- a/supreme/src/jvmMain/kotlin/at/asitplus/signum/supreme/os/JKSProvider.kt
+++ b/supreme/src/jvmMain/kotlin/at/asitplus/signum/supreme/os/JKSProvider.kt
@@ -30,7 +30,6 @@ import at.asitplus.signum.supreme.sign.Signer
 import at.asitplus.signum.supreme.sign.SigningKeyConfiguration
 import at.asitplus.signum.supreme.sign.getKPGInstance
 import com.ionspin.kotlin.bignum.integer.base63.toJavaBigInteger
-import kotlinx.datetime.Clock
 import java.nio.channels.Channels
 import java.nio.channels.FileChannel
 import java.nio.channels.FileLock
@@ -44,6 +43,7 @@ import java.security.spec.ECGenParameterSpec
 import java.security.spec.RSAKeyGenParameterSpec
 import org.kotlincrypto.random.CryptoRand
 import kotlin.io.path.extension
+import kotlin.time.Clock
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.days
 


### PR DESCRIPTION
* Update to kotlinx.datetime 0.7.1.
    * This moves Instant and Clock to stdlib
    * (but introduces typealiases for easier migration)

(and fix versions in changelog)

closes #309 + #316