### PR TITLE
Release 3.18.1: workaround KT-71375

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 3.0
 
-### NEXT
+### 3.18.1 / Supreme 0.10.1
+Fix Android target pulling in JDK-21-specifics ([KT-71375](https://youtrack.jetbrains.com/issue/KT-71375/Prevent-Kotlins-removeFirst-and-removeLast-from-causing-crashes-on-Android-14-and-below-after-upgrading-to-Android-API-Level-35))
 
 ### 3.18.0 / Supreme 0.10.0
 * **Fixes:**

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,8 +3,8 @@ org.gradle.jvmargs=-Xmx10g -Dfile.encoding=UTF-8 -Xms200m
 kotlin.daemon.jvm.options=-Xmx10G -Xms200m
 kotlin.daemon.jvmargs=-Didea.max.content.load.filesize=50000000 -Didea.max.intellisense.filesize=50000000 -Xmx10g -Xms200m
 
-indispensableVersion=3.19.0-SNAPSHOT
-supremeVersion=0.11.0-SNAPSHOT
+indispensableVersion=3.18.1
+supremeVersion=0.10.1
 
 # This is not a well-defined property, the ASP convention plugin respects it, though
 jdk.version=17
@@ -12,7 +12,8 @@ org.gradle.java.installations.auto-download=true
 org.gradle.java.installations.auto-detect=true
 
 android.minSdk=26
-android.compileSdk=36
+#well, we're stuck at 34: https://youtrack.jetbrains.com/issue/KT-71375/Prevent-Kotlins-removeFirst-and-removeLast-from-causing-crashes-on-Android-14-and-below-after-upgrading-to-Android-API-Level-35
+android.compileSdk=34
 android.raiseTestToJdkTarget=true
 #MPP
 kotlin.mpp.enableCInteropCommonization=true


### PR DESCRIPTION
Fix Android target pulling in JDK-21-specifics ([KT-71375](https://youtrack.jetbrains.com/issue/KT-71375/Prevent-Kotlins-removeFirst-and-removeLast-from-causing-crashes-on-Android-14-and-below-after-upgrading-to-Android-API-Level-35))
