### PR TITLE
3.19.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
-## NEXT
+## 3.19.3 / Supreme 0.11.3
+* Support CURSED X.509 Certificate extensions that encode critical=false instead of omitting it
 
 ## 3.19.2 / Supreme 0.11.2
 * Introduce CURSED RSA X.509 signature algorithm profiles to support CURSED certificates produced by some devices in the field produced by OEMs with impressive market shares

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,8 +3,8 @@ org.gradle.jvmargs=-Xmx10g -Dfile.encoding=UTF-8 -Xms200m
 kotlin.daemon.jvm.options=-Xmx10G -Xms200m
 kotlin.daemon.jvmargs=-Didea.max.content.load.filesize=50000000 -Didea.max.intellisense.filesize=50000000 -Xmx10g -Xms200m
 
-indispensableVersion=3.20-SNAPSHOT
-supremeVersion=0.12-SNAPSHOT
+indispensableVersion=3.19.3
+supremeVersion=0.11.3
 
 # This is not a well-defined property, the ASP convention plugin respects it, though
 jdk.version=17


### PR DESCRIPTION
Support CURSED X.509 Certificate extensions that encode critical=false instead of omitting it