### PR TITLE
release 3.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 3.0
 
-### NEXT
+### 3.19.0 / Supreme 0.11.0
 * Fix a glaring JWS bug that caused an error whenever trying to get the digest of a JWS signature algorithm
 * Add `Enumerable` and `Enumeration` interfaces to support the pattern in sealed types where the companion object provides `entries` containing all possible instances
     * Classes and interfaces refactored to use `Set` as `entries` to follow  the standardized pattern:

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,8 +3,8 @@ org.gradle.jvmargs=-Xmx10g -Dfile.encoding=UTF-8 -Xms200m
 kotlin.daemon.jvm.options=-Xmx10G -Xms200m
 kotlin.daemon.jvmargs=-Didea.max.content.load.filesize=50000000 -Didea.max.intellisense.filesize=50000000 -Xmx10g -Xms200m
 
-indispensableVersion=3.19.0-SNAPSHOT
-supremeVersion=0.11.0-SNAPSHOT
+indispensableVersion=3.19.0
+supremeVersion=0.11.0
 
 # This is not a well-defined property, the ASP convention plugin respects it, though
 jdk.version=17


### PR DESCRIPTION
* Fix a glaring JWS bug that caused an error whenever trying to get the digest of a JWS signature algorithm
* Add `Enumerable` and `Enumeration` interfaces to support the pattern in sealed types where the companion object provides `entries` containing all possible instances
    * Classes and interfaces refactored to use `Set` as `entries` to follow  the standardized pattern:
        * `Asn1Element.Tag`
        * `CoseAlgorithm` and its nested implementations
        * `JsonWebAlgorithm`
        * `JwsAlgorithm` and its nested implementations
        * `DataIntegrityAlgorithm`
        * `MessageAuthenticationCode`
        * `SignatureAlgorithm`
        * `RSAPadding`
        * `SymmetricEncryptionAlgorithm` and its nested implementations
* Fix project setup on non-macOS build hosts
* COSE: Add identifiers `-9`, `-51`, `-53` for fully-specified algorithms for ECDSA, see [RFC 9864](https://www.rfc-editor.org/rfc/rfc9864.html#name-elliptic-curve-digital-sign)
* Fix Android project setup
* Limit Keystore operations with `limitedParallelism` from `kotlinx.coroutines`