### PR TITLE
Full implementation of all three JWS serialization shapes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
     * Represent protected and unprotected header fragments explicitly via `JwsHeader.Part`, merging them into a `JwsHeader` only when the combined header is valid
     * Parse `JwsHeader.attestationJwt` and `JwsHeader.keyAttestation` as `JwsCompact` instead of raw strings
     * Deprecate `JwsSigned` in favor of `JwsCompact`
+    * Typed payloads remain supported via `JwsTyped`
 
 ## 3.21.0 / Supreme 0.13.0
 * Drop Apple X64 targets

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
 ## NEXT
+* Rework JWS support around explicit compact, flattened, and general representations
+    * Add sealed `JWS` support with dedicated `JwsCompact`, `JwsFlattened`, `JwsGeneral`
+    * Add conversions between compact, flattened, and general JWS representations
+    * Represent protected and unprotected header fragments explicitly via `JwsHeader.Part`, merging them into a `JwsHeader` only when the combined header is valid
+    * Parse `JwsHeader.attestationJwt` and `JwsHeader.keyAttestation` as `JwsCompact` instead of raw strings
+    * Deprecate `JwsSigned` in favor of `JwsCompact`
 
 ## 3.21.0 / Supreme 0.13.0
 * Drop Apple X64 targets

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/Jws.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/Jws.kt
@@ -1,0 +1,44 @@
+package at.asitplus.signum.indispensable.josef
+
+import at.asitplus.signum.indispensable.contentEqualsIfArray
+import at.asitplus.signum.indispensable.io.ByteArrayBase64UrlSerializer
+import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
+import kotlinx.serialization.*
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.decodeFromJsonElement
+
+sealed class JWS {
+    abstract val payload: ByteArray
+
+    fun <P> getPayload(serializer: KSerializer<P>, serialFormat: SerialFormat = joseCompliantSerializer): P =
+        when (serialFormat) {
+            is StringFormat -> serialFormat.decodeFromString(serializer, payload.decodeToString())
+            is BinaryFormat -> serialFormat.decodeFromByteArray(serializer, payload)
+            else -> throw NotImplementedError("Unknown serial format $serialFormat")
+        }
+
+    /**
+     * Find correct serializer at compile time
+     */
+    inline fun <reified P> getPayload(serialFormat: SerialFormat): P =
+        getPayload(serialFormat.serializersModule.serializer(), serialFormat)
+
+    object SerialNames {
+        const val PROTECTED = "protected"
+        const val HEADER = "header"
+        const val SIGNATURE = "signature"
+        const val SIGNATURES = "signatures"
+    }
+}
+
+internal fun JsonObject?.strictUnion(other: JsonObject?): JsonObject {
+    if (this == null) return other ?: JsonObject(emptyMap())
+    if (other == null) return this
+
+    val duplicates = this.keys intersect other.keys
+    require(duplicates.isEmpty()) {
+        "Duplicate keys: ${duplicates.joinToString()}"
+    }
+
+    return JsonObject(this + other)
+}

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/Jws.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/Jws.kt
@@ -1,12 +1,17 @@
 package at.asitplus.signum.indispensable.josef
 
-import at.asitplus.signum.indispensable.contentEqualsIfArray
-import at.asitplus.signum.indispensable.io.ByteArrayBase64UrlSerializer
+import at.asitplus.signum.indispensable.CryptoSignature
+import at.asitplus.signum.indispensable.io.Base64UrlStrict
 import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
+import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
 import kotlinx.serialization.*
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.decodeFromJsonElement
 
+
+/**
+ * Wrapper for all JWS formats.
+ */
 sealed class JWS {
     abstract val payload: ByteArray
 
@@ -23,11 +28,32 @@ sealed class JWS {
     inline fun <reified P> getPayload(serialFormat: SerialFormat): P =
         getPayload(serialFormat.serializersModule.serializer(), serialFormat)
 
+    /**
+     * Lenient Signature Parsing
+     */
+    fun getSignature(combinedHeader: JwsHeader, plainSignature: ByteArray): CryptoSignature.RawByteEncodable =
+        when (val alg = combinedHeader.algorithm) {
+            is JwsAlgorithm.Signature.EC -> CryptoSignature.EC.fromRawBytes(alg.ecCurve, plainSignature)
+            is JwsAlgorithm.Signature.RSA -> CryptoSignature.RSA(plainSignature)
+            else -> throw SerializationException("Unsupported algorithm for JWS signature element: $alg")
+        }
+
+    fun getCombinedHeader(unprotectedHeader: JsonObject, protectedHeader: ByteArray): JwsHeader =
+        joseCompliantSerializer.decodeFromJsonElement(
+            unprotectedHeader.strictUnion(
+                joseCompliantSerializer.decodeFromString(protectedHeader.decodeToString())
+            )
+        )
+
+    fun getSignatureInput(protectedHeader: ByteArray, payload: ByteArray) =
+        "${protectedHeader.encodeToString(Base64UrlStrict)}.${payload.encodeToString(Base64UrlStrict)}".encodeToByteArray()
+
     object SerialNames {
         const val PROTECTED = "protected"
         const val HEADER = "header"
         const val SIGNATURE = "signature"
         const val SIGNATURES = "signatures"
+        const val PAYLOAD = "payload"
     }
 }
 

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/Jws.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/Jws.kt
@@ -42,6 +42,12 @@ sealed class JWS {
         const val SIGNATURE = "signature"
         const val SIGNATURES = "signatures"
         const val PAYLOAD = "payload"
+
+        /* Shapes */
+        const val COMPACT = "compact"
+        const val FLATTENED = "flattened"
+        const val GENERAL = "general"
+
     }
 
     companion object {
@@ -62,9 +68,9 @@ sealed class JWS {
     object JwsSerializer: KSerializer<JWS> {
         @OptIn(InternalSerializationApi::class)
         override val descriptor: SerialDescriptor = buildSerialDescriptor("JWS", PolymorphicKind.SEALED) {
-            element("compact", JwsCompactStringSerializer.descriptor)
-            element("flattened", JwsFlattened.serializer().descriptor)
-            element("general", JwsGeneral.serializer().descriptor)
+            element(SerialNames.COMPACT, JwsCompactStringSerializer.descriptor)
+            element(SerialNames.FLATTENED, JwsFlattened.serializer().descriptor)
+            element(SerialNames.GENERAL, JwsGeneral.serializer().descriptor)
         }
 
         override fun serialize(

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/Jws.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/Jws.kt
@@ -20,6 +20,8 @@ import kotlinx.serialization.json.JsonPrimitive
 
 /**
  * Wrapper for all JWS formats.
+ *
+ * If [plainPayload] data structure is defined as part of the contact consider [JwsTyped]
  */
 @Serializable(with = JWS.JwsSerializer::class)
 sealed class JWS {

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/Jws.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/Jws.kt
@@ -61,7 +61,7 @@ sealed class JWS {
     object JwsSerializer: KSerializer<JWS> {
         @OptIn(InternalSerializationApi::class)
         override val descriptor: SerialDescriptor = buildSerialDescriptor("JWS", PolymorphicKind.SEALED) {
-            element("compact", JwsCompact.serializer().descriptor)
+            element("compact", JwsCompactStringSerializer.descriptor)
             element("flattened", JwsFlattened.serializer().descriptor)
             element("general", JwsGeneral.serializer().descriptor)
         }
@@ -71,7 +71,7 @@ sealed class JWS {
             value: JWS
         ) {
             when (value) {
-                is JwsCompact -> encoder.encodeSerializableValue(JwsCompact.serializer(), value)
+                is JwsCompact -> encoder.encodeSerializableValue(JwsCompactStringSerializer, value)
                 is JwsFlattened -> encoder.encodeSerializableValue(JwsFlattened.serializer(), value)
                 is JwsGeneral -> encoder.encodeSerializableValue(JwsGeneral.serializer(), value)
             }
@@ -82,7 +82,7 @@ sealed class JWS {
             val jsonElement = decoder.decodeJsonElement()
 
             return when (jsonElement) {
-                is JsonPrimitive -> decoder.json.decodeFromJsonElement(JwsCompact.serializer(), jsonElement)
+                is JsonPrimitive -> decoder.json.decodeFromJsonElement(JwsCompactStringSerializer, jsonElement)
                 is JsonObject -> {
                     val hasGeneralSignatures = SerialNames.SIGNATURES in jsonElement
                     val hasFlattenedSignature = SerialNames.SIGNATURE in jsonElement

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/Jws.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/Jws.kt
@@ -13,7 +13,6 @@ import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.json.JsonDecoder
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
-import kotlinx.serialization.json.decodeFromJsonElement
 
 
 /**
@@ -45,22 +44,15 @@ sealed class JWS {
     }
 
     companion object {
-        fun getSignature(combinedHeader: JwsHeader, plainSignature: ByteArray): CryptoSignature.RawByteEncodable =
-            when (val alg = combinedHeader.algorithm) {
+        fun getSignature(jwsHeader: JwsHeader, plainSignature: ByteArray): CryptoSignature.RawByteEncodable =
+            when (val alg = jwsHeader.algorithm) {
                 is JwsAlgorithm.Signature.EC -> CryptoSignature.EC.fromRawBytes(alg.ecCurve, plainSignature)
                 is JwsAlgorithm.Signature.RSA -> CryptoSignature.RSA(plainSignature)
                 else -> throw SerializationException("Unsupported algorithm for JWS signature element: $alg")
             }
 
-        fun getCombinedHeader(unprotectedHeader: JsonObject, protectedHeader: ByteArray): JwsHeader =
-            joseCompliantSerializer.decodeFromJsonElement(
-                unprotectedHeader.strictUnion(
-                    joseCompliantSerializer.decodeFromString(protectedHeader.decodeToString())
-                )
-            )
-
         fun getSignatureInput(protectedHeader: ByteArray, payload: ByteArray) =
-            "${protectedHeader.encodeToString(Base64UrlStrict)}.${payload.encodeToString(Base64UrlStrict)}".encodeToByteArray()
+            "${protectedHeader.decodeToString()}.${payload.encodeToString(Base64UrlStrict)}".encodeToByteArray()
     }
 
     object JwsSerializer: KSerializer<JWS> {

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/Jws.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/Jws.kt
@@ -11,6 +11,7 @@ import kotlinx.serialization.descriptors.buildSerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.json.JsonDecoder
+import kotlinx.serialization.json.JsonEncoder
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 
@@ -77,6 +78,7 @@ sealed class JWS {
             encoder: Encoder,
             value: JWS
         ) {
+            require(encoder is JsonEncoder) { "JWS serialization requires a JsonDecoder" }
             when (value) {
                 is JwsCompact -> encoder.encodeSerializableValue(JwsCompactStringSerializer, value)
                 is JwsFlattened -> encoder.encodeSerializableValue(JwsFlattened.serializer(), value)

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/Jws.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/Jws.kt
@@ -23,6 +23,12 @@ import kotlinx.serialization.json.JsonPrimitive
  */
 @Serializable(with = JWS.JwsSerializer::class)
 sealed class JWS {
+    /**
+     * Raw payload bytes.
+     *
+     * JWS serializers and signature-input construction base64url-encode these bytes where required.
+     * Callers should not pre-encode the payload.
+     */
     abstract val plainPayload: ByteArray
 
     fun <P> getPayload(serializer: KSerializer<P>, serialFormat: SerialFormat = joseCompliantSerializer): KmmResult<P> = runCatching {
@@ -65,6 +71,11 @@ sealed class JWS {
         fun getEncodedProtectedHeader(protectedHeader: ByteArray?): String =
             protectedHeader?.encodeToString(Base64UrlStrict).orEmpty()
 
+        /**
+         * Builds the RFC 7515 signing input from raw protected-header bytes and raw payload bytes.
+         *
+         * [payload] must be plain payload bytes; this helper base64url-encodes it internally.
+         */
         fun getSignatureInput(protectedHeader: ByteArray?, payload: ByteArray) =
             "${getEncodedProtectedHeader(protectedHeader)}.${payload.encodeToString(Base64UrlStrict)}".encodeToByteArray()
     }

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/Jws.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/Jws.kt
@@ -32,6 +32,7 @@ sealed class JWS {
     /**
      * Find correct serializer at compile time
      */
+    @Suppress("unused")
     inline fun <reified P> getPayload(serialFormat: SerialFormat = joseCompliantSerializer): P =
         getPayload(serialFormat.serializersModule.serializer(), serialFormat)
 

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/Jws.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/Jws.kt
@@ -1,5 +1,7 @@
 package at.asitplus.signum.indispensable.josef
 
+import at.asitplus.KmmResult
+import at.asitplus.KmmResult.Companion.wrap
 import at.asitplus.signum.indispensable.CryptoSignature
 import at.asitplus.signum.indispensable.io.Base64UrlStrict
 import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
@@ -21,20 +23,21 @@ import kotlinx.serialization.json.JsonPrimitive
  */
 @Serializable(with = JWS.JwsSerializer::class)
 sealed class JWS {
-    abstract val payload: ByteArray
+    abstract val plainPayload: ByteArray
 
-    fun <P> getPayload(serializer: KSerializer<P>, serialFormat: SerialFormat = joseCompliantSerializer): P =
+    fun <P> getPayload(serializer: KSerializer<P>, serialFormat: SerialFormat = joseCompliantSerializer): KmmResult<P> = runCatching {
         when (serialFormat) {
-            is StringFormat -> serialFormat.decodeFromString(serializer, payload.decodeToString())
-            is BinaryFormat -> serialFormat.decodeFromByteArray(serializer, payload)
+            is StringFormat -> serialFormat.decodeFromString(serializer, plainPayload.decodeToString())
+            is BinaryFormat -> serialFormat.decodeFromByteArray(serializer, plainPayload)
             else -> throw NotImplementedError("Unknown serial format $serialFormat")
         }
+    }.wrap()
 
     /**
      * Find correct serializer at compile time
      */
     @Suppress("unused")
-    inline fun <reified P> getPayload(serialFormat: SerialFormat = joseCompliantSerializer): P =
+    inline fun <reified P> getPayload(serialFormat: SerialFormat = joseCompliantSerializer): KmmResult<P> =
         getPayload(serialFormat.serializersModule.serializer(), serialFormat)
 
     object SerialNames {

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/Jws.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/Jws.kt
@@ -44,15 +44,18 @@ sealed class JWS {
     }
 
     companion object {
-        fun getSignature(jwsHeader: JwsHeader, plainSignature: ByteArray): CryptoSignature.RawByteEncodable =
-            when (val alg = jwsHeader.algorithm) {
-                is JwsAlgorithm.Signature.EC -> CryptoSignature.EC.fromRawBytes(alg.ecCurve, plainSignature)
+        fun getSignature(algorithm: JwsAlgorithm, plainSignature: ByteArray): CryptoSignature.RawByteEncodable =
+            when (algorithm) {
+                is JwsAlgorithm.Signature.EC -> CryptoSignature.EC.fromRawBytes(algorithm.ecCurve, plainSignature)
                 is JwsAlgorithm.Signature.RSA -> CryptoSignature.RSA(plainSignature)
-                else -> throw SerializationException("Unsupported algorithm for JWS signature element: $alg")
+                else -> throw SerializationException("Unsupported algorithm for JWS signature element: $algorithm")
             }
 
-        fun getSignatureInput(protectedHeader: ByteArray, payload: ByteArray) =
-            "${protectedHeader.decodeToString()}.${payload.encodeToString(Base64UrlStrict)}".encodeToByteArray()
+        fun getEncodedProtectedHeader(protectedHeader: ByteArray?): String =
+            protectedHeader?.encodeToString(Base64UrlStrict).orEmpty()
+
+        fun getSignatureInput(protectedHeader: ByteArray?, payload: ByteArray) =
+            "${getEncodedProtectedHeader(protectedHeader)}.${payload.encodeToString(Base64UrlStrict)}".encodeToByteArray()
     }
 
     object JwsSerializer: KSerializer<JWS> {

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/Jws.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/Jws.kt
@@ -5,13 +5,21 @@ import at.asitplus.signum.indispensable.io.Base64UrlStrict
 import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
 import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
 import kotlinx.serialization.*
+import kotlinx.serialization.descriptors.PolymorphicKind
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.descriptors.buildSerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.JsonDecoder
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.decodeFromJsonElement
 
 
 /**
  * Wrapper for all JWS formats.
  */
+@Serializable(with = JWS.JwsSerializer::class)
 sealed class JWS {
     abstract val payload: ByteArray
 
@@ -25,7 +33,7 @@ sealed class JWS {
     /**
      * Find correct serializer at compile time
      */
-    inline fun <reified P> getPayload(serialFormat: SerialFormat): P =
+    inline fun <reified P> getPayload(serialFormat: SerialFormat = joseCompliantSerializer): P =
         getPayload(serialFormat.serializersModule.serializer(), serialFormat)
 
     object SerialNames {
@@ -53,6 +61,63 @@ sealed class JWS {
 
         fun getSignatureInput(protectedHeader: ByteArray, payload: ByteArray) =
             "${protectedHeader.encodeToString(Base64UrlStrict)}.${payload.encodeToString(Base64UrlStrict)}".encodeToByteArray()
+    }
+
+    object JwsSerializer: KSerializer<JWS> {
+        @OptIn(InternalSerializationApi::class)
+        override val descriptor: SerialDescriptor = buildSerialDescriptor("JWS", PolymorphicKind.SEALED) {
+            element("compact", JwsCompact.serializer().descriptor)
+            element("flattened", JwsFlattened.serializer().descriptor)
+            element("general", JwsGeneral.serializer().descriptor)
+        }
+
+        override fun serialize(
+            encoder: Encoder,
+            value: JWS
+        ) {
+            when (value) {
+                is JwsCompact -> encoder.encodeSerializableValue(JwsCompact.serializer(), value)
+                is JwsFlattened -> encoder.encodeSerializableValue(JwsFlattened.serializer(), value)
+                is JwsGeneral -> encoder.encodeSerializableValue(JwsGeneral.serializer(), value)
+            }
+        }
+
+        override fun deserialize(decoder: Decoder): JWS {
+            require(decoder is JsonDecoder) { "JWS deserialization requires a JsonDecoder" }
+            val jsonElement = decoder.decodeJsonElement()
+
+            return when (jsonElement) {
+                is JsonPrimitive -> decoder.json.decodeFromJsonElement(JwsCompact.serializer(), jsonElement)
+                is JsonObject -> {
+                    val hasGeneralSignatures = SerialNames.SIGNATURES in jsonElement
+                    val hasFlattenedSignature = SerialNames.SIGNATURE in jsonElement
+
+                    when {
+                        hasGeneralSignatures && hasFlattenedSignature ->
+                            throw SerializationException(
+                                "Invalid JWS JSON serialization: object must not contain both " +
+                                    "'${SerialNames.SIGNATURE}' and '${SerialNames.SIGNATURES}'"
+                            )
+
+                        hasGeneralSignatures ->
+                            decoder.json.decodeFromJsonElement(JwsGeneral.serializer(), jsonElement)
+
+                        hasFlattenedSignature ->
+                            decoder.json.decodeFromJsonElement(JwsFlattened.serializer(), jsonElement)
+
+                        else ->
+                            throw SerializationException(
+                                "Invalid JWS JSON serialization: object must contain " +
+                                    "'${SerialNames.SIGNATURE}' or '${SerialNames.SIGNATURES}'"
+                            )
+                    }
+                }
+
+                else -> throw SerializationException(
+                    "Invalid JWS JSON serialization: expected a compact string or JSON object"
+                )
+            }
+        }
     }
 }
 

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/Jws.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/Jws.kt
@@ -28,32 +28,31 @@ sealed class JWS {
     inline fun <reified P> getPayload(serialFormat: SerialFormat): P =
         getPayload(serialFormat.serializersModule.serializer(), serialFormat)
 
-    /**
-     * Lenient Signature Parsing
-     */
-    fun getSignature(combinedHeader: JwsHeader, plainSignature: ByteArray): CryptoSignature.RawByteEncodable =
-        when (val alg = combinedHeader.algorithm) {
-            is JwsAlgorithm.Signature.EC -> CryptoSignature.EC.fromRawBytes(alg.ecCurve, plainSignature)
-            is JwsAlgorithm.Signature.RSA -> CryptoSignature.RSA(plainSignature)
-            else -> throw SerializationException("Unsupported algorithm for JWS signature element: $alg")
-        }
-
-    fun getCombinedHeader(unprotectedHeader: JsonObject, protectedHeader: ByteArray): JwsHeader =
-        joseCompliantSerializer.decodeFromJsonElement(
-            unprotectedHeader.strictUnion(
-                joseCompliantSerializer.decodeFromString(protectedHeader.decodeToString())
-            )
-        )
-
-    fun getSignatureInput(protectedHeader: ByteArray, payload: ByteArray) =
-        "${protectedHeader.encodeToString(Base64UrlStrict)}.${payload.encodeToString(Base64UrlStrict)}".encodeToByteArray()
-
     object SerialNames {
         const val PROTECTED = "protected"
         const val HEADER = "header"
         const val SIGNATURE = "signature"
         const val SIGNATURES = "signatures"
         const val PAYLOAD = "payload"
+    }
+
+    companion object {
+        fun getSignature(combinedHeader: JwsHeader, plainSignature: ByteArray): CryptoSignature.RawByteEncodable =
+            when (val alg = combinedHeader.algorithm) {
+                is JwsAlgorithm.Signature.EC -> CryptoSignature.EC.fromRawBytes(alg.ecCurve, plainSignature)
+                is JwsAlgorithm.Signature.RSA -> CryptoSignature.RSA(plainSignature)
+                else -> throw SerializationException("Unsupported algorithm for JWS signature element: $alg")
+            }
+
+        fun getCombinedHeader(unprotectedHeader: JsonObject, protectedHeader: ByteArray): JwsHeader =
+            joseCompliantSerializer.decodeFromJsonElement(
+                unprotectedHeader.strictUnion(
+                    joseCompliantSerializer.decodeFromString(protectedHeader.decodeToString())
+                )
+            )
+
+        fun getSignatureInput(protectedHeader: ByteArray, payload: ByteArray) =
+            "${protectedHeader.encodeToString(Base64UrlStrict)}.${payload.encodeToString(Base64UrlStrict)}".encodeToByteArray()
     }
 }
 

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsCompact.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsCompact.kt
@@ -8,6 +8,7 @@ import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.StringFormat
+import kotlinx.serialization.Transient
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
 import kotlinx.serialization.descriptors.SerialDescriptor
@@ -37,7 +38,9 @@ data class JwsCompact(
     val plainSignature: ByteArray,
 ) : JWS() {
 
-    val jwsHeader by lazy { JwsHeader.fromParts(plainProtectedHeader, null) }
+    @Transient
+    val jwsHeader = JwsHeader.fromParts(plainProtectedHeader, null)
+
     val signature by lazy { getSignature(jwsHeader.algorithm, plainSignature) }
     val signatureInput by lazy { getSignatureInput(plainProtectedHeader, payload) }
 

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsCompact.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsCompact.kt
@@ -28,7 +28,8 @@ import kotlinx.serialization.encoding.Encoder
  *
  * For a standalone compact JWS string, use [toString] and [JwsCompact.invoke].
  */
-data class JwsCompact(
+@ConsistentCopyVisibility
+data class JwsCompact internal constructor(
     val plainProtectedHeader: ByteArray,
     override val plainPayload: ByteArray,
     val plainSignature: ByteArray,

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsCompact.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsCompact.kt
@@ -1,5 +1,7 @@
 package at.asitplus.signum.indispensable.josef
 
+import at.asitplus.KmmResult
+import at.asitplus.catching
 import at.asitplus.signum.indispensable.io.Base64UrlStrict
 import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArray
 import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
@@ -41,8 +43,7 @@ data class JwsCompact(
     @Transient
     val signatureInput = getSignatureInput(plainProtectedHeader, plainPayload)
 
-    override fun toString() =
-        "${signatureInput.decodeToString()}.${plainSignature.encodeToString(Base64UrlStrict)}"
+    override fun toString() = "${signatureInput.decodeToString()}.${plainSignature.encodeToString(Base64UrlStrict)}"
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -65,6 +66,20 @@ data class JwsCompact(
     }
 
     companion object {
+
+        /**
+         * Build a [at.asitplus.signum.indispensable.josef.JwsCompact] received as string
+         * and immediately resolve the payload
+         */
+        inline fun <reified P> parse(base64UrlString: String): KmmResult<Pair<JwsCompact, P>> = catching{
+            val jws = JwsCompact(base64UrlString)
+            val payload = jws.getPayload<P>().getOrThrow()
+            jws to payload
+        }
+
+        /**
+         * Build a [at.asitplus.signum.indispensable.josef.JwsCompact] received as string
+         */
         operator fun invoke(
             base64UrlString: String,
         ): JwsCompact {
@@ -88,6 +103,10 @@ data class JwsCompact(
             }
         }
 
+        /**
+         * Build a new [at.asitplus.signum.indispensable.josef.JwsCompact]
+         * from components and immediately sign the correct representation
+         */
         suspend operator fun invoke(
             protectedHeader: JwsHeader,
             payload: ByteArray,
@@ -109,14 +128,11 @@ data class JwsCompact(
  * This serializer must be opted into explicitly to avoid accidentally treating [JwsCompact] as a JSON object.
  */
 object JwsCompactStringSerializer : KSerializer<JwsCompact> {
-    override val descriptor: SerialDescriptor =
-        PrimitiveSerialDescriptor("JwsCompact", PrimitiveKind.STRING)
+    override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("JwsCompact", PrimitiveKind.STRING)
 
-    override fun serialize(encoder: Encoder, value: JwsCompact) =
-        encoder.encodeString(value.toString())
+    override fun serialize(encoder: Encoder, value: JwsCompact) = encoder.encodeString(value.toString())
 
-    override fun deserialize(decoder: Decoder): JwsCompact =
-        JwsCompact(decoder.decodeString())
+    override fun deserialize(decoder: Decoder): JwsCompact = JwsCompact(decoder.decodeString())
 }
 
 /**

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsCompact.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsCompact.kt
@@ -67,15 +67,12 @@ data class JwsCompact(
             PrimitiveSerialDescriptor("JwsCompact", PrimitiveKind.STRING)
 
         override fun serialize(encoder: Encoder, value: JwsCompact) {
-            val compact = buildString {
-                append(value.plainProtectedHeader.encodeToString(Base64UrlStrict))
-                append('.')
-                append(value.payload.encodeToString(Base64UrlStrict))
-                append('.')
-                append(value.plainSignature.encodeToString(Base64UrlStrict))
-            }
+            val signingInput =
+                value.getSignatureInput(value.plainProtectedHeader, value.payload).decodeToString()
+            val signature =
+                value.plainSignature.encodeToString(Base64UrlStrict)
 
-            encoder.encodeString(compact)
+            encoder.encodeString("$signingInput.$signature")
         }
 
         override fun deserialize(decoder: Decoder): JwsCompact {

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsCompact.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsCompact.kt
@@ -1,0 +1,15 @@
+package at.asitplus.signum.indispensable.josef
+
+
+data class JwsCompact(
+    val protected: ByteArray,
+    override val payload: ByteArray,
+    val signature: ByteArray,
+) : JWS() {
+    fun toJwsFlattened(): JwsFlattened = JwsFlattened(
+        plainProtectedHeader = protected,
+        unprotectedHeader = null,
+        payload = payload,
+        plainSignature = signature,
+    )
+}

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsCompact.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsCompact.kt
@@ -68,6 +68,7 @@ data class JwsCompact(
         operator fun invoke(
             base64UrlString: String,
         ): JwsCompact {
+            require(!base64UrlString.contains("=")) { "Trailing = are not supported. See RFC 7515" }
             val parts = base64UrlString.split('.')
 
             if (parts.size != 3) {

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsCompact.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsCompact.kt
@@ -6,10 +6,30 @@ data class JwsCompact(
     override val payload: ByteArray,
     val signature: ByteArray,
 ) : JWS() {
-    fun toJwsFlattened(): JwsFlattened = JwsFlattened(
-        plainProtectedHeader = protected,
-        unprotectedHeader = null,
-        payload = payload,
-        plainSignature = signature,
-    )
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as JwsCompact
+
+        if (!protected.contentEquals(other.protected)) return false
+        if (!payload.contentEquals(other.payload)) return false
+        if (!signature.contentEquals(other.signature)) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = protected.contentHashCode()
+        result = 31 * result + payload.contentHashCode()
+        result = 31 * result + signature.contentHashCode()
+        return result
+    }
 }
+
+fun JwsCompact.toJwsFlattened(): JwsFlattened = JwsFlattened(
+    plainProtectedHeader = protected,
+    unprotectedHeader = null,
+    payload = payload,
+    plainSignature = signature,
+)

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsCompact.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsCompact.kt
@@ -7,7 +7,6 @@ import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.SerializationException
-import kotlinx.serialization.StringFormat
 import kotlinx.serialization.Transient
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
@@ -41,16 +40,14 @@ data class JwsCompact(
     @Transient
     val jwsHeader = JwsHeader.fromParts(plainProtectedHeader, null)
 
-    val signature by lazy { getSignature(jwsHeader.algorithm, plainSignature) }
-    val signatureInput by lazy { getSignatureInput(plainProtectedHeader, payload) }
+    @Transient
+    val signature = getSignature(jwsHeader.algorithm, plainSignature)
 
-    override fun toString(): String {
-        val signingInput =
-            getSignatureInput(plainProtectedHeader, payload).decodeToString()
-        val signature =
-            plainSignature.encodeToString(Base64UrlStrict)
-        return "$signingInput.$signature"
-    }
+    @Transient
+    val signatureInput = getSignatureInput(plainProtectedHeader, payload)
+
+    override fun toString() =
+        "${signatureInput.decodeToString()}.${plainSignature.encodeToString(Base64UrlStrict)}"
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsCompact.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsCompact.kt
@@ -98,7 +98,7 @@ data class JwsCompact(
                     payload = parts[1].decodeToByteArray(Base64UrlStrict),
                     plainSignature = parts[2].decodeToByteArray(Base64UrlStrict),
                 )
-            } catch (e: IllegalArgumentException) {
+            } catch (e: Exception) {
                 throw SerializationException("Invalid base64url content in JWS compact serialization", e)
             }
         }

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsCompact.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsCompact.kt
@@ -28,7 +28,7 @@ import kotlinx.serialization.encoding.Encoder
  */
 data class JwsCompact(
     val plainProtectedHeader: ByteArray,
-    override val payload: ByteArray,
+    override val plainPayload: ByteArray,
     val plainSignature: ByteArray,
 ) : JWS() {
 
@@ -39,7 +39,7 @@ data class JwsCompact(
     val signature = getSignature(jwsHeader.algorithm, plainSignature)
 
     @Transient
-    val signatureInput = getSignatureInput(plainProtectedHeader, payload)
+    val signatureInput = getSignatureInput(plainProtectedHeader, plainPayload)
 
     override fun toString() =
         "${signatureInput.decodeToString()}.${plainSignature.encodeToString(Base64UrlStrict)}"
@@ -51,7 +51,7 @@ data class JwsCompact(
         other as JwsCompact
 
         if (!plainProtectedHeader.contentEquals(other.plainProtectedHeader)) return false
-        if (!payload.contentEquals(other.payload)) return false
+        if (!plainPayload.contentEquals(other.plainPayload)) return false
         if (!plainSignature.contentEquals(other.plainSignature)) return false
 
         return true
@@ -59,7 +59,7 @@ data class JwsCompact(
 
     override fun hashCode(): Int {
         var result = plainProtectedHeader.contentHashCode()
-        result = 31 * result + payload.contentHashCode()
+        result = 31 * result + plainPayload.contentHashCode()
         result = 31 * result + plainSignature.contentHashCode()
         return result
     }
@@ -80,7 +80,7 @@ data class JwsCompact(
             return try {
                 JwsCompact(
                     plainProtectedHeader = parts[0].decodeToByteArray(Base64UrlStrict),
-                    payload = parts[1].decodeToByteArray(Base64UrlStrict),
+                    plainPayload = parts[1].decodeToByteArray(Base64UrlStrict),
                     plainSignature = parts[2].decodeToByteArray(Base64UrlStrict),
                 )
             } catch (e: Exception) {
@@ -88,16 +88,16 @@ data class JwsCompact(
             }
         }
 
-        operator fun invoke(
+        suspend operator fun invoke(
             protectedHeader: JwsHeader,
             payload: ByteArray,
-            signer: (JwsAlgorithm, ByteArray) -> ByteArray
+            signer: suspend (ByteArray) -> ByteArray
         ): JwsCompact {
             val plainProtectedHeader = JwsProtectedHeaderSerializer.encodeToByteArray(protectedHeader.toPart())
             return JwsCompact(
                 plainProtectedHeader = plainProtectedHeader,
-                payload = payload,
-                plainSignature = signer(protectedHeader.algorithm, getSignatureInput(plainProtectedHeader, payload)),
+                plainPayload = payload,
+                plainSignature = signer(getSignatureInput(plainProtectedHeader, payload)),
             )
         }
     }
@@ -128,6 +128,6 @@ object JwsCompactStringSerializer : KSerializer<JwsCompact> {
 fun JwsCompact.toJwsFlattened(): JwsFlattened = JwsFlattened(
     plainProtectedHeader = plainProtectedHeader,
     unprotectedHeader = null,
-    payload = payload,
+    plainPayload = plainPayload,
     plainSignature = plainSignature,
 )

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsCompact.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsCompact.kt
@@ -106,7 +106,10 @@ data class JwsCompact internal constructor(
 
         /**
          * Build a new [at.asitplus.signum.indispensable.josef.JwsCompact]
-         * from components and immediately sign the correct representation
+         * from components and immediately sign the correct representation.
+         *
+         * [payload] must be the plain payload bytes. Do not base64url-encode it before calling this overload;
+         * compact serialization and signing input construction apply base64url encoding internally.
          */
         suspend operator fun invoke(
             protectedHeader: JwsHeader,

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsCompact.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsCompact.kt
@@ -7,13 +7,26 @@ import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.SerializationException
+import kotlinx.serialization.StringFormat
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 
-
+/**
+ * Implements compact serialization as defined in [RFC 7515](https://datatracker.ietf.org/doc/html/rfc7515)
+ *
+ * Serialized output is of the form
+ * BASE64URL(UTF8(HEADER)).BASE64URL(PAYLOAD).BASE64URL(SIGNATURE)
+ *
+ * This class does not support an unprotected header field!
+ *
+ * When [JwsCompact] is serialized through a JSON format, the compact representation becomes a JSON string literal.
+ * That is correct for nested usage inside a larger JSON document, but the surrounding JSON text contains quotes.
+ *
+ * For a standalone compact JWS string, use [toString] and [JwsCompact.invoke]
+ */
 @Serializable(with = JwsCompact.JwsCompactSerializer::class)
 data class JwsCompact(
     @Serializable(ByteArrayBase64UrlSerializer::class)
@@ -25,6 +38,16 @@ data class JwsCompact(
 ) : JWS() {
 
     val jwsHeader by lazy { JwsHeader.fromParts(plainProtectedHeader, null) }
+    val signature by lazy { getSignature(jwsHeader.algorithm, plainSignature) }
+    val signatureInput by lazy { getSignatureInput(plainProtectedHeader, payload) }
+
+    override fun toString(): String {
+        val signingInput =
+            getSignatureInput(plainProtectedHeader, payload).decodeToString()
+        val signature =
+            plainSignature.encodeToString(Base64UrlStrict)
+        return "$signingInput.$signature"
+    }
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -50,18 +73,18 @@ data class JwsCompact(
         override val descriptor: SerialDescriptor =
             PrimitiveSerialDescriptor("JwsCompact", PrimitiveKind.STRING)
 
-        override fun serialize(encoder: Encoder, value: JwsCompact) {
-            val signingInput =
-                getSignatureInput(value.plainProtectedHeader, value.payload).decodeToString()
-            val signature =
-                value.plainSignature.encodeToString(Base64UrlStrict)
+        override fun serialize(encoder: Encoder, value: JwsCompact) =
+            encoder.encodeString(value.toString())
 
-            encoder.encodeString("$signingInput.$signature")
-        }
+        override fun deserialize(decoder: Decoder): JwsCompact =
+            JwsCompact(decoder.decodeString())
+    }
 
-        override fun deserialize(decoder: Decoder): JwsCompact {
-            val compact = decoder.decodeString()
-            val parts = compact.split('.')
+    companion object {
+        operator fun invoke(
+            base64UrlString: String,
+        ): JwsCompact {
+            val parts = base64UrlString.split('.')
 
             if (parts.size != 3) {
                 throw SerializationException(
@@ -71,7 +94,7 @@ data class JwsCompact(
 
             return try {
                 JwsCompact(
-                    plainProtectedHeader = parts[0].encodeToByteArray(),
+                    plainProtectedHeader = parts[0].decodeToByteArray(Base64UrlStrict),
                     payload = parts[1].decodeToByteArray(Base64UrlStrict),
                     plainSignature = parts[2].decodeToByteArray(Base64UrlStrict),
                 )
@@ -79,10 +102,8 @@ data class JwsCompact(
                 throw SerializationException("Invalid base64url content in JWS compact serialization", e)
             }
         }
-    }
 
-    companion object {
-        fun invoke(
+        operator fun invoke(
             protectedHeader: JwsHeader.Part,
             payload: ByteArray,
             signer: (JwsAlgorithm, ByteArray) -> ByteArray

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsCompact.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsCompact.kt
@@ -1,15 +1,12 @@
 package at.asitplus.signum.indispensable.josef
 
-import at.asitplus.signum.indispensable.CryptoSignature
 import at.asitplus.signum.indispensable.io.Base64UrlStrict
 import at.asitplus.signum.indispensable.io.ByteArrayBase64UrlSerializer
-import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
 import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArray
 import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.SerializationException
-import kotlinx.serialization.Transient
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
 import kotlinx.serialization.descriptors.SerialDescriptor
@@ -26,21 +23,6 @@ data class JwsCompact(
     @Serializable(ByteArrayBase64UrlSerializer::class)
     val plainSignature: ByteArray,
 ) : JWS() {
-
-    @Transient
-    private val protectedHeader: JwsHeader =
-        joseCompliantSerializer.decodeFromString(plainProtectedHeader.encodeToString(Base64UrlStrict))
-
-    /**
-     * Lenient Signature Parsing
-     */
-    @Transient
-    val signature: CryptoSignature.RawByteEncodable
-        get() = when (val alg = protectedHeader.algorithm) {
-            is JwsAlgorithm.Signature.EC -> CryptoSignature.EC.fromRawBytes(alg.ecCurve, plainSignature)
-            is JwsAlgorithm.Signature.RSA -> CryptoSignature.RSA(plainSignature)
-            else -> throw SerializationException("Unsupported algorithm for JWS signature element: $alg")
-        }
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsCompact.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsCompact.kt
@@ -118,6 +118,12 @@ object JwsCompactStringSerializer : KSerializer<JwsCompact> {
         JwsCompact(decoder.decodeString())
 }
 
+/**
+ * Converts compact serialization to the equivalent flattened JSON form.
+ *
+ * The protected header bytes are preserved and the unprotected header is absent, because compact serialization does
+ * not support unprotected header parameters.
+ */
 fun JwsCompact.toJwsFlattened(): JwsFlattened = JwsFlattened(
     plainProtectedHeader = plainProtectedHeader,
     unprotectedHeader = null,

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsCompact.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsCompact.kt
@@ -27,6 +27,8 @@ import kotlinx.serialization.encoding.Encoder
  * a JSON document.
  *
  * For a standalone compact JWS string, use [toString] and [JwsCompact.invoke].
+ *
+ * If [plainPayload] data structure is defined as part of the contact consider [JwsCompactTyped]
  */
 @ConsistentCopyVisibility
 data class JwsCompact internal constructor(

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsCompact.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsCompact.kt
@@ -24,6 +24,8 @@ data class JwsCompact(
     val plainSignature: ByteArray,
 ) : JWS() {
 
+    val jwsHeader by lazy { JwsHeader.fromParts(plainProtectedHeader, null) }
+
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other == null || this::class != other::class) return false
@@ -69,13 +71,29 @@ data class JwsCompact(
 
             return try {
                 JwsCompact(
-                    plainProtectedHeader = parts[0].decodeToByteArray(Base64UrlStrict),
+                    plainProtectedHeader = parts[0].encodeToByteArray(),
                     payload = parts[1].decodeToByteArray(Base64UrlStrict),
                     plainSignature = parts[2].decodeToByteArray(Base64UrlStrict),
                 )
             } catch (e: IllegalArgumentException) {
                 throw SerializationException("Invalid base64url content in JWS compact serialization", e)
             }
+        }
+    }
+
+    companion object {
+        fun invoke(
+            protectedHeader: JwsHeader.Part,
+            payload: ByteArray,
+            signer: (JwsAlgorithm, ByteArray) -> ByteArray
+        ): JwsCompact {
+            val jwsHeader = JwsHeader.fromParts(protectedHeader, null)
+            val plainProtectedHeader = JwsProtectedHeaderSerializer.encodeToByteArray(protectedHeader)
+            return JwsCompact(
+                plainProtectedHeader = plainProtectedHeader,
+                payload = payload,
+                plainSignature = signer(jwsHeader.algorithm, getSignatureInput(plainProtectedHeader, payload)),
+            )
         }
     }
 }

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsCompact.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsCompact.kt
@@ -50,7 +50,7 @@ data class JwsCompact(
 
         override fun serialize(encoder: Encoder, value: JwsCompact) {
             val signingInput =
-                value.getSignatureInput(value.plainProtectedHeader, value.payload).decodeToString()
+                getSignatureInput(value.plainProtectedHeader, value.payload).decodeToString()
             val signature =
                 value.plainSignature.encodeToString(Base64UrlStrict)
 

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsCompact.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsCompact.kt
@@ -1,11 +1,9 @@
 package at.asitplus.signum.indispensable.josef
 
 import at.asitplus.signum.indispensable.io.Base64UrlStrict
-import at.asitplus.signum.indispensable.io.ByteArrayBase64UrlSerializer
 import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArray
 import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
 import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializable
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.Transient
 import kotlinx.serialization.descriptors.PrimitiveKind
@@ -22,18 +20,15 @@ import kotlinx.serialization.encoding.Encoder
  *
  * This class does not support an unprotected header field!
  *
- * When [JwsCompact] is serialized through a JSON format, the compact representation becomes a JSON string literal.
- * That is correct for nested usage inside a larger JSON document, but the surrounding JSON text contains quotes.
+ * [JwsCompact] is intentionally *not* annotated with `@Serializable`: its JSON representation is only the compact
+ * JWS string, not a JSON object. Use [JwsCompactStringSerializer] explicitly when you want that string form inside
+ * a JSON document.
  *
- * For a standalone compact JWS string, use [toString] and [JwsCompact.invoke]
+ * For a standalone compact JWS string, use [toString] and [JwsCompact.invoke].
  */
-@Serializable(with = JwsCompact.JwsCompactSerializer::class)
 data class JwsCompact(
-    @Serializable(ByteArrayBase64UrlSerializer::class)
     val plainProtectedHeader: ByteArray,
-    @Serializable(ByteArrayBase64UrlSerializer::class)
     override val payload: ByteArray,
-    @Serializable(ByteArrayBase64UrlSerializer::class)
     val plainSignature: ByteArray,
 ) : JWS() {
 
@@ -67,17 +62,6 @@ data class JwsCompact(
         result = 31 * result + payload.contentHashCode()
         result = 31 * result + plainSignature.contentHashCode()
         return result
-    }
-
-    object JwsCompactSerializer : KSerializer<JwsCompact> {
-        override val descriptor: SerialDescriptor =
-            PrimitiveSerialDescriptor("JwsCompact", PrimitiveKind.STRING)
-
-        override fun serialize(encoder: Encoder, value: JwsCompact) =
-            encoder.encodeString(value.toString())
-
-        override fun deserialize(decoder: Decoder): JwsCompact =
-            JwsCompact(decoder.decodeString())
     }
 
     companion object {
@@ -116,6 +100,22 @@ data class JwsCompact(
             )
         }
     }
+}
+
+/**
+ * Serializes a [JwsCompact] as its compact JWS string form inside JSON.
+ *
+ * This serializer must be opted into explicitly to avoid accidentally treating [JwsCompact] as a JSON object.
+ */
+object JwsCompactStringSerializer : KSerializer<JwsCompact> {
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor("JwsCompact", PrimitiveKind.STRING)
+
+    override fun serialize(encoder: Encoder, value: JwsCompact) =
+        encoder.encodeString(value.toString())
+
+    override fun deserialize(decoder: Decoder): JwsCompact =
+        JwsCompact(decoder.decodeString())
 }
 
 fun JwsCompact.toJwsFlattened(): JwsFlattened = JwsFlattened(

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsCompact.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsCompact.kt
@@ -1,35 +1,109 @@
 package at.asitplus.signum.indispensable.josef
 
+import at.asitplus.signum.indispensable.CryptoSignature
+import at.asitplus.signum.indispensable.io.Base64UrlStrict
+import at.asitplus.signum.indispensable.io.ByteArrayBase64UrlSerializer
+import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
+import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArray
+import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.Transient
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
 
+
+@Serializable(with = JwsCompact.JwsCompactSerializer::class)
 data class JwsCompact(
-    val protected: ByteArray,
+    @Serializable(ByteArrayBase64UrlSerializer::class)
+    val plainProtectedHeader: ByteArray,
+    @Serializable(ByteArrayBase64UrlSerializer::class)
     override val payload: ByteArray,
-    val signature: ByteArray,
+    @Serializable(ByteArrayBase64UrlSerializer::class)
+    val plainSignature: ByteArray,
 ) : JWS() {
+
+    @Transient
+    private val protectedHeader: JwsHeader =
+        joseCompliantSerializer.decodeFromString(plainProtectedHeader.encodeToString(Base64UrlStrict))
+
+    /**
+     * Lenient Signature Parsing
+     */
+    @Transient
+    val signature: CryptoSignature.RawByteEncodable
+        get() = when (val alg = protectedHeader.algorithm) {
+            is JwsAlgorithm.Signature.EC -> CryptoSignature.EC.fromRawBytes(alg.ecCurve, plainSignature)
+            is JwsAlgorithm.Signature.RSA -> CryptoSignature.RSA(plainSignature)
+            else -> throw SerializationException("Unsupported algorithm for JWS signature element: $alg")
+        }
+
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other == null || this::class != other::class) return false
 
         other as JwsCompact
 
-        if (!protected.contentEquals(other.protected)) return false
+        if (!plainProtectedHeader.contentEquals(other.plainProtectedHeader)) return false
         if (!payload.contentEquals(other.payload)) return false
-        if (!signature.contentEquals(other.signature)) return false
+        if (!plainSignature.contentEquals(other.plainSignature)) return false
 
         return true
     }
 
     override fun hashCode(): Int {
-        var result = protected.contentHashCode()
+        var result = plainProtectedHeader.contentHashCode()
         result = 31 * result + payload.contentHashCode()
-        result = 31 * result + signature.contentHashCode()
+        result = 31 * result + plainSignature.contentHashCode()
         return result
+    }
+
+    object JwsCompactSerializer : KSerializer<JwsCompact> {
+        override val descriptor: SerialDescriptor =
+            PrimitiveSerialDescriptor("JwsCompact", PrimitiveKind.STRING)
+
+        override fun serialize(encoder: Encoder, value: JwsCompact) {
+            val compact = buildString {
+                append(value.plainProtectedHeader.encodeToString(Base64UrlStrict))
+                append('.')
+                append(value.payload.encodeToString(Base64UrlStrict))
+                append('.')
+                append(value.plainSignature.encodeToString(Base64UrlStrict))
+            }
+
+            encoder.encodeString(compact)
+        }
+
+        override fun deserialize(decoder: Decoder): JwsCompact {
+            val compact = decoder.decodeString()
+            val parts = compact.split('.')
+
+            if (parts.size != 3) {
+                throw SerializationException(
+                    "Invalid JWS compact serialization: expected 3 parts, got ${parts.size}"
+                )
+            }
+
+            return try {
+                JwsCompact(
+                    plainProtectedHeader = parts[0].decodeToByteArray(Base64UrlStrict),
+                    payload = parts[1].decodeToByteArray(Base64UrlStrict),
+                    plainSignature = parts[2].decodeToByteArray(Base64UrlStrict),
+                )
+            } catch (e: IllegalArgumentException) {
+                throw SerializationException("Invalid base64url content in JWS compact serialization", e)
+            }
+        }
     }
 }
 
 fun JwsCompact.toJwsFlattened(): JwsFlattened = JwsFlattened(
-    plainProtectedHeader = protected,
+    plainProtectedHeader = plainProtectedHeader,
     unprotectedHeader = null,
     payload = payload,
-    plainSignature = signature,
+    plainSignature = plainSignature,
 )

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsCompact.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsCompact.kt
@@ -107,16 +107,15 @@ data class JwsCompact(
         }
 
         operator fun invoke(
-            protectedHeader: JwsHeader.Part,
+            protectedHeader: JwsHeader,
             payload: ByteArray,
             signer: (JwsAlgorithm, ByteArray) -> ByteArray
         ): JwsCompact {
-            val jwsHeader = JwsHeader.fromParts(protectedHeader, null)
-            val plainProtectedHeader = JwsProtectedHeaderSerializer.encodeToByteArray(protectedHeader)
+            val plainProtectedHeader = JwsProtectedHeaderSerializer.encodeToByteArray(protectedHeader.toPart())
             return JwsCompact(
                 plainProtectedHeader = plainProtectedHeader,
                 payload = payload,
-                plainSignature = signer(jwsHeader.algorithm, getSignatureInput(plainProtectedHeader, payload)),
+                plainSignature = signer(protectedHeader.algorithm, getSignatureInput(plainProtectedHeader, payload)),
             )
         }
     }

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsFlattened.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsFlattened.kt
@@ -1,30 +1,25 @@
 package at.asitplus.signum.indispensable.josef
 
 import at.asitplus.signum.indispensable.contentEqualsIfArray
-import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
-import kotlinx.serialization.Transient
+import at.asitplus.signum.indispensable.io.ByteArrayBase64UrlSerializer
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.decodeFromJsonElement
 
 
 data class JwsFlattened(
+    @Serializable(ByteArrayBase64UrlSerializer::class)
+    @SerialName(JWS.SerialNames.PROTECTED)
     val plainProtectedHeader: ByteArray? = null,
+    @SerialName(JWS.SerialNames.HEADER)
     val unprotectedHeader: JsonObject? = null,
-    val payload: ByteArray,
+    @Serializable(ByteArrayBase64UrlSerializer::class)
+    @SerialName(JWS.SerialNames.PAYLOAD)
+    override val payload: ByteArray,
+    @Serializable(ByteArrayBase64UrlSerializer::class)
+    @SerialName(JWS.SerialNames.SIGNATURE)
     val plainSignature: ByteArray
-) {
-
-    @Transient
-    private val protectedHeader: JsonObject? =
-        plainProtectedHeader?.let { joseCompliantSerializer.decodeFromString(it.decodeToString()) }
-
-    /**
-     * Only the combined header must be a valid [JwsHeader]
-     */
-    @Transient
-    val combinedHeader: JwsHeader =
-        joseCompliantSerializer.decodeFromJsonElement(unprotectedHeader.strictUnion(protectedHeader))
-
+) : JWS() {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other == null || this::class != other::class) return false
@@ -50,9 +45,9 @@ data class JwsFlattened(
 
 fun JwsFlattened.toJwsCompact(): JwsCompact =
     JwsCompact(
-        protected = plainProtectedHeader!!,
+        plainProtectedHeader = plainProtectedHeader!!,
         payload = payload,
-        signature = plainSignature,
+        plainSignature = plainSignature,
     )
 
 fun List<JwsFlattened>.toJwsGeneral(): JwsGeneral {

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsFlattened.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsFlattened.kt
@@ -74,11 +74,10 @@ data class JwsFlattened(
 
 fun JwsFlattened.toJwsCompact(): JwsCompact {
     require(unprotectedHeader == null) { "Compact Serialization does not support unprotected header" }
+    requireNotNull(plainProtectedHeader)
     runCatching { JwsHeader.fromParts(plainProtectedHeader) }.getOrElse { throw IllegalArgumentException("Compact JWS requires protected header to be a valid JwsHeader") }
     return JwsCompact(
-        plainProtectedHeader = requireNotNull(plainProtectedHeader) {
-            "Compact JWS requires a protected header"
-        },
+        plainProtectedHeader = plainProtectedHeader,
         payload = payload,
         plainSignature = plainSignature,
     )

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsFlattened.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsFlattened.kt
@@ -16,8 +16,9 @@ import kotlinx.serialization.Transient
  * Either header fragment may be partial. Only the combination of protected and unprotected parameters must
  * constitute a valid [JwsHeader].
  */
+@ConsistentCopyVisibility
 @Serializable
-data class JwsFlattened(
+data class JwsFlattened internal constructor(
     @Serializable(ByteArrayBase64UrlNoPaddingSerializer::class)
     @SerialName(SerialNames.PROTECTED)
     val plainProtectedHeader: ByteArray? = null,

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsFlattened.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsFlattened.kt
@@ -25,7 +25,7 @@ data class JwsFlattened(
     val unprotectedHeader: JwsHeader.Part? = null,
     @Serializable(ByteArrayBase64UrlNoPaddingSerializer::class)
     @SerialName(SerialNames.PAYLOAD)
-    override val payload: ByteArray,
+    override val plainPayload: ByteArray,
     @Serializable(ByteArrayBase64UrlNoPaddingSerializer::class)
     @SerialName(SerialNames.SIGNATURE)
     val plainSignature: ByteArray
@@ -38,7 +38,7 @@ data class JwsFlattened(
     val signature = getSignature(jwsHeader.algorithm, plainSignature)
 
     @Transient
-    val signatureInput = getSignatureInput(plainProtectedHeader, payload)
+    val signatureInput = getSignatureInput(plainProtectedHeader, plainPayload)
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -48,7 +48,7 @@ data class JwsFlattened(
 
         if (!plainProtectedHeader.contentEquals(other.plainProtectedHeader)) return false
         if (unprotectedHeader != other.unprotectedHeader) return false
-        if (!payload.contentEquals(other.payload)) return false
+        if (!plainPayload.contentEquals(other.plainPayload)) return false
         if (!plainSignature.contentEquals(other.plainSignature)) return false
 
         return true
@@ -57,7 +57,7 @@ data class JwsFlattened(
     override fun hashCode(): Int {
         var result = plainProtectedHeader?.contentHashCode() ?: 0
         result = 31 * result + (unprotectedHeader?.hashCode() ?: 0)
-        result = 31 * result + payload.contentHashCode()
+        result = 31 * result + plainPayload.contentHashCode()
         result = 31 * result + plainSignature.contentHashCode()
         return result
     }
@@ -68,19 +68,18 @@ data class JwsFlattened(
          *
          * The fragments may be partial, but their merged content must form a valid [JwsHeader].
          */
-        operator fun invoke(
+        suspend operator fun invoke(
             protectedHeader: JwsHeader.Part?,
             unprotectedHeader: JwsHeader.Part?,
             payload: ByteArray,
-            signer: (JwsAlgorithm, ByteArray) -> ByteArray
+            signer: suspend (ByteArray) -> ByteArray
         ): JwsFlattened {
-            val jwsHeader = JwsHeader.fromParts(protectedHeader, unprotectedHeader)
             val plainProtectedHeader = protectedHeader?.let { JwsProtectedHeaderSerializer.encodeToByteArray(it) }
             return JwsFlattened(
                 plainProtectedHeader,
                 unprotectedHeader,
                 payload,
-                signer(jwsHeader.algorithm, getSignatureInput(plainProtectedHeader, payload))
+                signer(getSignatureInput(plainProtectedHeader, payload))
             )
         }
     }
@@ -98,7 +97,7 @@ fun JwsFlattened.toJwsCompact(): JwsCompact {
     runCatching { JwsHeader.fromParts(plainProtectedHeader) }.getOrElse { throw IllegalArgumentException("Compact JWS requires protected header to be a valid JwsHeader") }
     return JwsCompact(
         plainProtectedHeader = plainProtectedHeader,
-        payload = payload,
+        plainPayload = plainPayload,
         plainSignature = plainSignature,
     )
 }
@@ -108,9 +107,9 @@ fun JwsFlattened.toJwsCompact(): JwsCompact {
  */
 fun List<JwsFlattened>.toJwsGeneral(): JwsGeneral {
     require(isNotEmpty()) { "General JWS requires at least one signature" }
-    val payload = this[0].payload
+    val payload = this[0].plainPayload
     val signatures = this.map {
-        require(payload.contentEqualsIfArray(it.payload)) {
+        require(payload.contentEqualsIfArray(it.plainPayload)) {
             "Additional signed JWS payload must match existing payload"
         }
         SignatureElement(
@@ -120,7 +119,7 @@ fun List<JwsFlattened>.toJwsGeneral(): JwsGeneral {
         )
     }
     return JwsGeneral(
-        payload = payload,
+        plainPayload = payload,
         signatureElements = signatures
     )
 }

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsFlattened.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsFlattened.kt
@@ -1,7 +1,7 @@
 package at.asitplus.signum.indispensable.josef
 
 import at.asitplus.signum.indispensable.contentEqualsIfArray
-import at.asitplus.signum.indispensable.io.ByteArrayBase64UrlSerializer
+import at.asitplus.signum.indispensable.io.ByteArrayBase64UrlNoPaddingSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
@@ -18,15 +18,15 @@ import kotlinx.serialization.Transient
  */
 @Serializable
 data class JwsFlattened(
-    @Serializable(ByteArrayBase64UrlSerializer::class)
+    @Serializable(ByteArrayBase64UrlNoPaddingSerializer::class)
     @SerialName(SerialNames.PROTECTED)
     val plainProtectedHeader: ByteArray? = null,
     @SerialName(SerialNames.HEADER)
     val unprotectedHeader: JwsHeader.Part? = null,
-    @Serializable(ByteArrayBase64UrlSerializer::class)
+    @Serializable(ByteArrayBase64UrlNoPaddingSerializer::class)
     @SerialName(SerialNames.PAYLOAD)
     override val payload: ByteArray,
-    @Serializable(ByteArrayBase64UrlSerializer::class)
+    @Serializable(ByteArrayBase64UrlNoPaddingSerializer::class)
     @SerialName(SerialNames.SIGNATURE)
     val plainSignature: ByteArray
 ) : JWS() {

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsFlattened.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsFlattened.kt
@@ -2,14 +2,13 @@ package at.asitplus.signum.indispensable.josef
 
 import at.asitplus.signum.indispensable.contentEqualsIfArray
 import at.asitplus.signum.indispensable.io.ByteArrayBase64UrlSerializer
-import at.asitplus.signum.indispensable.io.ByteArrayUtf8Serializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 
 @Serializable
 data class JwsFlattened(
-    @Serializable(ByteArrayUtf8Serializer::class)
+    @Serializable(ByteArrayBase64UrlSerializer::class)
     @SerialName(SerialNames.PROTECTED)
     val plainProtectedHeader: ByteArray? = null,
     @SerialName(SerialNames.HEADER)
@@ -21,6 +20,10 @@ data class JwsFlattened(
     @SerialName(SerialNames.SIGNATURE)
     val plainSignature: ByteArray
 ) : JWS() {
+
+    val jwsHeader by lazy { JwsHeader.fromParts(plainProtectedHeader, unprotectedHeader) }
+    val signature by lazy { getSignature(jwsHeader.algorithm, plainSignature) }
+    val signatureInput by lazy { getSignatureInput(plainProtectedHeader, payload) }
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -44,10 +47,8 @@ data class JwsFlattened(
         return result
     }
 
-    val jwsHeader by lazy { JwsHeader.fromParts(plainProtectedHeader, unprotectedHeader) }
-
     companion object {
-        fun invoke(
+        operator fun invoke(
             protectedHeader: JwsHeader.Part,
             unprotectedHeader: JwsHeader.Part = JwsHeader.Part(),
             payload: ByteArray,

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsFlattened.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsFlattened.kt
@@ -49,13 +49,13 @@ data class JwsFlattened(
 
     companion object {
         operator fun invoke(
-            protectedHeader: JwsHeader.Part,
-            unprotectedHeader: JwsHeader.Part = JwsHeader.Part(),
+            protectedHeader: JwsHeader.Part?,
+            unprotectedHeader: JwsHeader.Part?,
             payload: ByteArray,
             signer: (JwsAlgorithm, ByteArray) -> ByteArray
         ): JwsFlattened {
             val jwsHeader = JwsHeader.fromParts(protectedHeader, unprotectedHeader)
-            val plainProtectedHeader = JwsProtectedHeaderSerializer.encodeToByteArray(protectedHeader)
+            val plainProtectedHeader = protectedHeader?.let { JwsProtectedHeaderSerializer.encodeToByteArray(it) }
             return JwsFlattened(
                 plainProtectedHeader,
                 unprotectedHeader,
@@ -66,14 +66,20 @@ data class JwsFlattened(
     }
 }
 
-fun JwsFlattened.toJwsCompact(): JwsCompact =
-    JwsCompact(
-        plainProtectedHeader = plainProtectedHeader!!,
+fun JwsFlattened.toJwsCompact(): JwsCompact {
+    require(unprotectedHeader == null) {"Compact Serialization does not support unprotected header"}
+    runCatching { JwsHeader.fromParts(plainProtectedHeader) }.getOrElse { throw IllegalArgumentException("Compact JWS requires protected header to be a valid JwsHeader") }
+    return JwsCompact(
+        plainProtectedHeader = requireNotNull(plainProtectedHeader) {
+            "Compact JWS requires a protected header"
+        },
         payload = payload,
         plainSignature = plainSignature,
     )
+}
 
 fun List<JwsFlattened>.toJwsGeneral(): JwsGeneral {
+    require(isNotEmpty()) { "General JWS requires at least one signature" }
     val payload = this[0].payload
     val signatures = this.map {
         require(payload.contentEqualsIfArray(it.payload)) {

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsFlattened.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsFlattened.kt
@@ -24,6 +24,28 @@ data class JwsFlattened(
     @Transient
     val combinedHeader: JwsHeader =
         joseCompliantSerializer.decodeFromJsonElement(unprotectedHeader.strictUnion(protectedHeader))
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as JwsFlattened
+
+        if (!plainProtectedHeader.contentEquals(other.plainProtectedHeader)) return false
+        if (unprotectedHeader != other.unprotectedHeader) return false
+        if (!payload.contentEquals(other.payload)) return false
+        if (!plainSignature.contentEquals(other.plainSignature)) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = plainProtectedHeader?.contentHashCode() ?: 0
+        result = 31 * result + (unprotectedHeader?.hashCode() ?: 0)
+        result = 31 * result + payload.contentHashCode()
+        result = 31 * result + plainSignature.contentHashCode()
+        return result
+    }
 }
 
 fun JwsFlattened.toJwsCompact(): JwsCompact =

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsFlattened.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsFlattened.kt
@@ -1,0 +1,52 @@
+package at.asitplus.signum.indispensable.josef
+
+import at.asitplus.signum.indispensable.contentEqualsIfArray
+import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
+import kotlinx.serialization.Transient
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.decodeFromJsonElement
+
+
+data class JwsFlattened(
+    val plainProtectedHeader: ByteArray? = null,
+    val unprotectedHeader: JsonObject? = null,
+    val payload: ByteArray,
+    val plainSignature: ByteArray
+) {
+
+    @Transient
+    private val protectedHeader: JsonObject? =
+        plainProtectedHeader?.let { joseCompliantSerializer.decodeFromString(it.decodeToString()) }
+
+    /**
+     * Only the combined header must be a valid [JwsHeader]
+     */
+    @Transient
+    val combinedHeader: JwsHeader =
+        joseCompliantSerializer.decodeFromJsonElement(unprotectedHeader.strictUnion(protectedHeader))
+}
+
+fun JwsFlattened.toJwsCompact(): JwsCompact =
+    JwsCompact(
+        protected = plainProtectedHeader!!,
+        payload = payload,
+        signature = plainSignature,
+    )
+
+fun List<JwsFlattened>.toJwsGeneral(): JwsGeneral {
+    val payload = this[0].payload
+    val signatures = this.map {
+        require(payload.contentEqualsIfArray(it.payload)) {
+            "Additional signed JWS payload must match existing payload"
+        }
+        SignatureElement(
+            plainSignature = it.plainSignature,
+            plainProtectedHeader = it.plainProtectedHeader,
+            unprotectedHeader = it.unprotectedHeader,
+        )
+    }
+    return JwsGeneral(
+        payload = payload,
+        signatures = signatures
+    )
+}

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsFlattened.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsFlattened.kt
@@ -2,20 +2,18 @@ package at.asitplus.signum.indispensable.josef
 
 import at.asitplus.signum.indispensable.contentEqualsIfArray
 import at.asitplus.signum.indispensable.io.ByteArrayBase64UrlSerializer
-import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
+import at.asitplus.signum.indispensable.io.ByteArrayUtf8Serializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.decodeFromJsonElement
 
 
 @Serializable
 data class JwsFlattened(
-    @Serializable(ByteArrayBase64UrlSerializer::class)
+    @Serializable(ByteArrayUtf8Serializer::class)
     @SerialName(SerialNames.PROTECTED)
     val plainProtectedHeader: ByteArray? = null,
     @SerialName(SerialNames.HEADER)
-    val unprotectedHeader: JsonObject? = null,
+    val unprotectedHeader: JwsHeader.Part? = null,
     @Serializable(ByteArrayBase64UrlSerializer::class)
     @SerialName(SerialNames.PAYLOAD)
     override val payload: ByteArray,
@@ -46,20 +44,22 @@ data class JwsFlattened(
         return result
     }
 
+    val jwsHeader by lazy { JwsHeader.fromParts(plainProtectedHeader, unprotectedHeader) }
+
     companion object {
         fun invoke(
-            protectedHeader: JsonObject,
-            unprotectedHeader: JsonObject,
+            protectedHeader: JwsHeader.Part,
+            unprotectedHeader: JwsHeader.Part = JwsHeader.Part(),
             payload: ByteArray,
             signer: (JwsAlgorithm, ByteArray) -> ByteArray
         ): JwsFlattened {
-            val jwsHeader = joseCompliantSerializer.decodeFromJsonElement<JwsHeader>(protectedHeader.strictUnion(unprotectedHeader))
-            val plainProtectedHeader = joseCompliantSerializer.encodeToString(protectedHeader).encodeToByteArray()
+            val jwsHeader = JwsHeader.fromParts(protectedHeader, unprotectedHeader)
+            val plainProtectedHeader = JwsProtectedHeaderSerializer.encodeToByteArray(protectedHeader)
             return JwsFlattened(
-                plainProtectedHeader = plainProtectedHeader,
-                unprotectedHeader = unprotectedHeader,
-                payload = payload,
-                plainSignature = signer(jwsHeader.algorithm, getSignatureInput(plainProtectedHeader, payload))
+                plainProtectedHeader,
+                unprotectedHeader,
+                payload,
+                signer(jwsHeader.algorithm, getSignatureInput(plainProtectedHeader, payload))
             )
         }
     }

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsFlattened.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsFlattened.kt
@@ -6,7 +6,16 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
 
-
+/**
+ * Flattened JSON JWS serialization.
+ *
+ * A flattened JWS carries one payload and one signature. The protected header is stored as encoded bytes in
+ * [plainProtectedHeader]; the optional unprotected header is represented as [JwsHeader.Part]. The effective
+ * [jwsHeader] is reconstructed by merging both fragments with [JwsHeader.fromParts].
+ *
+ * Either header fragment may be partial. Only the combination of protected and unprotected parameters must
+ * constitute a valid [JwsHeader].
+ */
 @Serializable
 data class JwsFlattened(
     @Serializable(ByteArrayBase64UrlSerializer::class)
@@ -54,6 +63,11 @@ data class JwsFlattened(
     }
 
     companion object {
+        /**
+         * Creates a flattened JWS from protected and unprotected header fragments.
+         *
+         * The fragments may be partial, but their merged content must form a valid [JwsHeader].
+         */
         operator fun invoke(
             protectedHeader: JwsHeader.Part?,
             unprotectedHeader: JwsHeader.Part?,
@@ -72,6 +86,12 @@ data class JwsFlattened(
     }
 }
 
+/**
+ * Converts flattened JSON serialization to compact serialization.
+ *
+ * This requires the absence of an unprotected header, because compact JWS can only carry protected parameters.
+ * The protected fragment must therefore represent a valid [JwsHeader] by itself.
+ */
 fun JwsFlattened.toJwsCompact(): JwsCompact {
     require(unprotectedHeader == null) { "Compact Serialization does not support unprotected header" }
     requireNotNull(plainProtectedHeader)
@@ -83,6 +103,9 @@ fun JwsFlattened.toJwsCompact(): JwsCompact {
     )
 }
 
+/**
+ * Converts multiple flattened JWS values with the same payload into general JSON JWS representation.
+ */
 fun List<JwsFlattened>.toJwsGeneral(): JwsGeneral {
     require(isNotEmpty()) { "General JWS requires at least one signature" }
     val payload = this[0].payload

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsFlattened.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsFlattened.kt
@@ -2,24 +2,28 @@ package at.asitplus.signum.indispensable.josef
 
 import at.asitplus.signum.indispensable.contentEqualsIfArray
 import at.asitplus.signum.indispensable.io.ByteArrayBase64UrlSerializer
+import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.decodeFromJsonElement
 
 
+@Serializable
 data class JwsFlattened(
     @Serializable(ByteArrayBase64UrlSerializer::class)
-    @SerialName(JWS.SerialNames.PROTECTED)
+    @SerialName(SerialNames.PROTECTED)
     val plainProtectedHeader: ByteArray? = null,
-    @SerialName(JWS.SerialNames.HEADER)
+    @SerialName(SerialNames.HEADER)
     val unprotectedHeader: JsonObject? = null,
     @Serializable(ByteArrayBase64UrlSerializer::class)
-    @SerialName(JWS.SerialNames.PAYLOAD)
+    @SerialName(SerialNames.PAYLOAD)
     override val payload: ByteArray,
     @Serializable(ByteArrayBase64UrlSerializer::class)
-    @SerialName(JWS.SerialNames.SIGNATURE)
+    @SerialName(SerialNames.SIGNATURE)
     val plainSignature: ByteArray
 ) : JWS() {
+
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other == null || this::class != other::class) return false
@@ -40,6 +44,24 @@ data class JwsFlattened(
         result = 31 * result + payload.contentHashCode()
         result = 31 * result + plainSignature.contentHashCode()
         return result
+    }
+
+    companion object {
+        fun invoke(
+            protectedHeader: JsonObject,
+            unprotectedHeader: JsonObject,
+            payload: ByteArray,
+            signer: (JwsAlgorithm, ByteArray) -> ByteArray
+        ): JwsFlattened {
+            val jwsHeader = joseCompliantSerializer.decodeFromJsonElement<JwsHeader>(protectedHeader.strictUnion(unprotectedHeader))
+            val plainProtectedHeader = joseCompliantSerializer.encodeToString(protectedHeader).encodeToByteArray()
+            return JwsFlattened(
+                plainProtectedHeader = plainProtectedHeader,
+                unprotectedHeader = unprotectedHeader,
+                payload = payload,
+                plainSignature = signer(jwsHeader.algorithm, getSignatureInput(plainProtectedHeader, payload))
+            )
+        }
     }
 }
 

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsFlattened.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsFlattened.kt
@@ -25,8 +25,11 @@ data class JwsFlattened(
     @Transient
     val jwsHeader = JwsHeader.fromParts(plainProtectedHeader, unprotectedHeader)
 
-    val signature by lazy { getSignature(jwsHeader.algorithm, plainSignature) }
-    val signatureInput by lazy { getSignatureInput(plainProtectedHeader, payload) }
+    @Transient
+    val signature = getSignature(jwsHeader.algorithm, plainSignature)
+
+    @Transient
+    val signatureInput = getSignatureInput(plainProtectedHeader, payload)
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -70,7 +73,7 @@ data class JwsFlattened(
 }
 
 fun JwsFlattened.toJwsCompact(): JwsCompact {
-    require(unprotectedHeader == null) {"Compact Serialization does not support unprotected header"}
+    require(unprotectedHeader == null) { "Compact Serialization does not support unprotected header" }
     runCatching { JwsHeader.fromParts(plainProtectedHeader) }.getOrElse { throw IllegalArgumentException("Compact JWS requires protected header to be a valid JwsHeader") }
     return JwsCompact(
         plainProtectedHeader = requireNotNull(plainProtectedHeader) {

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsFlattened.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsFlattened.kt
@@ -18,6 +18,9 @@ import kotlinx.serialization.Transient
  *
  * [plainPayload] stores the plain payload bytes. JSON serialization base64url-encodes those bytes for the `payload`
  * member, so callers should not pre-encode them.
+ *
+ *
+ * If [plainPayload] data structure is defined as part of the contact consider [JwsFlattenedTyped]
  */
 @ConsistentCopyVisibility
 @Serializable

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsFlattened.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsFlattened.kt
@@ -4,6 +4,7 @@ import at.asitplus.signum.indispensable.contentEqualsIfArray
 import at.asitplus.signum.indispensable.io.ByteArrayBase64UrlSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.Transient
 
 
 @Serializable
@@ -21,7 +22,9 @@ data class JwsFlattened(
     val plainSignature: ByteArray
 ) : JWS() {
 
-    val jwsHeader by lazy { JwsHeader.fromParts(plainProtectedHeader, unprotectedHeader) }
+    @Transient
+    val jwsHeader = JwsHeader.fromParts(plainProtectedHeader, unprotectedHeader)
+
     val signature by lazy { getSignature(jwsHeader.algorithm, plainSignature) }
     val signatureInput by lazy { getSignatureInput(plainProtectedHeader, payload) }
 

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsFlattened.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsFlattened.kt
@@ -96,6 +96,6 @@ fun List<JwsFlattened>.toJwsGeneral(): JwsGeneral {
     }
     return JwsGeneral(
         payload = payload,
-        signatures = signatures
+        signatureElements = signatures
     )
 }

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsFlattened.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsFlattened.kt
@@ -32,6 +32,10 @@ data class JwsFlattened internal constructor(
     val plainSignature: ByteArray
 ) : JWS() {
 
+    init {
+        JwsProtectedHeaderSerializer.requireAbsentIfEmpty(plainProtectedHeader)
+    }
+
     @Transient
     val jwsHeader = JwsHeader.fromParts(plainProtectedHeader, unprotectedHeader)
 
@@ -75,7 +79,7 @@ data class JwsFlattened internal constructor(
             payload: ByteArray,
             signer: suspend (ByteArray) -> ByteArray
         ): JwsFlattened {
-            val plainProtectedHeader = protectedHeader?.let { JwsProtectedHeaderSerializer.encodeToByteArray(it) }
+            val plainProtectedHeader = JwsProtectedHeaderSerializer.encodeToByteArrayOrNull(protectedHeader)
             return JwsFlattened(
                 plainProtectedHeader,
                 unprotectedHeader,

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsFlattened.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsFlattened.kt
@@ -15,6 +15,9 @@ import kotlinx.serialization.Transient
  *
  * Either header fragment may be partial. Only the combination of protected and unprotected parameters must
  * constitute a valid [JwsHeader].
+ *
+ * [plainPayload] stores the plain payload bytes. JSON serialization base64url-encodes those bytes for the `payload`
+ * member, so callers should not pre-encode them.
  */
 @ConsistentCopyVisibility
 @Serializable
@@ -72,6 +75,8 @@ data class JwsFlattened internal constructor(
          * Creates a flattened JWS from protected and unprotected header fragments.
          *
          * The fragments may be partial, but their merged content must form a valid [JwsHeader].
+         * [payload] must be the plain payload bytes. Do not base64url-encode it before calling this overload;
+         * flattened JSON serialization and signing input construction apply base64url encoding internally.
          */
         suspend operator fun invoke(
             protectedHeader: JwsHeader.Part?,

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsGeneral.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsGeneral.kt
@@ -1,11 +1,22 @@
 package at.asitplus.signum.indispensable.josef
 
 import at.asitplus.signum.indispensable.contentEqualsIfArray
+import at.asitplus.signum.indispensable.io.ByteArrayBase64UrlSerializer
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 
+@Serializable
 data class JwsGeneral(
-    val payload: ByteArray,
+    @Serializable(ByteArrayBase64UrlSerializer::class)
+    @SerialName(JWS.SerialNames.PAYLOAD)
+    override val payload: ByteArray,
+    @Serializable
+    @SerialName(JWS.SerialNames.SIGNATURES)
     val signatures: List<SignatureElement>
-) {
+) : JWS() {
+    /**
+     * @return New [JwsGeneral] object with appended Signature
+     */
     fun appendSignature(jwsFlattened: JwsFlattened): JwsGeneral {
         require(payload.contentEqualsIfArray(jwsFlattened.payload)) {
             "Additional signed JWS payload must match existing payload"

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsGeneral.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsGeneral.kt
@@ -6,6 +6,13 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
 
+/**
+ * General JSON JWS.
+ *
+ * A general JWS carries one payload and one or more [signatureElements]. Each [SignatureElement] contains the header
+ * fragments for one signature and exposes its merged effective [JwsHeader]. All signatures in a [JwsGeneral] share
+ * the same payload.
+ */
 @Serializable
 data class JwsGeneral(
     @Serializable(ByteArrayBase64UrlSerializer::class)
@@ -30,7 +37,7 @@ data class JwsGeneral(
     val signatureInputs = signatureElements.map { getSignatureInput(it.plainProtectedHeader, payload) }
 
     /**
-     * @return New [JwsGeneral] object with appended Signature
+     * Returns a new [JwsGeneral] with one additional signature over the same payload.
      */
     fun appendSignature(jwsFlattened: JwsFlattened): JwsGeneral {
         require(payload.contentEqualsIfArray(jwsFlattened.payload)) {
@@ -69,7 +76,9 @@ data class JwsGeneral(
     }
 }
 
-
+/**
+ * Expands general JSON JWS representation into one flattened JWS per signature.
+ */
 fun JwsGeneral.toJwsFlattened(): List<JwsFlattened> =
     signatureElements.map {
         JwsFlattened(

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsGeneral.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsGeneral.kt
@@ -12,6 +12,9 @@ import kotlinx.serialization.Transient
  * A general JWS carries one payload and one or more [signatureElements]. Each [SignatureElement] contains the header
  * fragments for one signature and exposes its merged effective [JwsHeader]. All signatures in a [JwsGeneral] share
  * the same payload.
+ *
+ * [plainPayload] stores the plain payload bytes. JSON serialization base64url-encodes those bytes for the `payload`
+ * member, so callers should not pre-encode them.
  */
 @ConsistentCopyVisibility
 @Serializable

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsGeneral.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsGeneral.kt
@@ -17,7 +17,7 @@ import kotlinx.serialization.Transient
 data class JwsGeneral(
     @Serializable(ByteArrayBase64UrlNoPaddingSerializer::class)
     @SerialName(SerialNames.PAYLOAD)
-    override val payload: ByteArray,
+    override val plainPayload: ByteArray,
     @Serializable
     @SerialName(SerialNames.SIGNATURES)
     val signatureElements: List<SignatureElement>
@@ -34,13 +34,13 @@ data class JwsGeneral(
     val signatures = signatureElements.map { it.signature }
 
     @Transient
-    val signatureInputs = signatureElements.map { getSignatureInput(it.plainProtectedHeader, payload) }
+    val signatureInputs = signatureElements.map { getSignatureInput(it.plainProtectedHeader, plainPayload) }
 
     /**
      * Returns a new [JwsGeneral] with one additional signature over the same payload.
      */
     fun appendSignature(jwsFlattened: JwsFlattened): JwsGeneral {
-        require(payload.contentEqualsIfArray(jwsFlattened.payload)) {
+        require(plainPayload.contentEqualsIfArray(jwsFlattened.plainPayload)) {
             "Additional signed JWS payload must match existing payload"
         }
 
@@ -59,14 +59,14 @@ data class JwsGeneral(
 
         other as JwsGeneral
 
-        if (!payload.contentEquals(other.payload)) return false
+        if (!plainPayload.contentEquals(other.plainPayload)) return false
         if (signatureElements != other.signatureElements) return false
 
         return true
     }
 
     override fun hashCode(): Int {
-        var result = payload.contentHashCode()
+        var result = plainPayload.contentHashCode()
         result = 31 * result + signatureElements.hashCode()
         return result
     }
@@ -84,7 +84,7 @@ fun JwsGeneral.toJwsFlattened(): List<JwsFlattened> =
         JwsFlattened(
             plainProtectedHeader = it.plainProtectedHeader,
             unprotectedHeader = it.unprotectedHeader,
-            payload = this.payload,
+            plainPayload = this.plainPayload,
             plainSignature = it.plainSignature
         )
     }

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsGeneral.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsGeneral.kt
@@ -9,12 +9,14 @@ import kotlinx.serialization.Transient
 /**
  * General JSON JWS.
  *
- * A general JWS carries one payload and one or more [signatureElements]. Each [SignatureElement] contains the header
+ * A general JWS carries one payload and one or more [SignatureElement]s. Each [SignatureElement] contains the header
  * fragments for one signature and exposes its merged effective [JwsHeader]. All signatures in a [JwsGeneral] share
  * the same payload.
  *
  * [plainPayload] stores the plain payload bytes. JSON serialization base64url-encodes those bytes for the `payload`
  * member, so callers should not pre-encode them.
+ *
+ * If [plainPayload] data structure is defined as part of the contact consider [JwsGeneralTyped]
  */
 @ConsistentCopyVisibility
 @Serializable

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsGeneral.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsGeneral.kt
@@ -14,6 +14,9 @@ data class JwsGeneral(
     @SerialName(SerialNames.SIGNATURES)
     val signatures: List<SignatureElement>
 ) : JWS() {
+    init {
+        require(signatures.isNotEmpty()) { "At least one signature is required" }
+    }
 
     fun getHeaderAt(index: Int): JwsHeader = with(signatures[index]) {
         JwsHeader.fromParts(plainProtectedHeader, unprotectedHeader)

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsGeneral.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsGeneral.kt
@@ -1,7 +1,7 @@
 package at.asitplus.signum.indispensable.josef
 
 import at.asitplus.signum.indispensable.contentEqualsIfArray
-import at.asitplus.signum.indispensable.io.ByteArrayBase64UrlSerializer
+import at.asitplus.signum.indispensable.io.ByteArrayBase64UrlNoPaddingSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
@@ -15,7 +15,7 @@ import kotlinx.serialization.Transient
  */
 @Serializable
 data class JwsGeneral(
-    @Serializable(ByteArrayBase64UrlSerializer::class)
+    @Serializable(ByteArrayBase64UrlNoPaddingSerializer::class)
     @SerialName(SerialNames.PAYLOAD)
     override val payload: ByteArray,
     @Serializable

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsGeneral.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsGeneral.kt
@@ -1,0 +1,32 @@
+package at.asitplus.signum.indispensable.josef
+
+import at.asitplus.signum.indispensable.contentEqualsIfArray
+
+data class JwsGeneral(
+    val payload: ByteArray,
+    val signatures: List<SignatureElement>
+) {
+    fun appendSignature(jwsFlattened: JwsFlattened): JwsGeneral {
+        require(payload.contentEqualsIfArray(jwsFlattened.payload)) {
+            "Additional signed JWS payload must match existing payload"
+        }
+
+        return copy(
+            signatures = signatures + SignatureElement(
+                plainSignature = jwsFlattened.plainSignature,
+                unprotectedHeader = jwsFlattened.unprotectedHeader,
+                plainProtectedHeader = jwsFlattened.plainProtectedHeader,
+            )
+        )
+    }
+}
+
+fun JwsGeneral.toJwsFlattened(): List<JwsFlattened> =
+    signatures.map {
+        JwsFlattened(
+            plainProtectedHeader = it.plainProtectedHeader,
+            unprotectedHeader = it.unprotectedHeader,
+            payload = this.payload,
+            plainSignature = it.plainSignature
+        )
+    }

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsGeneral.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsGeneral.kt
@@ -4,6 +4,7 @@ import at.asitplus.signum.indispensable.contentEqualsIfArray
 import at.asitplus.signum.indispensable.io.ByteArrayBase64UrlSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.Transient
 
 @Serializable
 data class JwsGeneral(
@@ -12,17 +13,19 @@ data class JwsGeneral(
     override val payload: ByteArray,
     @Serializable
     @SerialName(SerialNames.SIGNATURES)
-    val signatures: List<SignatureElement>
+    val signatureElements: List<SignatureElement>
 ) : JWS() {
+
     init {
-        require(signatures.isNotEmpty()) { "At least one signature is required" }
+        require(signatureElements.isNotEmpty()) { "At least one signature is required" }
     }
 
-    fun getHeaderAt(index: Int): JwsHeader = with(signatures[index]) {
-        JwsHeader.fromParts(plainProtectedHeader, unprotectedHeader)
-    }
-    fun getSignatureAt(index: Int) = getSignature(getHeaderAt(index).algorithm, signatures[index].plainSignature)
-    fun getSignatureInputAt(index: Int) = getSignatureInput(signatures[index].plainProtectedHeader, payload)
+    @Transient
+    val jwsHeaders: List<JwsHeader> = signatureElements.map { it.jwsHeader }
+
+    fun getSignatureAt(index: Int) = getSignature(jwsHeaders[index].algorithm, signatureElements[index].plainSignature)
+    fun getSignatureInputAt(index: Int) = getSignatureInput(signatureElements[index].plainProtectedHeader, payload)
+
     /**
      * @return New [JwsGeneral] object with appended Signature
      */
@@ -32,7 +35,7 @@ data class JwsGeneral(
         }
 
         return copy(
-            signatures = signatures + SignatureElement(
+            signatureElements = signatureElements + SignatureElement(
                 plainSignature = jwsFlattened.plainSignature,
                 unprotectedHeader = jwsFlattened.unprotectedHeader,
                 plainProtectedHeader = jwsFlattened.plainProtectedHeader,
@@ -47,14 +50,14 @@ data class JwsGeneral(
         other as JwsGeneral
 
         if (!payload.contentEquals(other.payload)) return false
-        if (signatures != other.signatures) return false
+        if (signatureElements != other.signatureElements) return false
 
         return true
     }
 
     override fun hashCode(): Int {
         var result = payload.contentHashCode()
-        result = 31 * result + signatures.hashCode()
+        result = 31 * result + signatureElements.hashCode()
         return result
     }
 
@@ -65,7 +68,7 @@ data class JwsGeneral(
 
 
 fun JwsGeneral.toJwsFlattened(): List<JwsFlattened> =
-    signatures.map {
+    signatureElements.map {
         JwsFlattened(
             plainProtectedHeader = it.plainProtectedHeader,
             unprotectedHeader = it.unprotectedHeader,

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsGeneral.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsGeneral.kt
@@ -8,10 +8,10 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class JwsGeneral(
     @Serializable(ByteArrayBase64UrlSerializer::class)
-    @SerialName(JWS.SerialNames.PAYLOAD)
+    @SerialName(SerialNames.PAYLOAD)
     override val payload: ByteArray,
     @Serializable
-    @SerialName(JWS.SerialNames.SIGNATURES)
+    @SerialName(SerialNames.SIGNATURES)
     val signatures: List<SignatureElement>
 ) : JWS() {
     /**

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsGeneral.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsGeneral.kt
@@ -14,6 +14,11 @@ data class JwsGeneral(
     @SerialName(SerialNames.SIGNATURES)
     val signatures: List<SignatureElement>
 ) : JWS() {
+
+    fun getHeader(index: Int): JwsHeader = with(signatures[index]) {
+        JwsHeader.fromParts(plainProtectedHeader, unprotectedHeader)
+    }
+
     /**
      * @return New [JwsGeneral] object with appended Signature
      */
@@ -48,7 +53,12 @@ data class JwsGeneral(
         result = 31 * result + signatures.hashCode()
         return result
     }
+
+    companion object {
+        //TODO Invoke function
+    }
 }
+
 
 fun JwsGeneral.toJwsFlattened(): List<JwsFlattened> =
     signatures.map {

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsGeneral.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsGeneral.kt
@@ -19,6 +19,24 @@ data class JwsGeneral(
             )
         )
     }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as JwsGeneral
+
+        if (!payload.contentEquals(other.payload)) return false
+        if (signatures != other.signatures) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = payload.contentHashCode()
+        result = 31 * result + signatures.hashCode()
+        return result
+    }
 }
 
 fun JwsGeneral.toJwsFlattened(): List<JwsFlattened> =

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsGeneral.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsGeneral.kt
@@ -13,8 +13,9 @@ import kotlinx.serialization.Transient
  * fragments for one signature and exposes its merged effective [JwsHeader]. All signatures in a [JwsGeneral] share
  * the same payload.
  */
+@ConsistentCopyVisibility
 @Serializable
-data class JwsGeneral(
+data class JwsGeneral internal constructor(
     @Serializable(ByteArrayBase64UrlNoPaddingSerializer::class)
     @SerialName(SerialNames.PAYLOAD)
     override val plainPayload: ByteArray,

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsGeneral.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsGeneral.kt
@@ -23,8 +23,11 @@ data class JwsGeneral(
     @Transient
     val jwsHeaders: List<JwsHeader> = signatureElements.map { it.jwsHeader }
 
-    fun getSignatureAt(index: Int) = getSignature(jwsHeaders[index].algorithm, signatureElements[index].plainSignature)
-    fun getSignatureInputAt(index: Int) = getSignatureInput(signatureElements[index].plainProtectedHeader, payload)
+    @Transient
+    val signatures = signatureElements.map { it.signature }
+
+    @Transient
+    val signatureInputs = signatureElements.map { getSignatureInput(it.plainProtectedHeader, payload) }
 
     /**
      * @return New [JwsGeneral] object with appended Signature

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsGeneral.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsGeneral.kt
@@ -15,10 +15,11 @@ data class JwsGeneral(
     val signatures: List<SignatureElement>
 ) : JWS() {
 
-    fun getHeader(index: Int): JwsHeader = with(signatures[index]) {
+    fun getHeaderAt(index: Int): JwsHeader = with(signatures[index]) {
         JwsHeader.fromParts(plainProtectedHeader, unprotectedHeader)
     }
-
+    fun getSignatureAt(index: Int) = getSignature(getHeaderAt(index).algorithm, signatures[index].plainSignature)
+    fun getSignatureInputAt(index: Int) = getSignatureInput(signatures[index].plainProtectedHeader, payload)
     /**
      * @return New [JwsGeneral] object with appended Signature
      */
@@ -55,7 +56,7 @@ data class JwsGeneral(
     }
 
     companion object {
-        //TODO Invoke function
+        operator fun invoke(jwsFlattened: List<JwsFlattened>): JwsGeneral = jwsFlattened.toJwsGeneral()
     }
 }
 

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsHeader.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsHeader.kt
@@ -217,6 +217,7 @@ data class JwsHeader(
      * third party. May be parsed as a [JwsCompact], with [JsonWebToken] as the payload.
      */
     @SerialName("jwt")
+    @Serializable(with = JwsCompactStringSerializer::class)
     val attestationJwt: JwsCompact? = null,
 
     /**
@@ -224,6 +225,7 @@ data class JwsHeader(
      * Should be a [JwsCompact], with [JsonWebToken] as the payload
      */
     @SerialName("key_attestation")
+    @Serializable(with = JwsCompactStringSerializer::class)
     val keyAttestation: JwsCompact? = null,
 
     /**
@@ -282,8 +284,10 @@ data class JwsHeader(
         @Serializable(with = ByteArrayBase64UrlSerializer::class)
         val certificateSha256Thumbprint: ByteArray? = null,
         @SerialName("jwt")
+        @Serializable(with = JwsCompactStringSerializer::class)
         val attestationJwt: JwsCompact? = null,
         @SerialName("key_attestation")
+        @Serializable(with = JwsCompactStringSerializer::class)
         val keyAttestation: JwsCompact? = null,
         @SerialName("vctm")
         val vcTypeMetadata: Set<String>? = null,

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsHeader.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsHeader.kt
@@ -16,6 +16,10 @@ import kotlin.time.Instant
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.UseSerializers
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.decodeFromJsonElement
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.jsonObject
 
 /**
  * Header of a [JwsSigned].
@@ -238,6 +242,108 @@ data class JwsHeader(
     @Deprecated("To be removed in next release")
     fun serialize() = joseCompliantSerializer.encodeToString(this)
 
+    /**
+     * Typed representation of a protected or unprotected JWS header fragment.
+     *
+     * Individual fragments may be incomplete. Only [fromParts] guarantees a valid [JwsHeader].
+     */
+    @Serializable
+    data class Part(
+        @SerialName("kid")
+        val keyId: String? = null,
+        @SerialName("typ")
+        val type: String? = null,
+        @SerialName("alg")
+        val algorithm: JwsAlgorithm? = null,
+        @SerialName("cty")
+        val contentType: String? = null,
+        @SerialName("x5c")
+        @Serializable(with = CertificateChainBase64Serializer::class)
+        val certificateChain: CertificateChain? = null,
+        @SerialName("nbf")
+        @Serializable(with = InstantLongSerializer::class)
+        val notBefore: Instant? = null,
+        @SerialName("iat")
+        @Serializable(with = InstantLongSerializer::class)
+        val issuedAt: Instant? = null,
+        @SerialName("exp")
+        @Serializable(with = InstantLongSerializer::class)
+        val expiration: Instant? = null,
+        @SerialName("jwk")
+        val jsonWebKey: JsonWebKey? = null,
+        @SerialName("jku")
+        val jsonWebKeySetUrl: String? = null,
+        @SerialName("x5u")
+        val certificateUrl: String? = null,
+        @SerialName("x5t")
+        @Serializable(with = ByteArrayBase64UrlSerializer::class)
+        val certificateSha1Thumbprint: ByteArray? = null,
+        @SerialName("x5t#S256")
+        @Serializable(with = ByteArrayBase64UrlSerializer::class)
+        val certificateSha256Thumbprint: ByteArray? = null,
+        @SerialName("jwt")
+        val attestationJwt: String? = null,
+        @SerialName("key_attestation")
+        val keyAttestation: String? = null,
+        @SerialName("vctm")
+        val vcTypeMetadata: Set<String>? = null,
+    ) {
+        fun toJsonObject(): JsonObject =
+            joseCompliantSerializer.encodeToJsonElement(serializer(), this).jsonObject
+
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other == null || this::class != other::class) return false
+
+            other as Part
+
+            if (keyId != other.keyId) return false
+            if (type != other.type) return false
+            if (algorithm != other.algorithm) return false
+            if (contentType != other.contentType) return false
+            if (certificateChain != other.certificateChain) return false
+            if (notBefore != other.notBefore) return false
+            if (issuedAt != other.issuedAt) return false
+            if (expiration != other.expiration) return false
+            if (jsonWebKey != other.jsonWebKey) return false
+            if (jsonWebKeySetUrl != other.jsonWebKeySetUrl) return false
+            if (certificateUrl != other.certificateUrl) return false
+            if (certificateSha1Thumbprint != null) {
+                if (other.certificateSha1Thumbprint == null) return false
+                if (!certificateSha1Thumbprint.contentEquals(other.certificateSha1Thumbprint)) return false
+            } else if (other.certificateSha1Thumbprint != null) return false
+            if (certificateSha256Thumbprint != null) {
+                if (other.certificateSha256Thumbprint == null) return false
+                if (!certificateSha256Thumbprint.contentEquals(other.certificateSha256Thumbprint)) return false
+            } else if (other.certificateSha256Thumbprint != null) return false
+            if (attestationJwt != other.attestationJwt) return false
+            if (keyAttestation != other.keyAttestation) return false
+            if (vcTypeMetadata != other.vcTypeMetadata) return false
+
+            return true
+        }
+
+        override fun hashCode(): Int {
+            var result = keyId?.hashCode() ?: 0
+            result = 31 * result + (type?.hashCode() ?: 0)
+            result = 31 * result + (algorithm?.hashCode() ?: 0)
+            result = 31 * result + (contentType?.hashCode() ?: 0)
+            result = 31 * result + (certificateChain?.hashCode() ?: 0)
+            result = 31 * result + (notBefore?.hashCode() ?: 0)
+            result = 31 * result + (issuedAt?.hashCode() ?: 0)
+            result = 31 * result + (expiration?.hashCode() ?: 0)
+            result = 31 * result + (jsonWebKey?.hashCode() ?: 0)
+            result = 31 * result + (jsonWebKeySetUrl?.hashCode() ?: 0)
+            result = 31 * result + (certificateUrl?.hashCode() ?: 0)
+            result = 31 * result + (certificateSha1Thumbprint?.contentHashCode() ?: 0)
+            result = 31 * result + (certificateSha256Thumbprint?.contentHashCode() ?: 0)
+            result = 31 * result + (attestationJwt?.hashCode() ?: 0)
+            result = 31 * result + (keyAttestation?.hashCode() ?: 0)
+            result = 31 * result + (vcTypeMetadata?.hashCode() ?: 0)
+            return result
+        }
+    }
+
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other == null || this::class != other::class) return false
@@ -308,6 +414,29 @@ data class JwsHeader(
     }
 
     companion object {
+        fun fromParts(
+            protectedHeader: Part? = null,
+            unprotectedHeader: Part? = null,
+        ): JwsHeader = fromJsonObjects(
+            protectedHeader = protectedHeader?.toJsonObject(),
+            unprotectedHeader = unprotectedHeader?.toJsonObject(),
+        )
+
+        fun fromParts(
+            protectedHeader: ByteArray? = null,
+            unprotectedHeader: Part? = null,
+        ): JwsHeader = fromJsonObjects(
+            protectedHeader = protectedHeader?.let(JwsProtectedHeaderSerializer::decodeToJsonObject),
+            unprotectedHeader = unprotectedHeader?.toJsonObject(),
+        )
+
+        internal fun fromJsonObjects(
+            protectedHeader: JsonObject? = null,
+            unprotectedHeader: JsonObject? = null,
+        ): JwsHeader = joseCompliantSerializer.decodeFromJsonElement<JwsHeader>(
+            protectedHeader.strictUnion(unprotectedHeader)
+        )
+
         // TODO usages!
         @Deprecated("To be removed in next release")
         fun deserialize(it: String) = catching {

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsHeader.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsHeader.kt
@@ -18,7 +18,8 @@ import kotlinx.serialization.json.jsonObject
 import kotlin.time.Instant
 
 /**
- * Effective JWS header after combining protected and unprotected header members.
+ * Effective JWS header as defined in [RFC 7515](https://datatracker.ietf.org/doc/html/rfc7515)
+ * after combining protected and unprotected header members.
  *
  * [JwsCompact] carries this header entirely in the protected section. [JwsFlattened], [JwsGeneral], and
  * [SignatureElement] represent the protected and unprotected fragments as [Part] and reconstruct the effective
@@ -27,7 +28,7 @@ import kotlin.time.Instant
  * Individual fragments may be incomplete. Only the combination of protected and unprotected parameters must
  * constitute a valid [JwsHeader].
  *
- * See [RFC 7515](https://datatracker.ietf.org/doc/html/rfc7515).
+ * Private Header Parameters as specified in RFC 7515 4.3 are currently not implemented
  */
 @Serializable
 data class JwsHeader(

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsHeader.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsHeader.kt
@@ -41,7 +41,7 @@ data class JwsHeader(
      * When used with a JWK, the "kid" value is used to match a JWK "kid"
      * parameter value.
      */
-    @SerialName("kid")
+    @SerialName(SerialNames.KEY_ID)
     val keyId: String? = null,
 
     /**
@@ -56,7 +56,7 @@ data class JwsHeader(
      * processing of this parameter is performed by the JWS application.
      * Use of this Header Parameter is OPTIONAL.
      */
-    @SerialName("typ")
+    @SerialName(SerialNames.TYPE)
     val type: String? = null,
 
     /**
@@ -72,7 +72,7 @@ data class JwsHeader(
      * Parameter MUST be present and MUST be understood and processed by
      * implementations.
      */
-    @SerialName("alg")
+    @SerialName(SerialNames.ALGORITHM)
     val algorithm: JwsAlgorithm,
 
     /**
@@ -87,7 +87,7 @@ data class JwsHeader(
      * parameter is performed by the JWS application.  Use of this Header
      * Parameter is OPTIONAL.
      */
-    @SerialName("cty")
+    @SerialName(SerialNames.CONTENT_TYPE)
     val contentType: String? = null,
 
     /**
@@ -106,7 +106,7 @@ data class JwsHeader(
      * the certificate or certificate chain to be invalid if any validation
      * failure occurs.  Use of this Header Parameter is OPTIONAL.
      */
-    @SerialName("x5c")
+    @SerialName(SerialNames.CERTIFICATE_CHAIN)
     @Serializable(with = CertificateChainBase64Serializer::class)
     val certificateChain: CertificateChain? = null,
 
@@ -119,7 +119,7 @@ data class JwsHeader(
      * account for clock skew.  Its value MUST be a number containing a
      * NumericDate value.  Use of this claim is OPTIONAL.
      */
-    @SerialName("nbf")
+    @SerialName(SerialNames.NOT_BEFORE)
     @Serializable(with = InstantLongSerializer::class)
     val notBefore: Instant? = null,
 
@@ -129,7 +129,7 @@ data class JwsHeader(
      * value MUST be a number containing a NumericDate value.  Use of this
      * claim is OPTIONAL.
      */
-    @SerialName("iat")
+    @SerialName(SerialNames.ISSUED_AT)
     @Serializable(with = InstantLongSerializer::class)
     val issuedAt: Instant? = null,
 
@@ -142,7 +142,7 @@ data class JwsHeader(
      * a few minutes, to account for clock skew.  Its value MUST be a number
      * containing a NumericDate value.  Use of this claim is OPTIONAL.
      */
-    @SerialName("exp")
+    @SerialName(SerialNames.EXPIRATION)
     @Serializable(with = InstantLongSerializer::class)
     val expiration: Instant? = null,
 
@@ -152,7 +152,7 @@ data class JwsHeader(
      * represented as a JSON Web Key (JWK).  Use of this Header Parameter is
      * OPTIONAL.
      */
-    @SerialName("jwk")
+    @SerialName(SerialNames.JSON_WEB_KEY)
     val jsonWebKey: JsonWebKey? = null,
 
     /**
@@ -167,7 +167,7 @@ data class JwsHeader(
      * Section 8 on TLS requirements.  Use of this Header Parameter is
      * OPTIONAL.
      */
-    @SerialName("jku")
+    @SerialName(SerialNames.JSON_WEB_KEY_SET_URL)
     val jsonWebKeySetUrl: String? = null,
 
     /**
@@ -188,7 +188,7 @@ data class JwsHeader(
      * Also, see Section 8 on TLS requirements.  Use of this Header
      * Parameter is OPTIONAL.
      */
-    @SerialName("x5u")
+    @SerialName(SerialNames.CERTIFICATE_URL)
     val certificateUrl: String? = null,
 
     /**
@@ -199,7 +199,7 @@ data class JwsHeader(
      * are also sometimes known as certificate fingerprints.  Use of this
      * Header Parameter is OPTIONAL.
      */
-    @SerialName("x5t")
+    @SerialName(SerialNames.CERTIFICATE_SHA1_THUMBPRINT)
     @Serializable(with = ByteArrayBase64UrlSerializer::class)
     val certificateSha1Thumbprint: ByteArray? = null,
 
@@ -211,7 +211,7 @@ data class JwsHeader(
      * thumbprints are also sometimes known as certificate fingerprints.
      * Use of this Header Parameter is OPTIONAL.
      */
-    @SerialName("x5t#S256")
+    @SerialName(SerialNames.CERTIFICATE_SHA256_THUMBPRINT)
     @Serializable(with = ByteArrayBase64UrlSerializer::class)
     val certificateSha256Thumbprint: ByteArray? = null,
 
@@ -219,7 +219,7 @@ data class JwsHeader(
      * OID4VP: Verifier Attestation JWT, used to authenticate a Verifier, by providing a JWT signed by a trusted
      * third party. May be parsed as a [JwsCompact], with [JsonWebToken] as the payload.
      */
-    @SerialName("jwt")
+    @SerialName(SerialNames.ATTESTATION_JWT)
     @Serializable(with = JwsCompactStringSerializer::class)
     val attestationJwt: JwsCompact? = null,
 
@@ -227,7 +227,7 @@ data class JwsHeader(
      * OpenID4VCI: Optional. JOSE Header containing a key attestation as described in Appendix D.
      * Should be a [JwsCompact], with [JsonWebToken] as the payload
      */
-    @SerialName("key_attestation")
+    @SerialName(SerialNames.KEY_ATTESTATION)
     @Serializable(with = JwsCompactStringSerializer::class)
     val keyAttestation: JwsCompact? = null,
 
@@ -240,7 +240,7 @@ data class JwsHeader(
      *
      * Defined as a [String] here, so client applications can parse to appropriate types.
      */
-    @SerialName("vctm")
+    @SerialName(SerialNames.VC_TYPE_METADATA)
     val vcTypeMetadata: Set<String>? = null,
 ) {
     /**
@@ -251,45 +251,45 @@ data class JwsHeader(
      */
     @Serializable
     data class Part(
-        @SerialName("kid")
+        @SerialName(SerialNames.KEY_ID)
         val keyId: String? = null,
-        @SerialName("typ")
+        @SerialName(SerialNames.TYPE)
         val type: String? = null,
-        @SerialName("alg")
+        @SerialName(SerialNames.ALGORITHM)
         val algorithm: JwsAlgorithm? = null,
-        @SerialName("cty")
+        @SerialName(SerialNames.CONTENT_TYPE)
         val contentType: String? = null,
-        @SerialName("x5c")
+        @SerialName(SerialNames.CERTIFICATE_CHAIN)
         @Serializable(with = CertificateChainBase64Serializer::class)
         val certificateChain: CertificateChain? = null,
-        @SerialName("nbf")
+        @SerialName(SerialNames.NOT_BEFORE)
         @Serializable(with = InstantLongSerializer::class)
         val notBefore: Instant? = null,
-        @SerialName("iat")
+        @SerialName(SerialNames.ISSUED_AT)
         @Serializable(with = InstantLongSerializer::class)
         val issuedAt: Instant? = null,
-        @SerialName("exp")
+        @SerialName(SerialNames.EXPIRATION)
         @Serializable(with = InstantLongSerializer::class)
         val expiration: Instant? = null,
-        @SerialName("jwk")
+        @SerialName(SerialNames.JSON_WEB_KEY)
         val jsonWebKey: JsonWebKey? = null,
-        @SerialName("jku")
+        @SerialName(SerialNames.JSON_WEB_KEY_SET_URL)
         val jsonWebKeySetUrl: String? = null,
-        @SerialName("x5u")
+        @SerialName(SerialNames.CERTIFICATE_URL)
         val certificateUrl: String? = null,
-        @SerialName("x5t")
+        @SerialName(SerialNames.CERTIFICATE_SHA1_THUMBPRINT)
         @Serializable(with = ByteArrayBase64UrlSerializer::class)
         val certificateSha1Thumbprint: ByteArray? = null,
-        @SerialName("x5t#S256")
+        @SerialName(SerialNames.CERTIFICATE_SHA256_THUMBPRINT)
         @Serializable(with = ByteArrayBase64UrlSerializer::class)
         val certificateSha256Thumbprint: ByteArray? = null,
-        @SerialName("jwt")
+        @SerialName(SerialNames.ATTESTATION_JWT)
         @Serializable(with = JwsCompactStringSerializer::class)
         val attestationJwt: JwsCompact? = null,
-        @SerialName("key_attestation")
+        @SerialName(SerialNames.KEY_ATTESTATION)
         @Serializable(with = JwsCompactStringSerializer::class)
         val keyAttestation: JwsCompact? = null,
-        @SerialName("vctm")
+        @SerialName(SerialNames.VC_TYPE_METADATA)
         val vcTypeMetadata: Set<String>? = null,
     ) {
         fun toJsonObject(): JsonObject =
@@ -420,6 +420,25 @@ data class JwsHeader(
             )
                 .getOrNull()
         }
+    }
+
+    object SerialNames {
+        const val KEY_ID = "kid"
+        const val TYPE = "typ"
+        const val ALGORITHM = "alg"
+        const val CONTENT_TYPE = "cty"
+        const val CERTIFICATE_CHAIN = "x5c"
+        const val NOT_BEFORE = "nbf"
+        const val ISSUED_AT = "iat"
+        const val EXPIRATION = "exp"
+        const val JSON_WEB_KEY = "jwk"
+        const val JSON_WEB_KEY_SET_URL = "jku"
+        const val CERTIFICATE_URL = "x5u"
+        const val CERTIFICATE_SHA1_THUMBPRINT = "x5t"
+        const val CERTIFICATE_SHA256_THUMBPRINT = "x5t#S256"
+        const val ATTESTATION_JWT = "jwt"
+        const val KEY_ATTESTATION = "key_attestation"
+        const val VC_TYPE_METADATA = "vctm"
     }
 
     companion object {

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsHeader.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsHeader.kt
@@ -8,18 +8,18 @@ import at.asitplus.signum.indispensable.io.ByteArrayBase64Serializer
 import at.asitplus.signum.indispensable.io.ByteArrayBase64UrlSerializer
 import at.asitplus.signum.indispensable.io.CertificateChainBase64Serializer
 import at.asitplus.signum.indispensable.io.InstantLongSerializer
+import at.asitplus.signum.indispensable.josef.JwsHeader.Companion.fromParts
 import at.asitplus.signum.indispensable.josef.io.JwsCertificateSerializer
 import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
 import at.asitplus.signum.indispensable.pki.CertificateChain
 import at.asitplus.signum.indispensable.pki.leaf
-import kotlin.time.Instant
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.UseSerializers
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.decodeFromJsonElement
-import kotlinx.serialization.json.encodeToJsonElement
 import kotlinx.serialization.json.jsonObject
+import kotlin.time.Instant
 
 /**
  * Header of a [JwsSigned].
@@ -214,17 +214,17 @@ data class JwsHeader(
 
     /**
      * OID4VP: Verifier Attestation JWT, used to authenticate a Verifier, by providing a JWT signed by a trusted
-     * third party. May be parsed as a [JwsSigned], with [JsonWebToken] as the payload.
+     * third party. May be parsed as a [JwsCompact], with [JsonWebToken] as the payload.
      */
     @SerialName("jwt")
-    val attestationJwt: String? = null,
+    val attestationJwt: JwsCompact? = null,
 
     /**
      * OpenID4VCI: Optional. JOSE Header containing a key attestation as described in Appendix D.
-     * See [keyAttestationParsed].
+     * Should be a [JwsCompact], with [JsonWebToken] as the payload
      */
     @SerialName("key_attestation")
-    val keyAttestation: String? = null,
+    val keyAttestation: JwsCompact? = null,
 
     /**
      * SD-JWT VC: Credentials MAY encode Type Metadata directly, providing it as "glue information"
@@ -282,9 +282,9 @@ data class JwsHeader(
         @Serializable(with = ByteArrayBase64UrlSerializer::class)
         val certificateSha256Thumbprint: ByteArray? = null,
         @SerialName("jwt")
-        val attestationJwt: String? = null,
+        val attestationJwt: JwsCompact? = null,
         @SerialName("key_attestation")
-        val keyAttestation: String? = null,
+        val keyAttestation: JwsCompact? = null,
         @SerialName("vctm")
         val vcTypeMetadata: Set<String>? = null,
     ) {
@@ -406,9 +406,14 @@ data class JwsHeader(
             ?: certificateChain?.leaf?.decodedPublicKey?.getOrNull()
     }
 
+    @Deprecated("Use [keyAttestation] directly", replaceWith = ReplaceWith("keyAttestation"))
     val keyAttestationParsed: JwsSigned<KeyAttestationJwt>? by lazy {
         keyAttestation?.let {
-            JwsSigned.deserialize<KeyAttestationJwt>(KeyAttestationJwt.serializer(), it, joseCompliantSerializer)
+            JwsSigned.deserialize<KeyAttestationJwt>(
+                KeyAttestationJwt.serializer(),
+                it.toString(),
+                joseCompliantSerializer
+            )
                 .getOrNull()
         }
     }

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsHeader.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsHeader.kt
@@ -1,10 +1,7 @@
-@file:UseSerializers(ByteArrayBase64Serializer::class, JwsCertificateSerializer::class)
-
 package at.asitplus.signum.indispensable.josef
 
 import at.asitplus.catching
 import at.asitplus.signum.indispensable.CryptoPublicKey
-import at.asitplus.signum.indispensable.io.ByteArrayBase64Serializer
 import at.asitplus.signum.indispensable.io.ByteArrayBase64UrlSerializer
 import at.asitplus.signum.indispensable.io.CertificateChainBase64Serializer
 import at.asitplus.signum.indispensable.io.InstantLongSerializer
@@ -15,7 +12,6 @@ import at.asitplus.signum.indispensable.pki.CertificateChain
 import at.asitplus.signum.indispensable.pki.leaf
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.UseSerializers
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.decodeFromJsonElement
 import kotlinx.serialization.json.jsonObject

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsHeader.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsHeader.kt
@@ -22,9 +22,16 @@ import kotlinx.serialization.json.jsonObject
 import kotlin.time.Instant
 
 /**
- * Header of a [JwsSigned].
+ * Effective JWS header after combining protected and unprotected header members.
  *
- * See [RFC 7515](https://datatracker.ietf.org/doc/html/rfc7515)
+ * [JwsCompact] carries this header entirely in the protected section. [JwsFlattened], [JwsGeneral], and
+ * [SignatureElement] represent the protected and unprotected fragments as [Part] and reconstruct the effective
+ * header with [fromParts].
+ *
+ * Individual fragments may be incomplete. Only the combination of protected and unprotected parameters must
+ * constitute a valid [JwsHeader].
+ *
+ * See [RFC 7515](https://datatracker.ietf.org/doc/html/rfc7515).
  */
 @Serializable
 data class JwsHeader(
@@ -245,9 +252,10 @@ data class JwsHeader(
     fun serialize() = joseCompliantSerializer.encodeToString(this)
 
     /**
-     * Typed representation of a protected or unprotected JWS header fragment.
+     * Typed representation of either the protected or unprotected JWS header fragment.
      *
-     * Individual fragments may be incomplete. Only [fromParts] guarantees a valid [JwsHeader].
+     * A [Part] may be incomplete and does not have to be a valid [JwsHeader] on its own. Only the merged protected
+     * plus unprotected representation must decode to a valid [JwsHeader].
      */
     @Serializable
     data class Part(
@@ -423,6 +431,11 @@ data class JwsHeader(
     }
 
     companion object {
+        /**
+         * Merges protected and unprotected header fragments into the effective [JwsHeader].
+         *
+         * Either fragment may be partial, but their combined content must form a valid header.
+         */
         fun fromParts(
             protectedHeader: Part? = null,
             unprotectedHeader: Part? = null,
@@ -431,6 +444,11 @@ data class JwsHeader(
             unprotectedHeader = unprotectedHeader?.toJsonObject(),
         )
 
+        /**
+         * Decodes the protected fragment and merges it with the optional unprotected fragment.
+         *
+         * This is the form used when reading serialized JWS values such as [JwsCompact] or [JwsFlattened].
+         */
         fun fromParts(
             protectedHeader: ByteArray? = null,
             unprotectedHeader: Part? = null,
@@ -455,6 +473,12 @@ data class JwsHeader(
     }
 }
 
+/**
+ * Converts the effective header into a single [JwsHeader.Part].
+ *
+ * Use this when one fragment should represent the whole header, for example the protected header in [JwsCompact].
+ * When protected and unprotected members differ, construct the two [JwsHeader.Part] values explicitly.
+ */
 fun JwsHeader.toPart(): JwsHeader.Part = JwsHeader.Part(
     keyId = keyId,
     type = type,

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsHeader.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsHeader.kt
@@ -463,13 +463,6 @@ data class JwsHeader(
         ): JwsHeader = joseCompliantSerializer.decodeFromJsonElement<JwsHeader>(
             protectedHeader.strictUnion(unprotectedHeader)
         )
-
-        // TODO usages!
-        @Deprecated("To be removed in next release")
-        fun deserialize(it: String) = catching {
-            joseCompliantSerializer.decodeFromString<JwsHeader>(it)
-        }
-
     }
 }
 

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsHeader.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsHeader.kt
@@ -247,10 +247,6 @@ data class JwsHeader(
     @SerialName("vctm")
     val vcTypeMetadata: Set<String>? = null,
 ) {
-
-    @Deprecated("To be removed in next release")
-    fun serialize() = joseCompliantSerializer.encodeToString(this)
-
     /**
      * Typed representation of either the protected or unprotected JWS header fragment.
      *

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsHeader.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsHeader.kt
@@ -450,3 +450,22 @@ data class JwsHeader(
 
     }
 }
+
+fun JwsHeader.toPart(): JwsHeader.Part = JwsHeader.Part(
+    keyId = keyId,
+    type = type,
+    algorithm = algorithm,
+    contentType = contentType,
+    certificateChain = certificateChain,
+    notBefore = notBefore,
+    issuedAt = issuedAt,
+    expiration = expiration,
+    jsonWebKey = jsonWebKey,
+    jsonWebKeySetUrl = jsonWebKeySetUrl,
+    certificateUrl = certificateUrl,
+    certificateSha1Thumbprint = certificateSha1Thumbprint,
+    certificateSha256Thumbprint = certificateSha256Thumbprint,
+    attestationJwt = attestationJwt,
+    keyAttestation = keyAttestation,
+    vcTypeMetadata = vcTypeMetadata,
+)

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsHeader.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsHeader.kt
@@ -7,6 +7,7 @@ import at.asitplus.signum.indispensable.io.CertificateChainBase64Serializer
 import at.asitplus.signum.indispensable.io.InstantLongSerializer
 import at.asitplus.signum.indispensable.josef.JwsHeader.Companion.fromParts
 import at.asitplus.signum.indispensable.josef.io.JwsCertificateSerializer
+import at.asitplus.signum.indispensable.josef.JwsTyped.Companion.invoke
 import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
 import at.asitplus.signum.indispensable.pki.CertificateChain
 import at.asitplus.signum.indispensable.pki.leaf
@@ -411,16 +412,8 @@ data class JwsHeader(
             ?: certificateChain?.leaf?.decodedPublicKey?.getOrNull()
     }
 
-    @Deprecated("Use [keyAttestation] directly", replaceWith = ReplaceWith("keyAttestation"))
-    val keyAttestationParsed: JwsSigned<KeyAttestationJwt>? by lazy {
-        keyAttestation?.let {
-            JwsSigned.deserialize<KeyAttestationJwt>(
-                KeyAttestationJwt.serializer(),
-                it.toString(),
-                joseCompliantSerializer
-            )
-                .getOrNull()
-        }
+    val keyAttestationParsed: JwsCompactTyped<KeyAttestationJwt>? by lazy {
+        keyAttestation?.typed()
     }
 
     object SerialNames {

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsProtectedHeaderSerializer.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsProtectedHeaderSerializer.kt
@@ -26,6 +26,23 @@ object JwsProtectedHeaderSerializer : TransformingSerializerTemplate<JwsHeader.P
 ) {
     fun encodeToByteArray(header: JwsHeader.Part): ByteArray = header.toProtectedHeaderBytes()
 
+    /**
+     * RFC 7515 requires empty protected header values to be absent rather than encoded as `{}`.
+     */
+    fun encodeToByteArrayOrNull(header: JwsHeader.Part?): ByteArray? =
+        header
+            ?.takeUnless { it.toJsonObject().isEmpty() }
+            ?.toProtectedHeaderBytes()
+
+    /**
+     * RFC 7515 requires empty protected header values to be absent rather than encoded as `{}`.
+     */
+    internal fun requireAbsentIfEmpty(encodedHeader: ByteArray?) {
+        require(encodedHeader == null || decodeToJsonObject(encodedHeader).isNotEmpty()) {
+            "JWS protected header must be absent when it would otherwise be empty"
+        }
+    }
+
     fun decodeFromByteArray(encodedHeader: ByteArray): JwsHeader.Part = encodedHeader.toProtectedHeaderPart()
 
     fun decodeToJsonObject(encodedHeader: ByteArray): JsonObject = encodedHeader.toProtectedHeaderJsonObject()

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsProtectedHeaderSerializer.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsProtectedHeaderSerializer.kt
@@ -1,0 +1,42 @@
+package at.asitplus.signum.indispensable.josef
+
+import at.asitplus.signum.indispensable.io.Base64UrlStrict
+import at.asitplus.signum.indispensable.io.ByteArrayUtf8Serializer
+import at.asitplus.signum.indispensable.io.TransformingSerializerTemplate
+import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
+import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArray
+import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
+import kotlinx.serialization.json.JsonObject
+
+private fun JwsHeader.Part.toProtectedHeaderBytes(): ByteArray =
+    joseCompliantSerializer.encodeToString(JwsHeader.Part.serializer(), this)
+        .encodeToByteArray()
+        .encodeToString(Base64UrlStrict)
+        .encodeToByteArray()
+
+private fun ByteArray.toProtectedHeaderJsonString(): String =
+    decodeToString()
+        .decodeToByteArray(Base64UrlStrict)
+        .decodeToString()
+
+private fun ByteArray.toProtectedHeaderPart(): JwsHeader.Part =
+    joseCompliantSerializer.decodeFromString(
+        JwsHeader.Part.serializer(),
+        toProtectedHeaderJsonString(),
+    )
+
+private fun ByteArray.toProtectedHeaderJsonObject(): JsonObject =
+    joseCompliantSerializer.decodeFromString(toProtectedHeaderJsonString())
+
+object JwsProtectedHeaderSerializer : TransformingSerializerTemplate<JwsHeader.Part, ByteArray>(
+    parent = ByteArrayUtf8Serializer,
+    encodeAs = JwsHeader.Part::toProtectedHeaderBytes,
+    decodeAs = ByteArray::toProtectedHeaderPart,
+    serialName = "JwsProtectedHeader",
+) {
+    fun encodeToByteArray(header: JwsHeader.Part): ByteArray = header.toProtectedHeaderBytes()
+
+    fun decodeFromByteArray(encodedHeader: ByteArray): JwsHeader.Part = encodedHeader.toProtectedHeaderPart()
+
+    fun decodeToJsonObject(encodedHeader: ByteArray): JsonObject = encodedHeader.toProtectedHeaderJsonObject()
+}

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsProtectedHeaderSerializer.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsProtectedHeaderSerializer.kt
@@ -1,35 +1,25 @@
 package at.asitplus.signum.indispensable.josef
 
-import at.asitplus.signum.indispensable.io.Base64UrlStrict
-import at.asitplus.signum.indispensable.io.ByteArrayUtf8Serializer
+import at.asitplus.signum.indispensable.io.ByteArrayBase64UrlSerializer
 import at.asitplus.signum.indispensable.io.TransformingSerializerTemplate
 import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
-import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArray
-import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
 import kotlinx.serialization.json.JsonObject
 
 private fun JwsHeader.Part.toProtectedHeaderBytes(): ByteArray =
     joseCompliantSerializer.encodeToString(JwsHeader.Part.serializer(), this)
         .encodeToByteArray()
-        .encodeToString(Base64UrlStrict)
-        .encodeToByteArray()
-
-private fun ByteArray.toProtectedHeaderJsonString(): String =
-    decodeToString()
-        .decodeToByteArray(Base64UrlStrict)
-        .decodeToString()
 
 private fun ByteArray.toProtectedHeaderPart(): JwsHeader.Part =
     joseCompliantSerializer.decodeFromString(
         JwsHeader.Part.serializer(),
-        toProtectedHeaderJsonString(),
+        decodeToString(),
     )
 
 private fun ByteArray.toProtectedHeaderJsonObject(): JsonObject =
-    joseCompliantSerializer.decodeFromString(toProtectedHeaderJsonString())
+    joseCompliantSerializer.decodeFromString(decodeToString())
 
 object JwsProtectedHeaderSerializer : TransformingSerializerTemplate<JwsHeader.Part, ByteArray>(
-    parent = ByteArrayUtf8Serializer,
+    parent = ByteArrayBase64UrlSerializer,
     encodeAs = JwsHeader.Part::toProtectedHeaderBytes,
     decodeAs = ByteArray::toProtectedHeaderPart,
     serialName = "JwsProtectedHeader",

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsSigned.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsSigned.kt
@@ -20,7 +20,7 @@ import kotlinx.serialization.json.Json
  *
  * See [RFC 7515](https://datatracker.ietf.org/doc/html/rfc7515)
  */
-@Deprecated("", level = DeprecationLevel.WARNING)
+@Deprecated("Replaced by JwsCompact", level = DeprecationLevel.WARNING, replaceWith = ReplaceWith("JwsCompact"))
 data class JwsSigned<out P : Any>(
     val header: JwsHeader,
     val payload: P,

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsSigned.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsSigned.kt
@@ -20,6 +20,7 @@ import kotlinx.serialization.json.Json
  *
  * See [RFC 7515](https://datatracker.ietf.org/doc/html/rfc7515)
  */
+@Deprecated("", level = DeprecationLevel.WARNING)
 data class JwsSigned<out P : Any>(
     val header: JwsHeader,
     val payload: P,

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsSigned.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsSigned.kt
@@ -20,7 +20,7 @@ import kotlinx.serialization.json.Json
  *
  * See [RFC 7515](https://datatracker.ietf.org/doc/html/rfc7515)
  */
-@Deprecated("Replaced by JwsCompact", level = DeprecationLevel.WARNING, replaceWith = ReplaceWith("JwsCompact"))
+@Deprecated("Replaced by JwsCompactTyped", level = DeprecationLevel.WARNING, replaceWith = ReplaceWith("JwsCompactTyped"))
 data class JwsSigned<out P : Any>(
     val header: JwsHeader,
     val payload: P,

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsTyped.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsTyped.kt
@@ -1,0 +1,71 @@
+package at.asitplus.signum.indispensable.josef
+
+import at.asitplus.signum.indispensable.josef.JwsTyped.Companion.invoke
+import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
+import kotlinx.serialization.serializer
+
+typealias JwsCompactTyped<P> = JwsTyped<JwsCompact, P>
+typealias JwsFlattenedTyped<P> = JwsTyped<JwsFlattened, P>
+typealias JwsGeneralTyped<P> = JwsTyped<JwsGeneral, P>
+
+fun <P> JwsCompactTyped<P>.toJwsFlattenedTyped() = JwsFlattenedTyped(this.jws.toJwsFlattened(), this.payload)
+fun <P> JwsFlattenedTyped<P>.toJwsCompactTyped() = JwsCompactTyped(this.jws.toJwsCompact(), this.payload)
+fun <P> JwsGeneralTyped<P>.toJwsFlattenedTyped() = this.jws.toJwsFlattened().map { JwsFlattenedTyped(it, this.payload) }
+
+inline fun <reified P, J : JWS> J.typed(): JwsTyped<J, P> =
+    JwsTyped(this, getPayload<P>().getOrThrow())
+
+/**
+ * Wrapper for [at.asitplus.signum.indispensable.josef.JWS]. Useful when [payload] type is known as part of the contract.
+ * All communication over the wire should use [jws] only!
+ *
+ * While the constructor can be used the different [invoke]s are recommended.
+ * For convenience also see the typealiases
+ */
+data class JwsTyped<out J : JWS, out P>(
+    val jws: J, val payload: P
+) {
+    override fun toString() = jws.toString()
+
+    companion object {
+        inline operator fun <reified P> invoke(base64UrlString: String) =
+            JwsCompact.parse<P>(base64UrlString).getOrThrow().let { (jws, payload) -> JwsTyped(jws, payload) }
+
+        inline operator fun <reified P> invoke(jwsFlattened: List<JwsFlattened>): JwsTyped<JwsGeneral, P> =
+            jwsFlattened.toJwsGeneral().typed()
+
+        /**
+         * Creates [JwsCompact]. [protectedHeader] must form a valid [JwsHeader].
+         */
+        suspend inline operator fun <reified P> invoke(
+            protectedHeader: JwsHeader, payload: P, noinline signer: suspend (ByteArray) -> ByteArray
+        ): JwsCompactTyped<P> {
+            val plainPayload = joseCompliantSerializer.encodeToString(
+                joseCompliantSerializer.serializersModule.serializer(), payload
+            ).encodeToByteArray()
+            return JwsCompactTyped(
+                JwsCompact.invoke(protectedHeader = protectedHeader, payload = plainPayload, signer = signer), payload
+            )
+        }
+
+        /**
+         * Creates a flattened JWS from protected and unprotected header fragments.
+         * The fragments may be partial, but their merged content must form a valid [JwsHeader].
+         */
+        suspend inline operator fun <reified P> invoke(
+            protectedHeader: JwsHeader.Part?,
+            unprotectedHeader: JwsHeader.Part?,
+            payload: P,
+            noinline signer: suspend (ByteArray) -> ByteArray
+        ): JwsFlattenedTyped<P> {
+            val plainPayload = joseCompliantSerializer.encodeToString(
+                joseCompliantSerializer.serializersModule.serializer(), payload
+            ).encodeToByteArray()
+            return JwsFlattenedTyped(
+                JwsFlattened(
+                    protectedHeader, unprotectedHeader, plainPayload, signer = signer
+                ), payload
+            )
+        }
+    }
+}

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/SignatureElement.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/SignatureElement.kt
@@ -7,7 +7,16 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
 
 /**
- * Signature element as defined in [RFC 7515 Sec 7.2.1](https://www.rfc-editor.org/rfc/rfc7515.html#section-7.2.1)
+ * One signature entry of general JSON JWS serialization.
+ *
+ * A [SignatureElement] contains the signature bytes plus the header fragments for that signature. The protected
+ * fragment is stored as encoded bytes in [plainProtectedHeader], while the optional unprotected fragment is
+ * represented as [JwsHeader.Part]. The effective [jwsHeader] is reconstructed by merging both fragments.
+ *
+ * Either header fragment may be partial. Only the combination of protected and unprotected parameters must
+ * constitute a valid [JwsHeader].
+ *
+ * See [RFC 7515 Sec 7.2.1](https://www.rfc-editor.org/rfc/rfc7515.html#section-7.2.1).
  */
 @Serializable
 data class SignatureElement(

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/SignatureElement.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/SignatureElement.kt
@@ -1,14 +1,9 @@
 package at.asitplus.signum.indispensable.josef
 
-import at.asitplus.signum.indispensable.CryptoSignature
 import at.asitplus.signum.indispensable.io.ByteArrayBase64UrlSerializer
-import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.SerializationException
-import kotlinx.serialization.Transient
 import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.decodeFromJsonElement
 
 
 /**
@@ -26,7 +21,7 @@ data class SignatureElement(
     val plainSignature: ByteArray,
 
     /**
-     * The [protectedHeader] member MUST be present ...when the JWS Protected
+     * The [plainProtectedHeader] member MUST be present ...when the JWS Protected
      * Header value is non-empty; otherwise, it MUST be absent.  These
      * Header Parameter values are integrity protected.
      *
@@ -55,26 +50,4 @@ data class SignatureElement(
         result = 31 * result + plainProtectedHeader.contentHashCode()
         return result
     }
-
-    @Transient
-    val protectedHeader: JsonObject? =
-        plainProtectedHeader?.let { joseCompliantSerializer.decodeFromString(it.decodeToString()) }
-
-    /**
-     * Only the combined header must be a valid [JwsHeader]
-     */
-    @Transient
-    val combinedHeader: JwsHeader =
-        joseCompliantSerializer.decodeFromJsonElement(unprotectedHeader.strictUnion(protectedHeader))
-
-    /**
-     * Lenient Signature Parsing
-     */
-    @Transient
-    val signature: CryptoSignature.RawByteEncodable
-        get() = when (val alg = combinedHeader.algorithm) {
-            is JwsAlgorithm.Signature.EC -> CryptoSignature.EC.fromRawBytes(alg.ecCurve, plainSignature)
-            is JwsAlgorithm.Signature.RSA -> CryptoSignature.RSA(plainSignature)
-            else -> throw SerializationException("Unsupported algorithm for JWS signature element: $alg")
-        }
 }

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/SignatureElement.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/SignatureElement.kt
@@ -1,6 +1,7 @@
 package at.asitplus.signum.indispensable.josef
 
 import at.asitplus.signum.indispensable.io.ByteArrayBase64UrlSerializer
+import at.asitplus.signum.indispensable.josef.JWS.Companion.getSignature
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
@@ -35,6 +36,8 @@ data class SignatureElement(
 ) {
     @Transient
     val jwsHeader: JwsHeader = JwsHeader.fromParts(plainProtectedHeader, unprotectedHeader)
+    @Transient
+    val signature = getSignature(jwsHeader.algorithm, plainSignature)
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/SignatureElement.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/SignatureElement.kt
@@ -43,6 +43,10 @@ data class SignatureElement(
     @SerialName(JWS.SerialNames.HEADER)
     val unprotectedHeader: JwsHeader.Part? = null
 ) {
+    init {
+        JwsProtectedHeaderSerializer.requireAbsentIfEmpty(plainProtectedHeader)
+    }
+
     @Transient
     val jwsHeader: JwsHeader = JwsHeader.fromParts(plainProtectedHeader, unprotectedHeader)
     @Transient

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/SignatureElement.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/SignatureElement.kt
@@ -1,0 +1,67 @@
+package at.asitplus.signum.indispensable.josef
+
+import at.asitplus.signum.indispensable.CryptoSignature
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.Transient
+
+
+/**
+ * Signature element as defined in [RFC 7515 Sec 7.2.1](https://www.rfc-editor.org/rfc/rfc7515.html#section-7.2.1)
+ *
+ * DOES NOT IMPLEMENT UNPROTECTED HEADERS!
+ * Will only be implemented when use-case arises as this significantly
+ * impacts JWS data class representation and verification
+ * (The header in JWS is the union of protected and unprotected header elements)
+ */
+//@Serializable(with = SignatureElementSerializer::class)
+data class SignatureElement(
+    /**
+     * The [protectedHeader] member MUST be present ...when the JWS Protected
+     * Header value is non-empty; otherwise, it MUST be absent.  These
+     * Header Parameter values are integrity protected.
+     *
+     * Serialization: BASE64URL(UTF8(JWS Protected Header))
+     */
+    @SerialName(SerialNames.PROTECTED)
+    @Serializable(with = JwsProtectedHeaderSerializer::class)
+    val protectedHeader: JwsHeader,
+
+    /**
+     * The [signature] member MUST be present
+     *
+     * Serialization: BASE64URL(JWS Signature).
+     */
+    @SerialName(SerialNames.SIGNATURE)
+    val signature: CryptoSignature.RawByteEncodable,
+
+    /**
+     * ASCII string `<BASE64URL(protected)>` as used for signature verification.
+     * See first part of [JwsSigned.prepareJwsSignatureInput]
+     *
+     * This parameter is required for correct serialization!
+     */
+    @Transient
+    val plainHeaderInput: ByteArray,
+) {
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as SignatureElement
+
+        if (protectedHeader != other.protectedHeader) return false
+        if (signature != other.signature) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = protectedHeader.hashCode()
+        result = 31 * result + signature.hashCode()
+        return result
+    }
+
+
+}

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/SignatureElement.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/SignatureElement.kt
@@ -1,10 +1,9 @@
 package at.asitplus.signum.indispensable.josef
 
 import at.asitplus.signum.indispensable.io.ByteArrayBase64UrlSerializer
+import at.asitplus.signum.indispensable.io.ByteArrayUtf8Serializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.JsonObject
-
 
 /**
  * Signature element as defined in [RFC 7515 Sec 7.2.1](https://www.rfc-editor.org/rfc/rfc7515.html#section-7.2.1)
@@ -26,13 +25,13 @@ data class SignatureElement(
      * Header Parameter values are integrity protected.
      *
      * Serialization: BASE64URL(UTF8(JWS Protected Header))
-     */
+    */
     @SerialName(JWS.SerialNames.PROTECTED)
-    @Serializable(with = ByteArrayBase64UrlSerializer::class)
+    @Serializable(with = ByteArrayUtf8Serializer::class)
     val plainProtectedHeader: ByteArray? = null,
 
     @SerialName(JWS.SerialNames.HEADER)
-    val unprotectedHeader: JsonObject? = null
+    val unprotectedHeader: JwsHeader.Part? = null
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/SignatureElement.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/SignatureElement.kt
@@ -3,6 +3,7 @@ package at.asitplus.signum.indispensable.josef
 import at.asitplus.signum.indispensable.io.ByteArrayBase64UrlSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.Transient
 
 /**
  * Signature element as defined in [RFC 7515 Sec 7.2.1](https://www.rfc-editor.org/rfc/rfc7515.html#section-7.2.1)
@@ -32,6 +33,9 @@ data class SignatureElement(
     @SerialName(JWS.SerialNames.HEADER)
     val unprotectedHeader: JwsHeader.Part? = null
 ) {
+    @Transient
+    val jwsHeader: JwsHeader = JwsHeader.fromParts(plainProtectedHeader, unprotectedHeader)
+
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other == null || this::class != other::class) return false

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/SignatureElement.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/SignatureElement.kt
@@ -1,21 +1,30 @@
 package at.asitplus.signum.indispensable.josef
 
 import at.asitplus.signum.indispensable.CryptoSignature
+import at.asitplus.signum.indispensable.io.ByteArrayBase64UrlSerializer
+import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerializationException
 import kotlinx.serialization.Transient
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.decodeFromJsonElement
 
 
 /**
  * Signature element as defined in [RFC 7515 Sec 7.2.1](https://www.rfc-editor.org/rfc/rfc7515.html#section-7.2.1)
- *
- * DOES NOT IMPLEMENT UNPROTECTED HEADERS!
- * Will only be implemented when use-case arises as this significantly
- * impacts JWS data class representation and verification
- * (The header in JWS is the union of protected and unprotected header elements)
  */
-//@Serializable(with = SignatureElementSerializer::class)
+@Serializable
 data class SignatureElement(
+    /**
+     * The [plainSignature] member MUST be present
+     *
+     * Serialization: BASE64URL(JWS Signature).
+     */
+    @SerialName(JWS.SerialNames.SIGNATURE)
+    @Serializable(ByteArrayBase64UrlSerializer::class)
+    val plainSignature: ByteArray,
+
     /**
      * The [protectedHeader] member MUST be present ...when the JWS Protected
      * Header value is non-empty; otherwise, it MUST be absent.  These
@@ -23,45 +32,49 @@ data class SignatureElement(
      *
      * Serialization: BASE64URL(UTF8(JWS Protected Header))
      */
-    @SerialName(SerialNames.PROTECTED)
-    @Serializable(with = JwsProtectedHeaderSerializer::class)
-    val protectedHeader: JwsHeader,
+    @SerialName(JWS.SerialNames.PROTECTED)
+    @Serializable(with = ByteArrayBase64UrlSerializer::class)
+    val plainProtectedHeader: ByteArray? = null,
 
-    /**
-     * The [signature] member MUST be present
-     *
-     * Serialization: BASE64URL(JWS Signature).
-     */
-    @SerialName(SerialNames.SIGNATURE)
-    val signature: CryptoSignature.RawByteEncodable,
-
-    /**
-     * ASCII string `<BASE64URL(protected)>` as used for signature verification.
-     * See first part of [JwsSigned.prepareJwsSignatureInput]
-     *
-     * This parameter is required for correct serialization!
-     */
-    @Transient
-    val plainHeaderInput: ByteArray,
+    @SerialName(JWS.SerialNames.HEADER)
+    val unprotectedHeader: JsonObject? = null
 ) {
-
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other == null || this::class != other::class) return false
 
         other as SignatureElement
 
-        if (protectedHeader != other.protectedHeader) return false
-        if (signature != other.signature) return false
-
+        if (!plainSignature.contentEquals(other.plainSignature)) return false
+        if (!plainProtectedHeader.contentEquals(other.plainProtectedHeader)) return false
         return true
     }
 
     override fun hashCode(): Int {
-        var result = protectedHeader.hashCode()
-        result = 31 * result + signature.hashCode()
+        var result = plainSignature.contentHashCode()
+        result = 31 * result + plainProtectedHeader.contentHashCode()
         return result
     }
 
+    @Transient
+    val protectedHeader: JsonObject? =
+        plainProtectedHeader?.let { joseCompliantSerializer.decodeFromString(it.decodeToString()) }
 
+    /**
+     * Only the combined header must be a valid [JwsHeader]
+     */
+    @Transient
+    val combinedHeader: JwsHeader =
+        joseCompliantSerializer.decodeFromJsonElement(unprotectedHeader.strictUnion(protectedHeader))
+
+    /**
+     * Lenient Signature Parsing
+     */
+    @Transient
+    val signature: CryptoSignature.RawByteEncodable
+        get() = when (val alg = combinedHeader.algorithm) {
+            is JwsAlgorithm.Signature.EC -> CryptoSignature.EC.fromRawBytes(alg.ecCurve, plainSignature)
+            is JwsAlgorithm.Signature.RSA -> CryptoSignature.RSA(plainSignature)
+            else -> throw SerializationException("Unsupported algorithm for JWS signature element: $alg")
+        }
 }

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/SignatureElement.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/SignatureElement.kt
@@ -40,12 +40,14 @@ data class SignatureElement(
 
         if (!plainSignature.contentEquals(other.plainSignature)) return false
         if (!plainProtectedHeader.contentEquals(other.plainProtectedHeader)) return false
+        if (unprotectedHeader != other.unprotectedHeader) return false
         return true
     }
 
     override fun hashCode(): Int {
         var result = plainSignature.contentHashCode()
         result = 31 * result + plainProtectedHeader.contentHashCode()
+        result = 31 * result + (unprotectedHeader?.hashCode() ?: 0)
         return result
     }
 }

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/SignatureElement.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/SignatureElement.kt
@@ -18,8 +18,9 @@ import kotlinx.serialization.Transient
  *
  * See [RFC 7515 Sec 7.2.1](https://www.rfc-editor.org/rfc/rfc7515.html#section-7.2.1).
  */
+@ConsistentCopyVisibility
 @Serializable
-data class SignatureElement(
+data class SignatureElement internal constructor(
     /**
      * The [plainSignature] member MUST be present
      *

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/SignatureElement.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/SignatureElement.kt
@@ -1,6 +1,6 @@
 package at.asitplus.signum.indispensable.josef
 
-import at.asitplus.signum.indispensable.io.ByteArrayBase64UrlSerializer
+import at.asitplus.signum.indispensable.io.ByteArrayBase64UrlNoPaddingSerializer
 import at.asitplus.signum.indispensable.josef.JWS.Companion.getSignature
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -26,7 +26,7 @@ data class SignatureElement(
      * Serialization: BASE64URL(JWS Signature).
      */
     @SerialName(JWS.SerialNames.SIGNATURE)
-    @Serializable(ByteArrayBase64UrlSerializer::class)
+    @Serializable(ByteArrayBase64UrlNoPaddingSerializer::class)
     val plainSignature: ByteArray,
 
     /**
@@ -37,7 +37,7 @@ data class SignatureElement(
      * Serialization: BASE64URL(UTF8(JWS Protected Header))
      */
     @SerialName(JWS.SerialNames.PROTECTED)
-    @Serializable(with = ByteArrayBase64UrlSerializer::class)
+    @Serializable(with = ByteArrayBase64UrlNoPaddingSerializer::class)
     val plainProtectedHeader: ByteArray? = null,
 
     @SerialName(JWS.SerialNames.HEADER)

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/SignatureElement.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/SignatureElement.kt
@@ -1,7 +1,6 @@
 package at.asitplus.signum.indispensable.josef
 
 import at.asitplus.signum.indispensable.io.ByteArrayBase64UrlSerializer
-import at.asitplus.signum.indispensable.io.ByteArrayUtf8Serializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -25,9 +24,9 @@ data class SignatureElement(
      * Header Parameter values are integrity protected.
      *
      * Serialization: BASE64URL(UTF8(JWS Protected Header))
-    */
+     */
     @SerialName(JWS.SerialNames.PROTECTED)
-    @Serializable(with = ByteArrayUtf8Serializer::class)
+    @Serializable(with = ByteArrayBase64UrlSerializer::class)
     val plainProtectedHeader: ByteArray? = null,
 
     @SerialName(JWS.SerialNames.HEADER)

--- a/indispensable-josef/src/commonTest/kotlin/at/asitplus/signum/indispensable/josef/JwsHeaderPartsTest.kt
+++ b/indispensable-josef/src/commonTest/kotlin/at/asitplus/signum/indispensable/josef/JwsHeaderPartsTest.kt
@@ -1,10 +1,8 @@
 package at.asitplus.signum.indispensable.josef
 
-import at.asitplus.signum.indispensable.io.Base64UrlStrict
 import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
 import at.asitplus.testballoon.invoke
 import de.infix.testBalloon.framework.core.testSuite
-import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
 import io.kotest.matchers.shouldBe
 
 val JwsHeaderPartsTest by testSuite {
@@ -84,7 +82,7 @@ val JwsHeaderPartsTest by testSuite {
         compact.jwsHeader shouldBe JwsHeader.fromParts(protectedHeader, null)
     }
 
-    "protected header bytes are base64url encoded header json" {
+    "protected header bytes are raw header json bytes" {
         val protectedHeader = JwsHeader.Part(
             algorithm = JwsAlgorithm.Signature.ES256,
             type = "application/example+jwt",
@@ -92,8 +90,6 @@ val JwsHeaderPartsTest by testSuite {
 
         val encoded = JwsProtectedHeaderSerializer.encodeToByteArray(protectedHeader)
         val expected = joseCompliantSerializer.encodeToString(JwsHeader.Part.serializer(), protectedHeader)
-            .encodeToByteArray()
-            .encodeToString(Base64UrlStrict)
             .encodeToByteArray()
 
         encoded shouldBe expected

--- a/indispensable-josef/src/commonTest/kotlin/at/asitplus/signum/indispensable/josef/JwsHeaderPartsTest.kt
+++ b/indispensable-josef/src/commonTest/kotlin/at/asitplus/signum/indispensable/josef/JwsHeaderPartsTest.kt
@@ -1,0 +1,102 @@
+package at.asitplus.signum.indispensable.josef
+
+import at.asitplus.signum.indispensable.io.Base64UrlStrict
+import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
+import at.asitplus.testballoon.invoke
+import de.infix.testBalloon.framework.core.testSuite
+import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
+import io.kotest.matchers.shouldBe
+
+val JwsHeaderPartsTest by testSuite {
+    "split headers combine into a valid JWS header" {
+        val protectedHeader = JwsHeader.Part(
+            algorithm = JwsAlgorithm.Signature.ES256,
+            type = "vc+sd-jwt",
+        )
+        val unprotectedHeader = JwsHeader.Part(
+            keyId = "did:example:signer",
+            vcTypeMetadata = setOf("bWV0YWRhdGE"),
+        )
+
+        val combined = JwsHeader.fromParts(
+            protectedHeader = protectedHeader,
+            unprotectedHeader = unprotectedHeader,
+        )
+
+        combined.algorithm shouldBe JwsAlgorithm.Signature.ES256
+        combined.type shouldBe "vc+sd-jwt"
+        combined.keyId shouldBe "did:example:signer"
+        combined.vcTypeMetadata shouldBe setOf("bWV0YWRhdGE")
+    }
+
+    "duplicate names across protected and unprotected headers are rejected" {
+        val exception = runCatching {
+            JwsHeader.fromParts(
+                protectedHeader = JwsHeader.Part(keyId = "protected"),
+                unprotectedHeader = JwsHeader.Part(keyId = "unprotected"),
+            )
+        }
+
+        exception.exceptionOrNull() shouldBe IllegalArgumentException("Duplicate keys: kid")
+    }
+
+    "flattened JWS accepts typed header parts" {
+        val protectedHeader = JwsHeader.Part(
+            algorithm = JwsAlgorithm.Signature.ES256,
+            type = "application/example+jwt",
+        )
+        val unprotectedHeader = JwsHeader.Part(
+            vcTypeMetadata = setOf("bWV0YWRhdGE"),
+        )
+        val payload = "payload".encodeToByteArray()
+        var capturedAlgorithm: JwsAlgorithm? = null
+
+        val flattened = JwsFlattened.invoke(
+            protectedHeader = protectedHeader,
+            unprotectedHeader = unprotectedHeader,
+            payload = payload,
+        ) { algorithm, _ ->
+            capturedAlgorithm = algorithm
+            byteArrayOf(1, 2, 3)
+        }
+
+        capturedAlgorithm shouldBe JwsAlgorithm.Signature.ES256
+        flattened.jwsHeader shouldBe JwsHeader.fromParts(protectedHeader, unprotectedHeader)
+    }
+
+    "compact JWS accepts typed protected header" {
+        val protectedHeader = JwsHeader.Part(
+            algorithm = JwsAlgorithm.Signature.ES256,
+            type = "application/example+jwt",
+        )
+        val payload = "payload".encodeToByteArray()
+        var capturedAlgorithm: JwsAlgorithm? = null
+
+        val compact = JwsCompact.invoke(
+            protectedHeader = protectedHeader,
+            payload = payload,
+        ) { algorithm, _ ->
+            capturedAlgorithm = algorithm
+            byteArrayOf(1, 2, 3)
+        }
+
+        capturedAlgorithm shouldBe JwsAlgorithm.Signature.ES256
+        compact.jwsHeader shouldBe JwsHeader.fromParts(protectedHeader, null)
+    }
+
+    "protected header bytes are base64url encoded header json" {
+        val protectedHeader = JwsHeader.Part(
+            algorithm = JwsAlgorithm.Signature.ES256,
+            type = "application/example+jwt",
+        )
+
+        val encoded = JwsProtectedHeaderSerializer.encodeToByteArray(protectedHeader)
+        val expected = joseCompliantSerializer.encodeToString(JwsHeader.Part.serializer(), protectedHeader)
+            .encodeToByteArray()
+            .encodeToString(Base64UrlStrict)
+            .encodeToByteArray()
+
+        encoded shouldBe expected
+        JwsProtectedHeaderSerializer.decodeFromByteArray(encoded) shouldBe protectedHeader
+    }
+}

--- a/indispensable-josef/src/commonTest/kotlin/at/asitplus/signum/indispensable/josef/JwsHeaderPartsTest.kt
+++ b/indispensable-josef/src/commonTest/kotlin/at/asitplus/signum/indispensable/josef/JwsHeaderPartsTest.kt
@@ -6,6 +6,31 @@ import de.infix.testBalloon.framework.core.testSuite
 import io.kotest.matchers.shouldBe
 
 val JwsHeaderPartsTest by testSuite {
+    "full JWS header can be converted to a typed header part" {
+        val header = JwsHeader(
+            keyId = "did:example:signer",
+            type = "vc+sd-jwt",
+            algorithm = JwsAlgorithm.Signature.ES256,
+            contentType = "application/example+json",
+            certificateSha1Thumbprint = byteArrayOf(1, 2, 3),
+            certificateSha256Thumbprint = byteArrayOf(4, 5, 6),
+            vcTypeMetadata = setOf("bWV0YWRhdGE"),
+        )
+
+        val part = header.toPart()
+
+        part shouldBe JwsHeader.Part(
+            keyId = "did:example:signer",
+            type = "vc+sd-jwt",
+            algorithm = JwsAlgorithm.Signature.ES256,
+            contentType = "application/example+json",
+            certificateSha1Thumbprint = byteArrayOf(1, 2, 3),
+            certificateSha256Thumbprint = byteArrayOf(4, 5, 6),
+            vcTypeMetadata = setOf("bWV0YWRhdGE"),
+        )
+        JwsHeader.fromParts(protectedHeader = part) shouldBe header
+    }
+
     "split headers combine into a valid JWS header" {
         val protectedHeader = JwsHeader.Part(
             algorithm = JwsAlgorithm.Signature.ES256,
@@ -98,16 +123,18 @@ val JwsHeaderPartsTest by testSuite {
         flattened.jwsHeader shouldBe JwsHeader.fromParts(protectedHeader, unprotectedHeader)
     }
 
-    "compact JWS accepts typed protected header" {
-        val protectedHeader = JwsHeader.Part(
+    "compact JWS accepts full headers and serializes their protected part" {
+        val header = JwsHeader(
             algorithm = JwsAlgorithm.Signature.ES256,
             type = "application/example+jwt",
+            keyId = "did:example:signer",
+            vcTypeMetadata = setOf("bWV0YWRhdGE"),
         )
         val payload = "payload".encodeToByteArray()
         var capturedAlgorithm: JwsAlgorithm? = null
 
         val compact = JwsCompact.invoke(
-            protectedHeader = protectedHeader,
+            protectedHeader = header,
             payload = payload,
         ) { algorithm, _ ->
             capturedAlgorithm = algorithm
@@ -115,7 +142,9 @@ val JwsHeaderPartsTest by testSuite {
         }
 
         capturedAlgorithm shouldBe JwsAlgorithm.Signature.ES256
-        compact.jwsHeader shouldBe JwsHeader.fromParts(protectedHeader, null)
+        compact.jwsHeader shouldBe header
+        compact.plainProtectedHeader shouldBe
+                JwsProtectedHeaderSerializer.encodeToByteArray(header.toPart())
     }
 
     "protected header bytes are raw header json bytes" {

--- a/indispensable-josef/src/commonTest/kotlin/at/asitplus/signum/indispensable/josef/JwsHeaderPartsTest.kt
+++ b/indispensable-josef/src/commonTest/kotlin/at/asitplus/signum/indispensable/josef/JwsHeaderPartsTest.kt
@@ -111,18 +111,15 @@ val JwsHeaderPartsTest by testSuite {
             vcTypeMetadata = setOf("bWV0YWRhdGE"),
         )
         val payload = "payload".encodeToByteArray()
-        var capturedAlgorithm: JwsAlgorithm? = null
 
         val flattened = JwsFlattened.invoke(
             protectedHeader = protectedHeader,
             unprotectedHeader = unprotectedHeader,
             payload = payload,
-        ) { algorithm, _ ->
-            capturedAlgorithm = algorithm
+        ) {
             validEs256SignatureFixture
         }
 
-        capturedAlgorithm shouldBe JwsAlgorithm.Signature.ES256
         flattened.jwsHeader shouldBe JwsHeader.fromParts(protectedHeader, unprotectedHeader)
     }
 
@@ -134,17 +131,14 @@ val JwsHeaderPartsTest by testSuite {
             vcTypeMetadata = setOf("bWV0YWRhdGE"),
         )
         val payload = "payload".encodeToByteArray()
-        var capturedAlgorithm: JwsAlgorithm? = null
 
-        val compact = JwsCompact(
+        val compact = JwsCompact.invoke(
             protectedHeader = header,
             payload = payload,
-        ) { algorithm, _ ->
-            capturedAlgorithm = algorithm
+        ) {
             validEs256SignatureFixture
         }
 
-        capturedAlgorithm shouldBe JwsAlgorithm.Signature.ES256
         compact.jwsHeader shouldBe header
         compact.plainProtectedHeader shouldBe
                 JwsProtectedHeaderSerializer.encodeToByteArray(header.toPart())

--- a/indispensable-josef/src/commonTest/kotlin/at/asitplus/signum/indispensable/josef/JwsHeaderPartsTest.kt
+++ b/indispensable-josef/src/commonTest/kotlin/at/asitplus/signum/indispensable/josef/JwsHeaderPartsTest.kt
@@ -1,9 +1,11 @@
 package at.asitplus.signum.indispensable.josef
 
+import at.asitplus.signum.indispensable.io.Base64UrlStrict
 import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
 import at.asitplus.testballoon.invoke
 import de.infix.testBalloon.framework.core.testSuite
 import io.kotest.matchers.shouldBe
+import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArray
 
 val JwsHeaderPartsTest by testSuite {
     "full JWS header can be converted to a typed header part" {
@@ -116,7 +118,7 @@ val JwsHeaderPartsTest by testSuite {
             payload = payload,
         ) { algorithm, _ ->
             capturedAlgorithm = algorithm
-            byteArrayOf(1, 2, 3)
+            validEs256SignatureFixture
         }
 
         capturedAlgorithm shouldBe JwsAlgorithm.Signature.ES256
@@ -133,12 +135,12 @@ val JwsHeaderPartsTest by testSuite {
         val payload = "payload".encodeToByteArray()
         var capturedAlgorithm: JwsAlgorithm? = null
 
-        val compact = JwsCompact.invoke(
+        val compact = JwsCompact(
             protectedHeader = header,
             payload = payload,
         ) { algorithm, _ ->
             capturedAlgorithm = algorithm
-            byteArrayOf(1, 2, 3)
+            validEs256SignatureFixture
         }
 
         capturedAlgorithm shouldBe JwsAlgorithm.Signature.ES256
@@ -161,3 +163,8 @@ val JwsHeaderPartsTest by testSuite {
         JwsProtectedHeaderSerializer.decodeFromByteArray(encoded) shouldBe protectedHeader
     }
 }
+
+// RFC 7515 Appendix A.6 ES256 signature; reused so constructors get a parseable raw ES256 signature.
+private val validEs256SignatureFixture =
+    "DtEhU3ljbEg8L38VWAfUAqOyKAM6-Xx-F4GawxaepmXFCgfTjDxw5djxLa8ISlSApmWQxfKTUJqPP3-Kg6NU1Q"
+        .decodeToByteArray(Base64UrlStrict)

--- a/indispensable-josef/src/commonTest/kotlin/at/asitplus/signum/indispensable/josef/JwsHeaderPartsTest.kt
+++ b/indispensable-josef/src/commonTest/kotlin/at/asitplus/signum/indispensable/josef/JwsHeaderPartsTest.kt
@@ -4,6 +4,7 @@ import at.asitplus.signum.indispensable.io.Base64UrlStrict
 import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
 import at.asitplus.testballoon.invoke
 import de.infix.testBalloon.framework.core.testSuite
+import io.kotest.matchers.result.shouldBeFailure
 import io.kotest.matchers.shouldBe
 import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArray
 
@@ -62,7 +63,7 @@ val JwsHeaderPartsTest by testSuite {
             )
         }
 
-        exception.exceptionOrNull() shouldBe IllegalArgumentException("Duplicate keys: kid")
+        exception.shouldBeFailure() shouldBe IllegalArgumentException("Duplicate keys: kid")
     }
 
     "encoded protected header bytes can be merged with unprotected fields" {
@@ -98,7 +99,7 @@ val JwsHeaderPartsTest by testSuite {
             )
         }
 
-        exception.exceptionOrNull() shouldBe IllegalArgumentException("Duplicate keys: kid")
+        exception.shouldBeFailure() shouldBe IllegalArgumentException("Duplicate keys: kid")
     }
 
     "flattened JWS accepts typed header parts" {

--- a/indispensable-josef/src/commonTest/kotlin/at/asitplus/signum/indispensable/josef/JwsHeaderPartsTest.kt
+++ b/indispensable-josef/src/commonTest/kotlin/at/asitplus/signum/indispensable/josef/JwsHeaderPartsTest.kt
@@ -38,6 +38,42 @@ val JwsHeaderPartsTest by testSuite {
         exception.exceptionOrNull() shouldBe IllegalArgumentException("Duplicate keys: kid")
     }
 
+    "encoded protected header bytes can be merged with unprotected fields" {
+        val protectedHeader = JwsHeader.Part(
+            algorithm = JwsAlgorithm.Signature.RS256,
+            type = "application/example+jws",
+        )
+        val unprotectedHeader = JwsHeader.Part(
+            keyId = "did:example:signer",
+            contentType = "application/example+json",
+        )
+
+        val combined = JwsHeader.fromParts(
+            protectedHeader = JwsProtectedHeaderSerializer.encodeToByteArray(protectedHeader),
+            unprotectedHeader = unprotectedHeader,
+        )
+
+        combined shouldBe JwsHeader.fromParts(protectedHeader, unprotectedHeader)
+    }
+
+    "duplicate names across encoded protected and unprotected headers are rejected" {
+        val protectedHeader = JwsProtectedHeaderSerializer.encodeToByteArray(
+            JwsHeader.Part(
+                algorithm = JwsAlgorithm.Signature.RS256,
+                keyId = "protected",
+            )
+        )
+
+        val exception = runCatching {
+            JwsHeader.fromParts(
+                protectedHeader = protectedHeader,
+                unprotectedHeader = JwsHeader.Part(keyId = "unprotected"),
+            )
+        }
+
+        exception.exceptionOrNull() shouldBe IllegalArgumentException("Duplicate keys: kid")
+    }
+
     "flattened JWS accepts typed header parts" {
         val protectedHeader = JwsHeader.Part(
             algorithm = JwsAlgorithm.Signature.ES256,

--- a/indispensable-josef/src/commonTest/kotlin/at/asitplus/signum/indispensable/josef/JwsSerializationTest.kt
+++ b/indispensable-josef/src/commonTest/kotlin/at/asitplus/signum/indispensable/josef/JwsSerializationTest.kt
@@ -77,20 +77,17 @@ val JwsSerializerTest by testSuite(compartment = { TestCompartment.Sequential })
         )
         val payload = """{"iss":"https://issuer.example","sub":"alice"}""".encodeToByteArray()
         val plainProtectedHeader = JwsProtectedHeaderSerializer.encodeToByteArray(protectedHeader)
-        var capturedAlgorithm: JwsAlgorithm? = null
         var capturedSignatureInput: ByteArray? = null
 
-        val flattened = JwsFlattened(
+        val flattened = JwsFlattened.invoke(
             protectedHeader = protectedHeader,
             unprotectedHeader = unprotectedHeader,
             payload = payload,
-        ) { algorithm, signatureInput ->
-            capturedAlgorithm = algorithm
+        ) { signatureInput ->
             capturedSignatureInput = signatureInput
             byteArrayOf(1, 2, 3, 4)
         }
 
-        capturedAlgorithm shouldBe JwsHeader.fromParts(protectedHeader, unprotectedHeader).algorithm
         capturedSignatureInput shouldBe JWS.getSignatureInput(plainProtectedHeader, payload)
 
         val serialized = joseCompliantSerializer.encodeToString(flattened)
@@ -102,7 +99,7 @@ val JwsSerializerTest by testSuite(compartment = { TestCompartment.Sequential })
         }
         val general = listOf(flattened).toJwsGeneral()
 
-        general.payload shouldBe payload
+        general.plainPayload shouldBe payload
         general.jwsHeaders[0] shouldBe flattened.jwsHeader
         general.signatures[0] shouldBe flattened.signature
         general.signatureInputs[0] shouldBe flattened.signatureInput
@@ -137,7 +134,7 @@ val JwsSerializerTest by testSuite(compartment = { TestCompartment.Sequential })
                 type = "application/example+jws",
             ),
             payload = """{"iss":"https://issuer.example","sub":"alice"}""".encodeToByteArray(),
-        ) { _, _ ->
+        ) {
             byteArrayOf(1, 2, 3, 4)
         }
 
@@ -160,7 +157,7 @@ val JwsSerializerTest by testSuite(compartment = { TestCompartment.Sequential })
                 keyId = "kid-1",
             ),
             payload = "x".encodeToByteArray(),
-        ) { _, _ ->
+        ) {
             byteArrayOf(1, 2, 3, 4)
         }.toString()
         val (protectedSegment, payloadSegment, signatureSegment) = canonical.split('.')
@@ -294,7 +291,7 @@ val JwsSerializerTest by testSuite(compartment = { TestCompartment.Sequential })
         val missingProtectedHeader = JwsFlattened(
             plainProtectedHeader = null,
             unprotectedHeader = JwsHeader.Part(keyId = "kid-1", algorithm = JwsAlgorithm.Signature.RSA.RS256),
-            payload = "payload".encodeToByteArray(),
+            plainPayload = "payload".encodeToByteArray(),
             plainSignature = byteArrayOf(1),
         )
 
@@ -343,11 +340,11 @@ val JwsSerializerTest by testSuite(compartment = { TestCompartment.Sequential })
         signatureA shouldNotBe signatureB
 
         val generalA = JwsGeneral(
-            payload = "payload".encodeToByteArray(),
+            plainPayload = "payload".encodeToByteArray(),
             signatureElements = listOf(signatureA),
         )
         val generalB = JwsGeneral(
-            payload = "payload".encodeToByteArray(),
+            plainPayload = "payload".encodeToByteArray(),
             signatureElements = listOf(signatureB),
         )
 
@@ -442,7 +439,7 @@ private fun flattenedSample(
 ): JwsFlattened = JwsFlattened(
     plainProtectedHeader = JwsProtectedHeaderSerializer.encodeToByteArray(protectedHeader),
     unprotectedHeader = unprotectedHeader,
-    payload = payload,
+    plainPayload = payload,
     plainSignature = plainSignature,
 )
 

--- a/indispensable-josef/src/commonTest/kotlin/at/asitplus/signum/indispensable/josef/JwsSerializationTest.kt
+++ b/indispensable-josef/src/commonTest/kotlin/at/asitplus/signum/indispensable/josef/JwsSerializationTest.kt
@@ -1,6 +1,5 @@
 package at.asitplus.signum.indispensable.josef
 
-import at.asitplus.nonFatalOrThrow
 import at.asitplus.signum.indispensable.CryptoSignature
 import at.asitplus.signum.indispensable.io.Base64UrlStrict
 import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
@@ -38,7 +37,7 @@ private val generalVectorSource = joseCompliantSerializer.decodeFromString(JsonO
 private val generalVectorPayload = generalVectorSource[JWS.SerialNames.PAYLOAD]!!.jsonPrimitive.content
 private val generalVectorSignatures = generalVectorSource[JWS.SerialNames.SIGNATURES]!!.jsonArray
 
-val JwsSerializerTest by testSuite {
+val JwsSerializerTest by testSuite(compartment = { TestCompartment.Sequential }) {
     "general JWS keeps vector bytes stable through serialization and flattening" {
         val general = joseCompliantSerializer.decodeFromString<JwsGeneral>(generalVectorJson)
 
@@ -150,6 +149,77 @@ val JwsSerializerTest by testSuite {
         val jsonString = joseCompliantSerializer.encodeToString(JwsCompactStringSerializer, compact)
             .removeSurrounding("\"")
         compactPattern.matches(jsonString) shouldBe true
+    }
+
+    "compact JWS rejects padded base64url segments" {
+        val canonical = JwsCompact.invoke(
+            protectedHeader = JwsHeader(
+                algorithm = JwsAlgorithm.Signature.RS256,
+                keyId = "kid-1",
+            ),
+            payload = "x".encodeToByteArray(),
+        ) { _, _ ->
+            byteArrayOf(1, 2, 3, 4)
+        }.toString()
+        val (protectedSegment, payloadSegment, signatureSegment) = canonical.split('.')
+        val nonCanonical = buildString {
+            append(protectedSegment)
+            append('.')
+            append(payloadSegment.toPaddedBase64UrlVariant())
+            append('.')
+            append(signatureSegment.toPaddedBase64UrlVariant())
+        }
+
+        nonCanonical shouldNotBe canonical
+
+        val result = runCatching { JwsCompact(nonCanonical) }
+
+        result.isSuccess shouldBe false
+        result.shouldBeFailure().message.shouldContain("Trailing = are not supported")
+    }
+
+    "flattened JSON JWS rejects padded base64url members" {
+        val paddedProtectedHeaderResult = runCatching {
+            joseCompliantSerializer.decodeFromString<JwsFlattened>(
+                flattenedJson(protectedHeaderBase64 = "eyJhbGciOiJSUzI1NiJ9".toPaddedBase64UrlVariant())
+            )
+        }
+        val paddedPayloadResult = runCatching {
+            joseCompliantSerializer.decodeFromString<JwsFlattened>(
+                flattenedJson(payloadBase64 = "e30".toPaddedBase64UrlVariant())
+            )
+        }
+        val paddedSignatureResult = runCatching {
+            joseCompliantSerializer.decodeFromString<JwsFlattened>(
+                flattenedJson(signatureBase64 = "AQ".toPaddedBase64UrlVariant())
+            )
+        }
+
+        paddedProtectedHeaderResult.shouldBeRejectedPaddedBase64Url()
+        paddedPayloadResult.shouldBeRejectedPaddedBase64Url()
+        paddedSignatureResult.shouldBeRejectedPaddedBase64Url()
+    }
+
+    "general JSON JWS rejects padded base64url members" {
+        val paddedPayloadResult = runCatching {
+            joseCompliantSerializer.decodeFromString<JwsGeneral>(
+                generalJson(payloadBase64 = "e30".toPaddedBase64UrlVariant())
+            )
+        }
+        val paddedProtectedHeaderResult = runCatching {
+            joseCompliantSerializer.decodeFromString<JwsGeneral>(
+                generalJson(protectedHeaderBase64 = "eyJhbGciOiJSUzI1NiJ9".toPaddedBase64UrlVariant())
+            )
+        }
+        val paddedSignatureResult = runCatching {
+            joseCompliantSerializer.decodeFromString<JwsGeneral>(
+                generalJson(signatureBase64 = "AQ".toPaddedBase64UrlVariant())
+            )
+        }
+
+        paddedPayloadResult.shouldBeRejectedPaddedBase64Url()
+        paddedProtectedHeaderResult.shouldBeRejectedPaddedBase64Url()
+        paddedSignatureResult.shouldBeRejectedPaddedBase64Url()
     }
 
     "general to flattened to compact preserves each single-signature view" {
@@ -341,6 +411,22 @@ private fun compactSerializationAt(index: Int): String {
     return "$protectedHeaderBase64.$generalVectorPayload.$signatureBase64"
 }
 
+private fun flattenedJson(
+    protectedHeaderBase64: String = "eyJhbGciOiJSUzI1NiJ9",
+    payloadBase64: String = "e30",
+    signatureBase64: String = "AQ",
+): String = """
+    {"protected":"$protectedHeaderBase64","payload":"$payloadBase64","signature":"$signatureBase64"}
+""".trimIndent()
+
+private fun generalJson(
+    protectedHeaderBase64: String = "eyJhbGciOiJSUzI1NiJ9",
+    payloadBase64: String = "e30",
+    signatureBase64: String = "AQ",
+): String = """
+    {"payload":"$payloadBase64","signatures":[{"protected":"$protectedHeaderBase64","signature":"$signatureBase64"}]}
+""".trimIndent()
+
 private fun flattenedSample(
     protectedHeader: JwsHeader.Part,
     payload: ByteArray,
@@ -352,3 +438,16 @@ private fun flattenedSample(
     payload = payload,
     plainSignature = plainSignature,
 )
+
+private fun String.toPaddedBase64UrlVariant(): String = when (length % 2) {
+    1 -> "${this}=="
+    else -> "${this}="
+}
+
+private fun Result<*>.shouldBeRejectedPaddedBase64Url() {
+    isSuccess shouldBe false
+    val failure = shouldBeFailure()
+    failure.message.orEmpty().shouldContain("Decoding failed")
+    failure.cause shouldNotBe null
+    failure.cause!!.message.orEmpty().shouldContain("Trailing = are not supported")
+}

--- a/indispensable-josef/src/commonTest/kotlin/at/asitplus/signum/indispensable/josef/JwsSerializationTest.kt
+++ b/indispensable-josef/src/commonTest/kotlin/at/asitplus/signum/indispensable/josef/JwsSerializationTest.kt
@@ -12,6 +12,8 @@ import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.types.shouldBeInstanceOf
 import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArray
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
@@ -365,15 +367,20 @@ val JwsSerializerTest by testSuite(compartment = { TestCompartment.Sequential })
         )
         val generalValue = listOf(flattenedValue).toJwsGeneral()
 
-        val compactDecoded = joseCompliantSerializer.decodeFromString<JWS>(
-            joseCompliantSerializer.encodeToString(JWS.serializer(), compactValue)
-        ).shouldBeInstanceOf<JwsCompact>()
-        val flattenedDecoded = joseCompliantSerializer.decodeFromString<JWS>(
-            joseCompliantSerializer.encodeToString(JWS.serializer(), flattenedValue)
-        ).shouldBeInstanceOf<JwsFlattened>()
-        val generalDecoded = joseCompliantSerializer.decodeFromString<JWS>(
-            joseCompliantSerializer.encodeToString(JWS.serializer(), generalValue)
-        ).shouldBeInstanceOf<JwsGeneral>()
+        val compactSerialized = joseCompliantSerializer.encodeToString(JWS.serializer(), compactValue)
+        val flattenedSerialized = joseCompliantSerializer.encodeToString(JWS.serializer(), flattenedValue)
+        val generalSerialized = joseCompliantSerializer.encodeToString(JWS.serializer(), generalValue)
+
+        joseCompliantSerializer.decodeFromString<JsonElement>(compactSerialized).shouldNotContainKey("type")
+        joseCompliantSerializer.decodeFromString<JsonElement>(flattenedSerialized).shouldNotContainKey("type")
+        joseCompliantSerializer.decodeFromString<JsonElement>(generalSerialized).shouldNotContainKey("type")
+
+        val compactDecoded = joseCompliantSerializer.decodeFromString<JWS>(compactSerialized)
+            .shouldBeInstanceOf<JwsCompact>()
+        val flattenedDecoded = joseCompliantSerializer.decodeFromString<JWS>(flattenedSerialized)
+            .shouldBeInstanceOf<JwsFlattened>()
+        val generalDecoded = joseCompliantSerializer.decodeFromString<JWS>(generalSerialized)
+            .shouldBeInstanceOf<JwsGeneral>()
 
         compactDecoded shouldBe compactValue
         flattenedDecoded shouldBe flattenedValue
@@ -450,4 +457,16 @@ private fun Result<*>.shouldBeRejectedPaddedBase64Url() {
     failure.message.orEmpty().shouldContain("Decoding failed")
     failure.cause shouldNotBe null
     failure.cause!!.message.orEmpty().shouldContain("Trailing = are not supported")
+}
+
+private fun JsonElement.shouldNotContainKey(key: String) {
+    when (this) {
+        is JsonObject -> {
+            keys.contains(key) shouldBe false
+            values.forEach { it.shouldNotContainKey(key) }
+        }
+
+        is JsonArray -> forEach { it.shouldNotContainKey(key) }
+        else -> Unit
+    }
 }

--- a/indispensable-josef/src/commonTest/kotlin/at/asitplus/signum/indispensable/josef/JwsSerializationTest.kt
+++ b/indispensable-josef/src/commonTest/kotlin/at/asitplus/signum/indispensable/josef/JwsSerializationTest.kt
@@ -10,7 +10,6 @@ import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.types.shouldBeInstanceOf
 import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArray
-import kotlinx.serialization.MissingFieldException
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
@@ -40,13 +39,13 @@ val JwsSerializerTest by testSuite {
     "general JWS keeps vector bytes stable through serialization and flattening" {
         val general = joseCompliantSerializer.decodeFromString<JwsGeneral>(generalVectorJson)
 
-        general.signatures.size shouldBe 2
-        general.getHeaderAt(0).algorithm shouldBe JwsAlgorithm.Signature.RS256
-        general.getHeaderAt(1).algorithm shouldBe JwsAlgorithm.Signature.ES256
+        general.signatureElements.size shouldBe 2
+        general.jwsHeaders[0].algorithm shouldBe JwsAlgorithm.Signature.RS256
+        general.jwsHeaders[1].algorithm shouldBe JwsAlgorithm.Signature.ES256
         general.getSignatureAt(0).shouldBeInstanceOf<CryptoSignature.RSA>()
         general.getSignatureAt(1).shouldBeInstanceOf<CryptoSignature.EC.DefiniteLength>()
 
-        general.signatures.forEachIndexed { index, signatureElement ->
+        general.signatureElements.forEachIndexed { index, signatureElement ->
             val sourceSignature = generalVectorSignatures[index].jsonObject
             val protectedHeaderBase64 = sourceSignature["protected"]!!.jsonPrimitive.content
             val signatureBase64 = sourceSignature["signature"]!!.jsonPrimitive.content
@@ -100,7 +99,7 @@ val JwsSerializerTest by testSuite {
         val general = listOf(flattened).toJwsGeneral()
 
         general.payload shouldBe payload
-        general.getHeaderAt(0) shouldBe flattened.jwsHeader
+        general.jwsHeaders[0] shouldBe flattened.jwsHeader
         general.getSignatureAt(0) shouldBe flattened.signature
         general.getSignatureInputAt(0) shouldBe flattened.signatureInput
         general.toJwsFlattened() shouldBe listOf(flattened)
@@ -129,9 +128,9 @@ val JwsSerializerTest by testSuite {
         val general = joseCompliantSerializer.decodeFromString<JwsGeneral>(generalVectorJson)
         val flattened = general.toJwsFlattened()
 
-        flattened.size shouldBe general.signatures.size
+        flattened.size shouldBe general.signatureElements.size
         flattened.forEachIndexed { index, entry ->
-            entry.jwsHeader shouldBe general.getHeaderAt(index)
+            entry.jwsHeader shouldBe general.jwsHeaders[index]
             entry.signature shouldBe general.getSignatureAt(index)
             entry.signatureInput shouldBe general.getSignatureInputAt(index)
             entry.toJwsCompact().toString() shouldBe compactSerializationAt(index)
@@ -245,11 +244,11 @@ val JwsSerializerTest by testSuite {
 
         val generalA = JwsGeneral(
             payload = "payload".encodeToByteArray(),
-            signatures = listOf(signatureA),
+            signatureElements = listOf(signatureA),
         )
         val generalB = JwsGeneral(
             payload = "payload".encodeToByteArray(),
-            signatures = listOf(signatureB),
+            signatureElements = listOf(signatureB),
         )
 
         generalA shouldNotBe generalB

--- a/indispensable-josef/src/commonTest/kotlin/at/asitplus/signum/indispensable/josef/JwsSerializationTest.kt
+++ b/indispensable-josef/src/commonTest/kotlin/at/asitplus/signum/indispensable/josef/JwsSerializationTest.kt
@@ -1,10 +1,13 @@
 package at.asitplus.signum.indispensable.josef
 
+import at.asitplus.nonFatalOrThrow
 import at.asitplus.signum.indispensable.CryptoSignature
 import at.asitplus.signum.indispensable.io.Base64UrlStrict
 import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
 import at.asitplus.testballoon.invoke
+import de.infix.testBalloon.framework.core.TestCompartment
 import de.infix.testBalloon.framework.core.testSuite
+import io.kotest.matchers.result.shouldBeFailure
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.shouldContain
@@ -204,14 +207,14 @@ val JwsSerializerTest by testSuite {
         val appendMismatchResult = runCatching { JwsGeneral(listOf(first)).appendSignature(second) }
 
         emptyResult.isSuccess shouldBe false
-        emptyResult.exceptionOrNull() shouldBe IllegalArgumentException("General JWS requires at least one signature")
+        emptyResult.shouldBeFailure() shouldBe IllegalArgumentException("General JWS requires at least one signature")
 
         listMismatchResult.isSuccess shouldBe false
-        listMismatchResult.exceptionOrNull() shouldBe
+        listMismatchResult.shouldBeFailure() shouldBe
                 IllegalArgumentException("Additional signed JWS payload must match existing payload")
 
         appendMismatchResult.isSuccess shouldBe false
-        appendMismatchResult.exceptionOrNull() shouldBe
+        appendMismatchResult.shouldBeFailure() shouldBe
                 IllegalArgumentException("Additional signed JWS payload must match existing payload")
     }
 
@@ -229,16 +232,16 @@ val JwsSerializerTest by testSuite {
         val invalidBase64Result = runCatching { JwsCompact("!!.e30.AQ") }
 
         missingHeaderResult.isSuccess shouldBe false
-        missingHeaderResult.exceptionOrNull().shouldBeInstanceOf<IllegalArgumentException>()
+        missingHeaderResult.shouldBeFailure().shouldBeInstanceOf<IllegalArgumentException>()
 
         missingPartResult.isSuccess shouldBe false
-        missingPartResult.exceptionOrNull()?.message?.shouldContain("expected 3 parts, got 2")
+        missingPartResult.shouldBeFailure().message.shouldContain("expected 3 parts, got 2")
 
         extraPartResult.isSuccess shouldBe false
-        extraPartResult.exceptionOrNull()?.message?.shouldContain("expected 3 parts, got 4")
+        extraPartResult.shouldBeFailure().message.shouldContain("expected 3 parts, got 4")
 
         invalidBase64Result.isSuccess shouldBe false
-        invalidBase64Result.exceptionOrNull()?.message?.shouldContain("Invalid base64url content")
+        invalidBase64Result.shouldBeFailure().message.shouldContain("Invalid base64url content")
     }
 
     "raw-signature decoding rejects MAC algorithms" {
@@ -247,7 +250,7 @@ val JwsSerializerTest by testSuite {
         }
 
         result.isSuccess shouldBe false
-        result.exceptionOrNull()?.message?.shouldContain("Unsupported algorithm")
+        result.shouldBeFailure().message.shouldContain("Unsupported algorithm")
     }
 
     "signature and general equality include unprotected headers" {
@@ -321,13 +324,13 @@ val JwsSerializerTest by testSuite {
         }
 
         ambiguousResult.isSuccess shouldBe false
-        ambiguousResult.exceptionOrNull()?.message?.shouldContain("must not contain both")
+        ambiguousResult.shouldBeFailure().message.shouldContain("must not contain both")
 
         incompleteResult.isSuccess shouldBe false
-        incompleteResult.exceptionOrNull()?.message?.shouldContain("must contain 'signature' or 'signatures'")
+        incompleteResult.shouldBeFailure().message.shouldContain("must contain 'signature' or 'signatures'")
 
         arrayResult.isSuccess shouldBe false
-        arrayResult.exceptionOrNull()?.message?.shouldContain("expected a compact string or JSON object")
+        arrayResult.shouldBeFailure().message.shouldContain("expected a compact string or JSON object")
     }
 }
 

--- a/indispensable-josef/src/commonTest/kotlin/at/asitplus/signum/indispensable/josef/JwsSerializationTest.kt
+++ b/indispensable-josef/src/commonTest/kotlin/at/asitplus/signum/indispensable/josef/JwsSerializationTest.kt
@@ -42,8 +42,8 @@ val JwsSerializerTest by testSuite {
         general.signatureElements.size shouldBe 2
         general.jwsHeaders[0].algorithm shouldBe JwsAlgorithm.Signature.RS256
         general.jwsHeaders[1].algorithm shouldBe JwsAlgorithm.Signature.ES256
-        general.getSignatureAt(0).shouldBeInstanceOf<CryptoSignature.RSA>()
-        general.getSignatureAt(1).shouldBeInstanceOf<CryptoSignature.EC.DefiniteLength>()
+        general.signatures[0].shouldBeInstanceOf<CryptoSignature.RSA>()
+        general.signatures[1].shouldBeInstanceOf<CryptoSignature.EC.DefiniteLength>()
 
         general.signatureElements.forEachIndexed { index, signatureElement ->
             val sourceSignature = generalVectorSignatures[index].jsonObject
@@ -52,7 +52,7 @@ val JwsSerializerTest by testSuite {
 
             signatureElement.plainProtectedHeader shouldBe protectedHeaderBase64.decodeToByteArray(Base64UrlStrict)
             signatureElement.plainSignature shouldBe signatureBase64.decodeToByteArray(Base64UrlStrict)
-            general.getSignatureInputAt(index).decodeToString() shouldBe "$protectedHeaderBase64.$generalVectorPayload"
+            general.signatureInputs[index].decodeToString() shouldBe "$protectedHeaderBase64.$generalVectorPayload"
         }
 
         val reserialized = joseCompliantSerializer.encodeToString(general)
@@ -100,8 +100,8 @@ val JwsSerializerTest by testSuite {
 
         general.payload shouldBe payload
         general.jwsHeaders[0] shouldBe flattened.jwsHeader
-        general.getSignatureAt(0) shouldBe flattened.signature
-        general.getSignatureInputAt(0) shouldBe flattened.signatureInput
+        general.signatures[0] shouldBe flattened.signature
+        general.signatureInputs[0] shouldBe flattened.signatureInput
         general.toJwsFlattened() shouldBe listOf(flattened)
     }
 
@@ -124,6 +124,27 @@ val JwsSerializerTest by testSuite {
         flattened.toJwsCompact() shouldBe compact
     }
 
+    "compact JWS invoke methods round-trip as three base64url segments" {
+        val compactPattern = Regex("[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+")
+        val compact = JwsCompact.invoke(
+            protectedHeader = JwsHeader(
+                algorithm = JwsAlgorithm.Signature.RS256,
+                keyId = "kid-1",
+                type = "application/example+jws",
+            ),
+            payload = """{"iss":"https://issuer.example","sub":"alice"}""".encodeToByteArray(),
+        ) { _, _ ->
+            byteArrayOf(1, 2, 3, 4)
+        }
+
+        val serialized = compact.toString()
+        val reparsed = JwsCompact(serialized)
+
+        compactPattern.matches(serialized) shouldBe true
+        reparsed shouldBe compact
+        reparsed.toString() shouldBe serialized
+    }
+
     "general to flattened to compact preserves each single-signature view" {
         val general = joseCompliantSerializer.decodeFromString<JwsGeneral>(generalVectorJson)
         val flattened = general.toJwsFlattened()
@@ -131,8 +152,8 @@ val JwsSerializerTest by testSuite {
         flattened.size shouldBe general.signatureElements.size
         flattened.forEachIndexed { index, entry ->
             entry.jwsHeader shouldBe general.jwsHeaders[index]
-            entry.signature shouldBe general.getSignatureAt(index)
-            entry.signatureInput shouldBe general.getSignatureInputAt(index)
+            entry.signature shouldBe general.signatures[index]
+            entry.signatureInput shouldBe general.signatureInputs[index]
             entry.toJwsCompact().toString() shouldBe compactSerializationAt(index)
         }
     }

--- a/indispensable-josef/src/commonTest/kotlin/at/asitplus/signum/indispensable/josef/JwsSerializationTest.kt
+++ b/indispensable-josef/src/commonTest/kotlin/at/asitplus/signum/indispensable/josef/JwsSerializationTest.kt
@@ -106,6 +106,54 @@ val JwsSerializerTest by testSuite(compartment = { TestCompartment.Sequential })
         general.toJwsFlattened() shouldBe listOf(flattened)
     }
 
+    "empty protected header part is omitted from flattened/general JWS and signing input" {
+        val payload = """{"iss":"https://issuer.example","sub":"alice"}""".encodeToByteArray()
+        val emptyProtectedHeader = JwsHeader.Part()
+        val unprotectedHeader = JwsHeader.Part(
+            algorithm = JwsAlgorithm.Signature.RS256,
+            keyId = "kid-1",
+        )
+        val conformantWithoutProtected = JwsFlattened(
+            plainProtectedHeader = null,
+            unprotectedHeader = unprotectedHeader,
+            plainPayload = payload,
+            plainSignature = byteArrayOf(1, 2, 3, 4),
+        )
+        var capturedSignatureInput: ByteArray? = null
+
+        val flattened = JwsFlattened(
+            protectedHeader = emptyProtectedHeader,
+            unprotectedHeader = unprotectedHeader,
+            payload = payload,
+        ) { signatureInput ->
+            capturedSignatureInput = signatureInput
+            byteArrayOf(1, 2, 3, 4)
+        }
+        val general = listOf(flattened).toJwsGeneral()
+
+        flattened shouldBe conformantWithoutProtected
+        flattened.plainProtectedHeader shouldBe null
+        capturedSignatureInput shouldBe JWS.getSignatureInput(null, payload)
+        flattened.signatureInput shouldBe capturedSignatureInput
+        flattened.signatureInput shouldBe conformantWithoutProtected.signatureInput
+
+        val flattenedJson = joseCompliantSerializer.decodeFromString<JsonObject>(
+            joseCompliantSerializer.encodeToString(flattened)
+        )
+        flattenedJson.shouldNotContainKey(JWS.SerialNames.PROTECTED)
+
+        general.signatureElements.single().plainProtectedHeader shouldBe null
+        general.signatureInputs.single() shouldBe conformantWithoutProtected.signatureInput
+
+        val generalJson = joseCompliantSerializer.decodeFromString<JsonObject>(
+            joseCompliantSerializer.encodeToString(general)
+        )
+        generalJson[JWS.SerialNames.SIGNATURES]!!
+            .jsonArray
+            .single()
+            .shouldNotContainKey(JWS.SerialNames.PROTECTED)
+    }
+
     "compact JWS keeps its exact string form and round-trips through flattened" {
         val compactString = compactSerializationAt(0)
         val compact = JwsCompact(compactString)
@@ -219,6 +267,28 @@ val JwsSerializerTest by testSuite(compartment = { TestCompartment.Sequential })
         paddedPayloadResult.shouldBeRejectedPaddedBase64Url()
         paddedProtectedHeaderResult.shouldBeRejectedPaddedBase64Url()
         paddedSignatureResult.shouldBeRejectedPaddedBase64Url()
+    }
+
+    "flattened and general JSON JWS reject explicitly empty protected headers" {
+        val flattenedResult = runCatching {
+            joseCompliantSerializer.decodeFromString<JwsFlattened>(
+                flattenedJson(
+                    protectedHeaderBase64 = "e30",
+                    headerJson = """{"alg":"RS256","kid":"kid-1"}""",
+                )
+            )
+        }
+        val generalResult = runCatching {
+            joseCompliantSerializer.decodeFromString<JwsGeneral>(
+                generalJson(
+                    protectedHeaderBase64 = "e30",
+                    headerJson = """{"alg":"RS256","kid":"kid-1"}""",
+                )
+            )
+        }
+
+        flattenedResult.shouldBeRejectedEmptyProtectedHeader()
+        generalResult.shouldBeRejectedEmptyProtectedHeader()
     }
 
     "general to flattened to compact preserves each single-signature view" {
@@ -419,16 +489,18 @@ private fun flattenedJson(
     protectedHeaderBase64: String = "eyJhbGciOiJSUzI1NiJ9",
     payloadBase64: String = "e30",
     signatureBase64: String = "AQ",
+    headerJson: String? = null,
 ): String = """
-    {"protected":"$protectedHeaderBase64","payload":"$payloadBase64","signature":"$signatureBase64"}
+    {"protected":"$protectedHeaderBase64","payload":"$payloadBase64","signature":"$signatureBase64"${headerJson?.let { ""","header":$it""" }.orEmpty()}}
 """.trimIndent()
 
 private fun generalJson(
     protectedHeaderBase64: String = "eyJhbGciOiJSUzI1NiJ9",
     payloadBase64: String = "e30",
     signatureBase64: String = "AQ",
+    headerJson: String? = null,
 ): String = """
-    {"payload":"$payloadBase64","signatures":[{"protected":"$protectedHeaderBase64","signature":"$signatureBase64"}]}
+    {"payload":"$payloadBase64","signatures":[{"protected":"$protectedHeaderBase64","signature":"$signatureBase64"${headerJson?.let { ""","header":$it""" }.orEmpty()}}]}
 """.trimIndent()
 
 private fun flattenedSample(
@@ -454,6 +526,11 @@ private fun Result<*>.shouldBeRejectedPaddedBase64Url() {
     failure.message.orEmpty().shouldContain("Decoding failed")
     failure.cause shouldNotBe null
     failure.cause!!.message.orEmpty().shouldContain("Trailing = are not supported")
+}
+
+private fun Result<*>.shouldBeRejectedEmptyProtectedHeader() {
+    isSuccess shouldBe false
+    shouldBeFailure().message.orEmpty().shouldContain("must be absent when it would otherwise be empty")
 }
 
 private fun JsonElement.shouldNotContainKey(key: String) {

--- a/indispensable-josef/src/commonTest/kotlin/at/asitplus/signum/indispensable/josef/JwsSerializationTest.kt
+++ b/indispensable-josef/src/commonTest/kotlin/at/asitplus/signum/indispensable/josef/JwsSerializationTest.kt
@@ -4,7 +4,6 @@ import at.asitplus.signum.indispensable.CryptoSignature
 import at.asitplus.signum.indispensable.io.Base64UrlStrict
 import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
 import at.asitplus.testballoon.invoke
-import de.infix.testBalloon.framework.core.TestCompartment
 import de.infix.testBalloon.framework.core.testSuite
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
@@ -33,8 +32,8 @@ private val generalVectorJson = """
 """.trimIndent()
 
 private val generalVectorSource = joseCompliantSerializer.decodeFromString(JsonObject.serializer(), generalVectorJson)
-private val generalVectorPayload = generalVectorSource["payload"]!!.jsonPrimitive.content
-private val generalVectorSignatures = generalVectorSource["signatures"]!!.jsonArray
+private val generalVectorPayload = generalVectorSource[JWS.SerialNames.PAYLOAD]!!.jsonPrimitive.content
+private val generalVectorSignatures = generalVectorSource[JWS.SerialNames.SIGNATURES]!!.jsonArray
 
 val JwsSerializerTest by testSuite {
     "general JWS keeps vector bytes stable through serialization and flattening" {
@@ -48,8 +47,8 @@ val JwsSerializerTest by testSuite {
 
         general.signatureElements.forEachIndexed { index, signatureElement ->
             val sourceSignature = generalVectorSignatures[index].jsonObject
-            val protectedHeaderBase64 = sourceSignature["protected"]!!.jsonPrimitive.content
-            val signatureBase64 = sourceSignature["signature"]!!.jsonPrimitive.content
+            val protectedHeaderBase64 = sourceSignature[JWS.SerialNames.PROTECTED]!!.jsonPrimitive.content
+            val signatureBase64 = sourceSignature[JWS.SerialNames.SIGNATURE]!!.jsonPrimitive.content
 
             signatureElement.plainProtectedHeader shouldBe protectedHeaderBase64.decodeToByteArray(Base64UrlStrict)
             signatureElement.plainSignature shouldBe signatureBase64.decodeToByteArray(Base64UrlStrict)
@@ -334,8 +333,8 @@ val JwsSerializerTest by testSuite {
 
 private fun compactSerializationAt(index: Int): String {
     val sourceSignature = generalVectorSignatures[index].jsonObject
-    val protectedHeaderBase64 = sourceSignature["protected"]!!.jsonPrimitive.content
-    val signatureBase64 = sourceSignature["signature"]!!.jsonPrimitive.content
+    val protectedHeaderBase64 = sourceSignature[JWS.SerialNames.PROTECTED]!!.jsonPrimitive.content
+    val signatureBase64 = sourceSignature[JWS.SerialNames.SIGNATURE]!!.jsonPrimitive.content
     return "$protectedHeaderBase64.$generalVectorPayload.$signatureBase64"
 }
 

--- a/indispensable-josef/src/commonTest/kotlin/at/asitplus/signum/indispensable/josef/JwsSerializationTest.kt
+++ b/indispensable-josef/src/commonTest/kotlin/at/asitplus/signum/indispensable/josef/JwsSerializationTest.kt
@@ -4,6 +4,7 @@ import at.asitplus.signum.indispensable.CryptoSignature
 import at.asitplus.signum.indispensable.io.Base64UrlStrict
 import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
 import at.asitplus.testballoon.invoke
+import de.infix.testBalloon.framework.core.TestCompartment
 import de.infix.testBalloon.framework.core.testSuite
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
@@ -113,10 +114,10 @@ val JwsSerializerTest by testSuite {
         compact.signature.shouldBeInstanceOf<CryptoSignature.RSA>()
         compact.toString() shouldBe compactString
 
-        val serialized = joseCompliantSerializer.encodeToString(JwsCompact.serializer(), compact)
+        val serialized = joseCompliantSerializer.encodeToString(JwsCompactStringSerializer, compact)
 
         serialized shouldBe "\"$compactString\""
-        joseCompliantSerializer.decodeFromString(JwsCompact.serializer(), serialized) shouldBe compact
+        joseCompliantSerializer.decodeFromString(JwsCompactStringSerializer, serialized) shouldBe compact
 
         val flattened = compact.toJwsFlattened()
 
@@ -143,6 +144,10 @@ val JwsSerializerTest by testSuite {
         compactPattern.matches(serialized) shouldBe true
         reparsed shouldBe compact
         reparsed.toString() shouldBe serialized
+
+        val jsonString = joseCompliantSerializer.encodeToString(JwsCompactStringSerializer, compact)
+            .removeSurrounding("\"")
+        compactPattern.matches(jsonString) shouldBe true
     }
 
     "general to flattened to compact preserves each single-signature view" {

--- a/indispensable-josef/src/commonTest/kotlin/at/asitplus/signum/indispensable/josef/JwsSerializationTest.kt
+++ b/indispensable-josef/src/commonTest/kotlin/at/asitplus/signum/indispensable/josef/JwsSerializationTest.kt
@@ -1,0 +1,326 @@
+package at.asitplus.signum.indispensable.josef
+
+import at.asitplus.signum.indispensable.CryptoSignature
+import at.asitplus.signum.indispensable.io.Base64UrlStrict
+import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
+import at.asitplus.testballoon.invoke
+import de.infix.testBalloon.framework.core.testSuite
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+private val generalVectorJson = """
+    {
+      "payload": "eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFtcGxlLmNvbS9pc19yb290Ijp0cnVlfQ",
+      "signatures": [
+        {
+          "protected": "eyJhbGciOiJSUzI1NiJ9",
+          "signature": "cC4hiUPoj9Eetdgtv3hF80EGrhuB__dzERat0XF9g2VtQgr9PJbu3XOiZj5RZmh7AAuHIm4Bh-0Qc_lF5YKt_O8W2Fp5jujGbds9uJdbF9CUAr7t1dnZcAcQjbKBYNX4BAynRFdiuB--f_nZLgrnbyTyWzO75vRK5h6xBArLIARNPvkSjtQBMHlb1L07Qe7K0GarZRmB_eSN9383LcOLn6_dO--xi12jzDwusC-eOkHWEsqtFZESc6BfI7noOPqvhJ1phCnvWh6IeYI2w9QOYEUipUTI8np6LbgGY9Fs98rqVt5AXLIhWkWywlVmtVrBp0igcN_IoypGlUPQGe77Rw"
+        },
+        {
+          "protected": "eyJhbGciOiJFUzI1NiJ9",
+          "signature": "DtEhU3ljbEg8L38VWAfUAqOyKAM6-Xx-F4GawxaepmXFCgfTjDxw5djxLa8ISlSApmWQxfKTUJqPP3-Kg6NU1Q"
+        }
+      ]
+    }
+""".trimIndent()
+
+private val generalVectorSource = joseCompliantSerializer.decodeFromString(JsonObject.serializer(), generalVectorJson)
+private val generalVectorPayload = generalVectorSource["payload"]!!.jsonPrimitive.content
+private val generalVectorSignatures = generalVectorSource["signatures"]!!.jsonArray
+
+val JwsGeneralTest by testSuite {
+    "general JWS keeps vector bytes stable through serialization and flattening" {
+        val general = joseCompliantSerializer.decodeFromString<JwsGeneral>(generalVectorJson)
+
+        general.signatures.size shouldBe 2
+        general.getHeaderAt(0).algorithm shouldBe JwsAlgorithm.Signature.RS256
+        general.getHeaderAt(1).algorithm shouldBe JwsAlgorithm.Signature.ES256
+        general.getSignatureAt(0).shouldBeInstanceOf<CryptoSignature.RSA>()
+        general.getSignatureAt(1).shouldBeInstanceOf<CryptoSignature.EC.DefiniteLength>()
+
+        general.signatures.forEachIndexed { index, signatureElement ->
+            val sourceSignature = generalVectorSignatures[index].jsonObject
+            val protectedHeaderBase64 = sourceSignature["protected"]!!.jsonPrimitive.content
+            val signatureBase64 = sourceSignature["signature"]!!.jsonPrimitive.content
+
+            signatureElement.plainProtectedHeader shouldBe protectedHeaderBase64.decodeToByteArray(Base64UrlStrict)
+            signatureElement.plainSignature shouldBe signatureBase64.decodeToByteArray(Base64UrlStrict)
+            general.getSignatureInputAt(index).decodeToString() shouldBe "$protectedHeaderBase64.$generalVectorPayload"
+        }
+
+        val reserialized = joseCompliantSerializer.encodeToString(general)
+
+        joseCompliantSerializer.decodeFromString(JsonObject.serializer(), reserialized) shouldBe generalVectorSource
+        general.toJwsFlattened().toJwsGeneral() shouldBe general
+    }
+
+    "flattened JWS keeps unprotected headers stable through serialization and general conversion" {
+        val protectedHeader = JwsHeader.Part(
+            algorithm = JwsAlgorithm.Signature.RS256,
+            type = "application/example+jws",
+            keyId = "protected-kid",
+        )
+        val unprotectedHeader = JwsHeader.Part(
+            contentType = "application/example+json",
+            certificateUrl = "https://example.com/cert.pem",
+        )
+        val payload = """{"iss":"https://issuer.example","sub":"alice"}""".encodeToByteArray()
+        val plainProtectedHeader = JwsProtectedHeaderSerializer.encodeToByteArray(protectedHeader)
+        var capturedAlgorithm: JwsAlgorithm? = null
+        var capturedSignatureInput: ByteArray? = null
+
+        val flattened = JwsFlattened(
+            protectedHeader = protectedHeader,
+            unprotectedHeader = unprotectedHeader,
+            payload = payload,
+        ) { algorithm, signatureInput ->
+            capturedAlgorithm = algorithm
+            capturedSignatureInput = signatureInput
+            byteArrayOf(1, 2, 3, 4)
+        }
+
+        capturedAlgorithm shouldBe JwsHeader.fromParts(protectedHeader, unprotectedHeader).algorithm
+        capturedSignatureInput shouldBe JWS.getSignatureInput(plainProtectedHeader, payload)
+
+        val serialized = joseCompliantSerializer.encodeToString(flattened)
+        val reparsed = joseCompliantSerializer.decodeFromString<JwsFlattened>(serialized)
+
+        reparsed shouldBe flattened
+        with(joseCompliantSerializer) {
+            decodeFromString<JsonObject>(serialized) shouldBe decodeFromString<JsonObject>(encodeToString(reparsed))
+        }
+        val general = listOf(flattened).toJwsGeneral()
+
+        general.payload shouldBe payload
+        general.getHeaderAt(0) shouldBe flattened.jwsHeader
+        general.getSignatureAt(0) shouldBe flattened.signature
+        general.getSignatureInputAt(0) shouldBe flattened.signatureInput
+        general.toJwsFlattened() shouldBe listOf(flattened)
+    }
+
+    "compact JWS keeps its exact string form and round-trips through flattened" {
+        val compactString = compactSerializationAt(0)
+        val compact = JwsCompact(compactString)
+
+        compact.jwsHeader.algorithm shouldBe JwsAlgorithm.Signature.RS256
+        compact.signature.shouldBeInstanceOf<CryptoSignature.RSA>()
+        compact.toString() shouldBe compactString
+
+        val serialized = joseCompliantSerializer.encodeToString(JwsCompact.serializer(), compact)
+
+        serialized shouldBe "\"$compactString\""
+        joseCompliantSerializer.decodeFromString(JwsCompact.serializer(), serialized) shouldBe compact
+
+        val flattened = compact.toJwsFlattened()
+
+        flattened.signatureInput shouldBe compact.signatureInput
+        flattened.toJwsCompact() shouldBe compact
+    }
+
+    "general to flattened to compact preserves each single-signature view" {
+        val general = joseCompliantSerializer.decodeFromString<JwsGeneral>(generalVectorJson)
+        val flattened = general.toJwsFlattened()
+
+        flattened.size shouldBe general.signatures.size
+        flattened.forEachIndexed { index, entry ->
+            entry.jwsHeader shouldBe general.getHeaderAt(index)
+            entry.signature shouldBe general.getSignatureAt(index)
+            entry.signatureInput shouldBe general.getSignatureInputAt(index)
+            entry.toJwsCompact().toString() shouldBe compactSerializationAt(index)
+        }
+    }
+
+    "appendSignature matches list-to-general conversion" {
+        val payload = """{"nonce":"1234"}""".encodeToByteArray()
+        val first = flattenedSample(
+            protectedHeader = JwsHeader.Part(
+                algorithm = JwsAlgorithm.Signature.RS256,
+                keyId = "kid-1",
+            ),
+            payload = payload,
+            plainSignature = byteArrayOf(0x01),
+        )
+        val second = flattenedSample(
+            protectedHeader = JwsHeader.Part(
+                algorithm = JwsAlgorithm.Signature.ES256,
+                keyId = "kid-2",
+            ),
+            payload = payload,
+            plainSignature = ByteArray(64) { (it + 1).toByte() },
+        )
+
+        val appended = JwsGeneral(listOf(first)).appendSignature(second)
+
+        appended.toJwsFlattened() shouldBe listOf(first, second)
+        appended shouldBe listOf(first, second).toJwsGeneral()
+    }
+
+    "general conversions reject empty and mismatched flattened inputs" {
+        val first = flattenedSample(
+            protectedHeader = JwsHeader.Part(algorithm = JwsAlgorithm.Signature.RS256),
+            payload = "payload-1".encodeToByteArray(),
+            plainSignature = byteArrayOf(1),
+        )
+        val second = flattenedSample(
+            protectedHeader = JwsHeader.Part(algorithm = JwsAlgorithm.Signature.RS256),
+            payload = "payload-2".encodeToByteArray(),
+            plainSignature = byteArrayOf(2),
+        )
+
+        val emptyResult = runCatching { emptyList<JwsFlattened>().toJwsGeneral() }
+        val listMismatchResult = runCatching { listOf(first, second).toJwsGeneral() }
+        val appendMismatchResult = runCatching { JwsGeneral(listOf(first)).appendSignature(second) }
+
+        emptyResult.isSuccess shouldBe false
+        emptyResult.exceptionOrNull() shouldBe IllegalArgumentException("General JWS requires at least one signature")
+
+        listMismatchResult.isSuccess shouldBe false
+        listMismatchResult.exceptionOrNull() shouldBe
+                IllegalArgumentException("Additional signed JWS payload must match existing payload")
+
+        appendMismatchResult.isSuccess shouldBe false
+        appendMismatchResult.exceptionOrNull() shouldBe
+                IllegalArgumentException("Additional signed JWS payload must match existing payload")
+    }
+
+    "compact conversion rejects missing protected header and malformed compact strings" {
+        val missingProtectedHeader = JwsFlattened(
+            plainProtectedHeader = null,
+            unprotectedHeader = JwsHeader.Part(keyId = "kid-1"),
+            payload = "payload".encodeToByteArray(),
+            plainSignature = byteArrayOf(1),
+        )
+
+        val missingHeaderResult = runCatching { missingProtectedHeader.toJwsCompact() }
+        val missingPartResult = runCatching { JwsCompact("a.b") }
+        val extraPartResult = runCatching { JwsCompact("a.b.c.d") }
+        val invalidBase64Result = runCatching { JwsCompact("!!.e30.AQ") }
+
+        missingHeaderResult.isSuccess shouldBe false
+        missingHeaderResult.exceptionOrNull().shouldBeInstanceOf<IllegalArgumentException>()
+
+        missingPartResult.isSuccess shouldBe false
+        missingPartResult.exceptionOrNull()?.message?.shouldContain("expected 3 parts, got 2")
+
+        extraPartResult.isSuccess shouldBe false
+        extraPartResult.exceptionOrNull()?.message?.shouldContain("expected 3 parts, got 4")
+
+        invalidBase64Result.isSuccess shouldBe false
+        invalidBase64Result.exceptionOrNull()?.message?.shouldContain("Invalid base64url content")
+    }
+
+    "raw-signature decoding rejects MAC algorithms" {
+        val result = runCatching {
+            JWS.getSignature(JwsAlgorithm.MAC.HS256, byteArrayOf(1, 2, 3))
+        }
+
+        result.isSuccess shouldBe false
+        result.exceptionOrNull()?.message?.shouldContain("Unsupported algorithm")
+    }
+
+    "signature and general equality include unprotected headers" {
+        val protectedHeader = JwsProtectedHeaderSerializer.encodeToByteArray(
+            JwsHeader.Part(algorithm = JwsAlgorithm.Signature.RS256)
+        )
+        val signatureA = SignatureElement(
+            plainSignature = byteArrayOf(1),
+            plainProtectedHeader = protectedHeader,
+            unprotectedHeader = JwsHeader.Part(keyId = "kid-a"),
+        )
+        val signatureB = SignatureElement(
+            plainSignature = byteArrayOf(1),
+            plainProtectedHeader = protectedHeader,
+            unprotectedHeader = JwsHeader.Part(keyId = "kid-b"),
+        )
+
+        signatureA shouldNotBe signatureB
+
+        val generalA = JwsGeneral(
+            payload = "payload".encodeToByteArray(),
+            signatures = listOf(signatureA),
+        )
+        val generalB = JwsGeneral(
+            payload = "payload".encodeToByteArray(),
+            signatures = listOf(signatureB),
+        )
+
+        generalA shouldNotBe generalB
+    }
+
+    "sealed JWS serializer preserves the concrete JWS form" {
+        val compactValue = JwsCompact(compactSerializationAt(1))
+        val flattenedValue = flattenedSample(
+            protectedHeader = JwsHeader.Part(
+                algorithm = JwsAlgorithm.Signature.RS256,
+                type = "application/example+jws",
+            ),
+            unprotectedHeader = JwsHeader.Part(contentType = "application/example+json"),
+            payload = """{"sub":"alice"}""".encodeToByteArray(),
+            plainSignature = byteArrayOf(9, 8, 7, 6),
+        )
+        val generalValue = listOf(flattenedValue).toJwsGeneral()
+
+        val compactDecoded = joseCompliantSerializer.decodeFromString<JWS>(
+            joseCompliantSerializer.encodeToString(JWS.serializer(), compactValue)
+        ).shouldBeInstanceOf<JwsCompact>()
+        val flattenedDecoded = joseCompliantSerializer.decodeFromString<JWS>(
+            joseCompliantSerializer.encodeToString(JWS.serializer(), flattenedValue)
+        ).shouldBeInstanceOf<JwsFlattened>()
+        val generalDecoded = joseCompliantSerializer.decodeFromString<JWS>(
+            joseCompliantSerializer.encodeToString(JWS.serializer(), generalValue)
+        ).shouldBeInstanceOf<JwsGeneral>()
+
+        compactDecoded shouldBe compactValue
+        flattenedDecoded shouldBe flattenedValue
+        generalDecoded.toJwsFlattened() shouldBe listOf(flattenedValue)
+    }
+
+    "sealed JWS serializer rejects ambiguous and incomplete JSON objects" {
+        val ambiguousResult = runCatching {
+            joseCompliantSerializer.decodeFromString<JWS>(
+                """{"payload":"e30","signature":"AQ","signatures":[{"signature":"AQ"}]}"""
+            )
+        }
+        val incompleteResult = runCatching {
+            joseCompliantSerializer.decodeFromString<JWS>("""{"payload":"e30"}""")
+        }
+        val arrayResult = runCatching {
+            joseCompliantSerializer.decodeFromString<JWS>("""[1,2,3]""")
+        }
+
+        ambiguousResult.isSuccess shouldBe false
+        ambiguousResult.exceptionOrNull()?.message?.shouldContain("must not contain both")
+
+        incompleteResult.isSuccess shouldBe false
+        incompleteResult.exceptionOrNull()?.message?.shouldContain("must contain 'signature' or 'signatures'")
+
+        arrayResult.isSuccess shouldBe false
+        arrayResult.exceptionOrNull()?.message?.shouldContain("expected a compact string or JSON object")
+    }
+}
+
+private fun compactSerializationAt(index: Int): String {
+    val sourceSignature = generalVectorSignatures[index].jsonObject
+    val protectedHeaderBase64 = sourceSignature["protected"]!!.jsonPrimitive.content
+    val signatureBase64 = sourceSignature["signature"]!!.jsonPrimitive.content
+    return "$protectedHeaderBase64.$generalVectorPayload.$signatureBase64"
+}
+
+private fun flattenedSample(
+    protectedHeader: JwsHeader.Part,
+    payload: ByteArray,
+    plainSignature: ByteArray,
+    unprotectedHeader: JwsHeader.Part? = null,
+): JwsFlattened = JwsFlattened(
+    plainProtectedHeader = JwsProtectedHeaderSerializer.encodeToByteArray(protectedHeader),
+    unprotectedHeader = unprotectedHeader,
+    payload = payload,
+    plainSignature = plainSignature,
+)

--- a/indispensable-josef/src/commonTest/kotlin/at/asitplus/signum/indispensable/josef/JwsSerializationTest.kt
+++ b/indispensable-josef/src/commonTest/kotlin/at/asitplus/signum/indispensable/josef/JwsSerializationTest.kt
@@ -10,6 +10,7 @@ import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.types.shouldBeInstanceOf
 import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArray
+import kotlinx.serialization.MissingFieldException
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
@@ -35,7 +36,7 @@ private val generalVectorSource = joseCompliantSerializer.decodeFromString(JsonO
 private val generalVectorPayload = generalVectorSource["payload"]!!.jsonPrimitive.content
 private val generalVectorSignatures = generalVectorSource["signatures"]!!.jsonArray
 
-val JwsGeneralTest by testSuite {
+val JwsSerializerTest by testSuite {
     "general JWS keeps vector bytes stable through serialization and flattening" {
         val general = joseCompliantSerializer.decodeFromString<JwsGeneral>(generalVectorJson)
 
@@ -193,7 +194,7 @@ val JwsGeneralTest by testSuite {
     "compact conversion rejects missing protected header and malformed compact strings" {
         val missingProtectedHeader = JwsFlattened(
             plainProtectedHeader = null,
-            unprotectedHeader = JwsHeader.Part(keyId = "kid-1"),
+            unprotectedHeader = JwsHeader.Part(keyId = "kid-1", algorithm = JwsAlgorithm.Signature.RSA.RS256),
             payload = "payload".encodeToByteArray(),
             plainSignature = byteArrayOf(1),
         )

--- a/indispensable-josef/src/commonTest/kotlin/at/asitplus/signum/indispensable/josef/JwsSignedRegressionTest.kt
+++ b/indispensable-josef/src/commonTest/kotlin/at/asitplus/signum/indispensable/josef/JwsSignedRegressionTest.kt
@@ -110,8 +110,8 @@ val JwsSignedRegressionTest by testSuite {
         flattened.signatureInput shouldBe regressionCase.legacy.plainSignatureInput
 
         general.jwsHeaders[0] shouldBe regressionCase.legacy.header
-        general.getSignatureAt(0) shouldBe regressionCase.legacy.signature
-        general.getSignatureInputAt(0) shouldBe regressionCase.legacy.plainSignatureInput
+        general.signatures[0] shouldBe regressionCase.legacy.signature
+        general.signatureInputs[0] shouldBe regressionCase.legacy.plainSignatureInput
     }
 
     "empty payload keeps the compact separator for both APIs" {

--- a/indispensable-josef/src/commonTest/kotlin/at/asitplus/signum/indispensable/josef/JwsSignedRegressionTest.kt
+++ b/indispensable-josef/src/commonTest/kotlin/at/asitplus/signum/indispensable/josef/JwsSignedRegressionTest.kt
@@ -6,10 +6,10 @@ import at.asitplus.signum.indispensable.CryptoSignature
 import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
 import at.asitplus.testballoon.invoke
 import de.infix.testBalloon.framework.core.testSuite
+import io.kotest.engine.runBlocking
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldEndWith
 import io.kotest.matchers.types.shouldBeInstanceOf
-import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 
@@ -56,8 +56,35 @@ val JwsSignedRegressionTest by testSuite {
         val compactJson = joseCompliantSerializer.encodeToString(JwsCompactStringSerializer, regressionCase.compact)
 
         compactJson.removeSurrounding("\"") shouldBe regressionCase.legacy.serialize()
-        joseCompliantSerializer.decodeFromString(JwsCompactStringSerializer, compactJson) shouldBe regressionCase.compact
+        joseCompliantSerializer.decodeFromString(
+            JwsCompactStringSerializer,
+            compactJson
+        ) shouldBe regressionCase.compact
         JwsSigned.deserialize(regressionCase.legacy.serialize()).getOrThrow() shouldBe regressionCase.legacy
+    }
+
+    "JwsCompact.parse decodes compact serialization and typed payload" {
+        val typedPayload = JsonObject(
+            mapOf(
+                "iss" to JsonPrimitive("https://issuer.example"),
+                "sub" to JsonPrimitive("alice"),
+            )
+        )
+        val regressionCase = compactRegressionCase(
+            protectedHeader = JwsHeader.Part(
+                algorithm = JwsAlgorithm.Signature.RS256,
+                type = "JWT",
+            ),
+            payload = joseCompliantSerializer.encodeToString(JsonObject.serializer(), typedPayload).encodeToByteArray(),
+            plainSignature = byteArrayOf(1, 2, 3, 4),
+        )
+
+        val (parsedCompact, parsedPayload) = JwsCompact.parse<JsonObject>(regressionCase.compact.toString())
+            .getOrThrow()
+
+        parsedCompact shouldBe regressionCase.compact
+        parsedCompact.jwsHeader shouldBe regressionCase.compact.jwsHeader
+        parsedPayload shouldBe typedPayload
     }
 
     "typed payload decoding matches between JwsSigned and JwsCompact" {

--- a/indispensable-josef/src/commonTest/kotlin/at/asitplus/signum/indispensable/josef/JwsSignedRegressionTest.kt
+++ b/indispensable-josef/src/commonTest/kotlin/at/asitplus/signum/indispensable/josef/JwsSignedRegressionTest.kt
@@ -13,19 +13,18 @@ import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 
 val JwsSignedRegressionTest by testSuite {
-    "JwsCompact.invoke passes the same signing input as JwsSigned.prepareJwsSignatureInput" {
-        val protectedHeader = JwsHeader.Part(
+    "JwsCompact.invoke signs the protected-header bytes derived from JwsHeader.toPart" {
+        val header = JwsHeader(
             algorithm = JwsAlgorithm.Signature.RS256,
             type = "application/example+jws",
             keyId = "kid-1",
         )
-        val header = JwsHeader.fromParts(protectedHeader, null)
         val payload = """{"iss":"https://issuer.example","sub":"alice"}""".encodeToByteArray()
         var capturedAlgorithm: JwsAlgorithm? = null
         var capturedInput: ByteArray? = null
 
-        JwsCompact.invoke(
-            protectedHeader = protectedHeader,
+        val compact = JwsCompact.invoke(
+            protectedHeader = header,
             payload = payload,
         ) { algorithm, signingInput ->
             capturedAlgorithm = algorithm
@@ -33,8 +32,12 @@ val JwsSignedRegressionTest by testSuite {
             byteArrayOf(1, 2, 3, 4)
         }
 
+        val expectedProtectedHeader = JwsProtectedHeaderSerializer.encodeToByteArray(header.toPart())
+
         capturedAlgorithm shouldBe header.algorithm
-        capturedInput shouldBe JwsSigned.prepareJwsSignatureInput(header, payload)
+        compact.plainProtectedHeader shouldBe expectedProtectedHeader
+        capturedInput shouldBe JWS.getSignatureInput(expectedProtectedHeader, payload)
+        compact.signatureInput shouldBe capturedInput
     }
 
     "legacy compact serialization matches JwsCompact for RS256" {

--- a/indispensable-josef/src/commonTest/kotlin/at/asitplus/signum/indispensable/josef/JwsSignedRegressionTest.kt
+++ b/indispensable-josef/src/commonTest/kotlin/at/asitplus/signum/indispensable/josef/JwsSignedRegressionTest.kt
@@ -1,0 +1,177 @@
+@file:Suppress("DEPRECATION")
+
+package at.asitplus.signum.indispensable.josef
+
+import at.asitplus.signum.indispensable.CryptoSignature
+import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
+import at.asitplus.testballoon.invoke
+import de.infix.testBalloon.framework.core.testSuite
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldEndWith
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+
+val JwsSignedRegressionTest by testSuite {
+    "JwsCompact.invoke passes the same signing input as JwsSigned.prepareJwsSignatureInput" {
+        val protectedHeader = JwsHeader.Part(
+            algorithm = JwsAlgorithm.Signature.RS256,
+            type = "application/example+jws",
+            keyId = "kid-1",
+        )
+        val header = JwsHeader.fromParts(protectedHeader, null)
+        val payload = """{"iss":"https://issuer.example","sub":"alice"}""".encodeToByteArray()
+        var capturedAlgorithm: JwsAlgorithm? = null
+        var capturedInput: ByteArray? = null
+
+        JwsCompact.invoke(
+            protectedHeader = protectedHeader,
+            payload = payload,
+        ) { algorithm, signingInput ->
+            capturedAlgorithm = algorithm
+            capturedInput = signingInput
+            byteArrayOf(1, 2, 3, 4)
+        }
+
+        capturedAlgorithm shouldBe header.algorithm
+        capturedInput shouldBe JwsSigned.prepareJwsSignatureInput(header, payload)
+    }
+
+    "legacy compact serialization matches JwsCompact for RS256" {
+        val regressionCase = compactRegressionCase(
+            protectedHeader = JwsHeader.Part(
+                algorithm = JwsAlgorithm.Signature.RS256,
+                type = "JWT",
+                keyId = "kid-rs256",
+            ),
+            payload = """{"iss":"https://issuer.example","aud":"example"}""".encodeToByteArray(),
+            plainSignature = byteArrayOf(5, 4, 3, 2, 1),
+        )
+
+        regressionCase.legacy.header shouldBe regressionCase.compact.jwsHeader
+        regressionCase.legacy.signature shouldBe regressionCase.compact.signature
+        regressionCase.legacy.plainSignatureInput shouldBe regressionCase.compact.signatureInput
+
+        val compactJson = joseCompliantSerializer.encodeToString(JwsCompact.serializer(), regressionCase.compact)
+
+        compactJson.removeSurrounding("\"") shouldBe regressionCase.legacy.serialize()
+        joseCompliantSerializer.decodeFromString(JwsCompact.serializer(), compactJson) shouldBe regressionCase.compact
+        JwsSigned.deserialize(regressionCase.legacy.serialize()).getOrThrow() shouldBe regressionCase.legacy
+    }
+
+    "typed payload decoding matches between JwsSigned and JwsCompact" {
+        val typedPayload = JsonObject(
+            mapOf(
+                "iss" to JsonPrimitive("https://issuer.example"),
+                "sub" to JsonPrimitive("alice"),
+                "admin" to JsonPrimitive(true),
+            )
+        )
+        val payload = joseCompliantSerializer.encodeToString(JsonObject.serializer(), typedPayload).encodeToByteArray()
+        val regressionCase = compactRegressionCase(
+            protectedHeader = JwsHeader.Part(
+                algorithm = JwsAlgorithm.Signature.RS256,
+                type = "application/example+jwt",
+            ),
+            payload = payload,
+            plainSignature = byteArrayOf(9, 8, 7, 6),
+        )
+
+        val legacyTyped = JwsSigned.deserialize(
+            deserializationStrategy = JsonObject.serializer(),
+            it = regressionCase.legacy.serialize(),
+            json = joseCompliantSerializer,
+        ).getOrThrow()
+
+        legacyTyped.header shouldBe regressionCase.compact.jwsHeader
+        legacyTyped.payload shouldBe regressionCase.compact.getPayload(JsonObject.serializer())
+        legacyTyped.signature shouldBe regressionCase.compact.signature
+        legacyTyped.plainSignatureInput shouldBe regressionCase.compact.signatureInput
+    }
+
+    "single-signature conversion path preserves the JwsSigned view" {
+        val regressionCase = compactRegressionCase(
+            protectedHeader = JwsHeader.Part(
+                algorithm = JwsAlgorithm.Signature.RS256,
+                keyId = "kid-general",
+            ),
+            payload = """{"nonce":"1234"}""".encodeToByteArray(),
+            plainSignature = byteArrayOf(0x2a),
+        )
+
+        val flattened = regressionCase.compact.toJwsFlattened()
+        val general = listOf(flattened).toJwsGeneral()
+
+        flattened.jwsHeader shouldBe regressionCase.legacy.header
+        flattened.signature shouldBe regressionCase.legacy.signature
+        flattened.signatureInput shouldBe regressionCase.legacy.plainSignatureInput
+
+        general.getHeaderAt(0) shouldBe regressionCase.legacy.header
+        general.getSignatureAt(0) shouldBe regressionCase.legacy.signature
+        general.getSignatureInputAt(0) shouldBe regressionCase.legacy.plainSignatureInput
+    }
+
+    "empty payload keeps the compact separator for both APIs" {
+        val regressionCase = compactRegressionCase(
+            protectedHeader = JwsHeader.Part(
+                algorithm = JwsAlgorithm.Signature.RS256,
+            ),
+            payload = byteArrayOf(),
+            plainSignature = byteArrayOf(1),
+        )
+
+        regressionCase.legacy.plainSignatureInput.decodeToString().shouldEndWith(".")
+        regressionCase.compact.signatureInput.decodeToString().shouldEndWith(".")
+        regressionCase.legacy.serialize() shouldBe regressionCase.compact.toString()
+
+        JwsSigned.deserialize(regressionCase.legacy.serialize()).getOrThrow().payload shouldBe byteArrayOf()
+    }
+
+    "ES256 compact signatures are decoded as EC signatures in both APIs" {
+        val plainSignature = ByteArray(64) { (it + 1).toByte() }
+        val regressionCase = compactRegressionCase(
+            protectedHeader = JwsHeader.Part(
+                algorithm = JwsAlgorithm.Signature.ES256,
+                type = "application/example+jws",
+            ),
+            payload = """{"sub":"alice"}""".encodeToByteArray(),
+            plainSignature = plainSignature,
+        )
+
+        val legacy = JwsSigned.deserialize(regressionCase.legacy.serialize()).getOrThrow()
+
+        legacy.header.algorithm shouldBe JwsAlgorithm.Signature.ES256
+        legacy.signature shouldBe regressionCase.compact.signature
+        legacy.signature.rawByteArray shouldBe plainSignature
+        legacy.signature.shouldBeInstanceOf<CryptoSignature.EC.DefiniteLength>()
+        regressionCase.compact.signature.shouldBeInstanceOf<CryptoSignature.EC.DefiniteLength>()
+    }
+}
+
+private data class CompactRegressionCase(
+    val legacy: JwsSigned<ByteArray>,
+    val compact: JwsCompact,
+)
+
+private fun compactRegressionCase(
+    protectedHeader: JwsHeader.Part,
+    payload: ByteArray,
+    plainSignature: ByteArray,
+): CompactRegressionCase {
+    val header = JwsHeader.fromParts(protectedHeader, null)
+    val compact = JwsCompact(
+        plainProtectedHeader = JwsProtectedHeaderSerializer.encodeToByteArray(protectedHeader),
+        payload = payload,
+        plainSignature = plainSignature,
+    )
+
+    return CompactRegressionCase(
+        legacy = JwsSigned(
+            header = header,
+            payload = payload,
+            signature = JWS.getSignature(header.algorithm, plainSignature),
+            plainSignatureInput = JwsSigned.prepareJwsSignatureInput(header, payload),
+        ),
+        compact = compact,
+    )
+}

--- a/indispensable-josef/src/commonTest/kotlin/at/asitplus/signum/indispensable/josef/JwsSignedRegressionTest.kt
+++ b/indispensable-josef/src/commonTest/kotlin/at/asitplus/signum/indispensable/josef/JwsSignedRegressionTest.kt
@@ -109,7 +109,7 @@ val JwsSignedRegressionTest by testSuite {
         flattened.signature shouldBe regressionCase.legacy.signature
         flattened.signatureInput shouldBe regressionCase.legacy.plainSignatureInput
 
-        general.getHeaderAt(0) shouldBe regressionCase.legacy.header
+        general.jwsHeaders[0] shouldBe regressionCase.legacy.header
         general.getSignatureAt(0) shouldBe regressionCase.legacy.signature
         general.getSignatureInputAt(0) shouldBe regressionCase.legacy.plainSignatureInput
     }

--- a/indispensable-josef/src/commonTest/kotlin/at/asitplus/signum/indispensable/josef/JwsSignedRegressionTest.kt
+++ b/indispensable-josef/src/commonTest/kotlin/at/asitplus/signum/indispensable/josef/JwsSignedRegressionTest.kt
@@ -55,10 +55,10 @@ val JwsSignedRegressionTest by testSuite {
         regressionCase.legacy.signature shouldBe regressionCase.compact.signature
         regressionCase.legacy.plainSignatureInput shouldBe regressionCase.compact.signatureInput
 
-        val compactJson = joseCompliantSerializer.encodeToString(JwsCompact.serializer(), regressionCase.compact)
+        val compactJson = joseCompliantSerializer.encodeToString(JwsCompactStringSerializer, regressionCase.compact)
 
         compactJson.removeSurrounding("\"") shouldBe regressionCase.legacy.serialize()
-        joseCompliantSerializer.decodeFromString(JwsCompact.serializer(), compactJson) shouldBe regressionCase.compact
+        joseCompliantSerializer.decodeFromString(JwsCompactStringSerializer, compactJson) shouldBe regressionCase.compact
         JwsSigned.deserialize(regressionCase.legacy.serialize()).getOrThrow() shouldBe regressionCase.legacy
     }
 

--- a/indispensable-josef/src/commonTest/kotlin/at/asitplus/signum/indispensable/josef/JwsSignedRegressionTest.kt
+++ b/indispensable-josef/src/commonTest/kotlin/at/asitplus/signum/indispensable/josef/JwsSignedRegressionTest.kt
@@ -9,6 +9,7 @@ import de.infix.testBalloon.framework.core.testSuite
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldEndWith
 import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 
@@ -20,21 +21,18 @@ val JwsSignedRegressionTest by testSuite {
             keyId = "kid-1",
         )
         val payload = """{"iss":"https://issuer.example","sub":"alice"}""".encodeToByteArray()
-        var capturedAlgorithm: JwsAlgorithm? = null
         var capturedInput: ByteArray? = null
 
         val compact = JwsCompact.invoke(
             protectedHeader = header,
             payload = payload,
-        ) { algorithm, signingInput ->
-            capturedAlgorithm = algorithm
+        ) { signingInput ->
             capturedInput = signingInput
             byteArrayOf(1, 2, 3, 4)
         }
 
         val expectedProtectedHeader = JwsProtectedHeaderSerializer.encodeToByteArray(header.toPart())
 
-        capturedAlgorithm shouldBe header.algorithm
         compact.plainProtectedHeader shouldBe expectedProtectedHeader
         capturedInput shouldBe JWS.getSignatureInput(expectedProtectedHeader, payload)
         compact.signatureInput shouldBe capturedInput
@@ -87,7 +85,7 @@ val JwsSignedRegressionTest by testSuite {
         ).getOrThrow()
 
         legacyTyped.header shouldBe regressionCase.compact.jwsHeader
-        legacyTyped.payload shouldBe regressionCase.compact.getPayload(JsonObject.serializer())
+        legacyTyped.payload shouldBe regressionCase.compact.getPayload(JsonObject.serializer()).getOrThrow()
         legacyTyped.signature shouldBe regressionCase.compact.signature
         legacyTyped.plainSignatureInput shouldBe regressionCase.compact.signatureInput
     }
@@ -164,7 +162,7 @@ private fun compactRegressionCase(
     val header = JwsHeader.fromParts(protectedHeader, null)
     val compact = JwsCompact(
         plainProtectedHeader = JwsProtectedHeaderSerializer.encodeToByteArray(protectedHeader),
-        payload = payload,
+        plainPayload = payload,
         plainSignature = plainSignature,
     )
 

--- a/indispensable-josef/src/commonTest/kotlin/at/asitplus/signum/indispensable/josef/JwsTypedTest.kt
+++ b/indispensable-josef/src/commonTest/kotlin/at/asitplus/signum/indispensable/josef/JwsTypedTest.kt
@@ -1,0 +1,128 @@
+package at.asitplus.signum.indispensable.josef
+
+import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
+import at.asitplus.signum.indispensable.josef.typed
+import at.asitplus.testballoon.invoke
+import de.infix.testBalloon.framework.core.testSuite
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+
+val payload = JsonObject(
+    content = mapOf(
+        "issuer" to JsonPrimitive("https://issuer.example"),
+        "subject" to JsonPrimitive("alice"),
+        "admin" to JsonPrimitive(true),
+    )
+)
+
+val JwsTypedTest by testSuite {
+    "compact typed wrappers can be built from payloads and reopened from compact JWS" {
+        val header = JwsHeader(
+            algorithm = JwsAlgorithm.Signature.RS256,
+            type = "application/example+jws",
+            keyId = "kid-compact",
+        )
+        val expectedPayload = joseCompliantSerializer.encodeToString<JsonObject>(payload).encodeToByteArray()
+        val expectedProtectedHeader = JwsProtectedHeaderSerializer.encodeToByteArray(header.toPart())
+        var capturedSignatureInput: ByteArray? = null
+
+        val typedCompact: JwsCompactTyped<JsonObject> = JwsTyped(
+            protectedHeader = header,
+            payload = payload,
+        ) { signatureInput ->
+            capturedSignatureInput = signatureInput
+            byteArrayOf(1, 2, 3, 4)
+        }
+
+        typedCompact.payload shouldBe payload
+        typedCompact.jws.plainPayload shouldBe expectedPayload
+        capturedSignatureInput shouldBe JWS.getSignatureInput(expectedProtectedHeader, expectedPayload)
+        typedCompact.toString() shouldBe typedCompact.jws.toString()
+
+        typedCompact.jws.typed<JsonObject, JwsCompact>() shouldBe typedCompact
+        JwsTyped<JsonObject>(typedCompact.toString()) shouldBe typedCompact
+    }
+
+    "compact and flattened typed wrappers convert without changing the payload view" {
+        val typedCompact: JwsCompactTyped<JsonObject> = JwsTyped(
+            protectedHeader = JwsHeader(
+                algorithm = JwsAlgorithm.Signature.RS256,
+                keyId = "kid-roundtrip",
+            ),
+            payload = payload,
+        ) {
+            byteArrayOf(9, 8, 7, 6)
+        }
+
+        val typedFlattened = typedCompact.toJwsFlattenedTyped()
+        val reparsedCompact = typedFlattened.toJwsCompactTyped()
+
+        typedFlattened.payload shouldBe payload
+        typedFlattened.jws shouldBe typedCompact.jws.toJwsFlattened()
+        reparsedCompact shouldBe typedCompact
+    }
+
+    "flattened typed wrappers can be created from header fragments and existing flattened JWS" {
+        val protectedHeader = JwsHeader.Part(
+            algorithm = JwsAlgorithm.Signature.RS256,
+            type = "application/example+jws",
+        )
+        val unprotectedHeader = JwsHeader.Part(
+            keyId = "kid-flattened",
+            contentType = "application/example+json",
+        )
+        val expectedPayload = joseCompliantSerializer.encodeToString<JsonObject>(payload).encodeToByteArray()
+        val expectedProtectedHeader = JwsProtectedHeaderSerializer.encodeToByteArrayOrNull(protectedHeader)
+        var capturedSignatureInput: ByteArray? = null
+
+        val typedFlattened: JwsFlattenedTyped<JsonObject> = JwsTyped(
+            protectedHeader = protectedHeader,
+            unprotectedHeader = unprotectedHeader,
+            payload = payload,
+        ) { signatureInput ->
+            capturedSignatureInput = signatureInput
+            byteArrayOf(4, 3, 2, 1)
+        }
+
+        typedFlattened.payload shouldBe payload
+        typedFlattened.jws.plainPayload shouldBe expectedPayload
+        typedFlattened.jws.unprotectedHeader shouldBe unprotectedHeader
+        capturedSignatureInput shouldBe JWS.getSignatureInput(expectedProtectedHeader, expectedPayload)
+        typedFlattened.toString() shouldBe typedFlattened.jws.toString()
+
+        typedFlattened.jws.typed<JsonObject, JwsFlattened>() shouldBe typedFlattened
+    }
+
+    "general typed wrappers can be assembled from flattened signatures and expanded again" {
+        val first: JwsFlattenedTyped<JsonObject> = JwsTyped(
+            protectedHeader = JwsHeader.Part(
+                algorithm = JwsAlgorithm.Signature.RS256,
+                type = "application/example+jws",
+            ),
+            unprotectedHeader = JwsHeader.Part(keyId = "kid-1"),
+            payload = payload,
+        ) {
+            byteArrayOf(1, 1, 1, 1)
+        }
+        val second: JwsFlattenedTyped<JsonObject> = JwsTyped(
+            protectedHeader = JwsHeader.Part(
+                algorithm = JwsAlgorithm.Signature.RS256,
+                type = "application/example+jws",
+            ),
+            unprotectedHeader = JwsHeader.Part(keyId = "kid-2"),
+            payload = payload,
+        ) {
+            byteArrayOf(2, 2, 2, 2)
+        }
+
+        val typedGeneral: JwsGeneralTyped<JsonObject> = JwsTyped(listOf(first.jws, second.jws))
+
+        typedGeneral.payload shouldBe payload
+        typedGeneral.jws shouldBe listOf(first.jws, second.jws).toJwsGeneral()
+        typedGeneral.toString() shouldBe typedGeneral.jws.toString()
+        typedGeneral.toJwsFlattenedTyped() shouldBe listOf(first, second)
+
+        typedGeneral.jws.typed<JsonObject, JwsGeneral>() shouldBe typedGeneral
+    }
+}

--- a/indispensable-josef/src/jvmTest/kotlin/at/asitplus/signum/indispensable/josef/JwsJvmTest.kt
+++ b/indispensable-josef/src/jvmTest/kotlin/at/asitplus/signum/indispensable/josef/JwsJvmTest.kt
@@ -13,7 +13,6 @@ import com.nimbusds.jose.crypto.ECDSAVerifier
 import de.infix.testBalloon.framework.core.testSuite
 import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.shouldBe
-import kotlinx.coroutines.runBlocking
 import java.security.interfaces.ECPublicKey
 
 val JwsJvmTest by testSuite {
@@ -32,8 +31,8 @@ val JwsJvmTest by testSuite {
         val verifier1 = ECDSAVerifier(signer1.publicKey.toJcaPublicKey().getOrThrow() as ECPublicKey)
         val verifier2 = ECDSAVerifier(signer2.publicKey.toJcaPublicKey().getOrThrow() as ECPublicKey)
 
-        fun signerFor(signer: Signer): (JwsAlgorithm, ByteArray) -> ByteArray = { _, input ->
-            runBlocking { signer.sign(input).signature.rawByteArray }
+        fun signerFor(signer: Signer): suspend (ByteArray) -> ByteArray = { input ->
+            signer.sign(input).signature.rawByteArray
         }
     }
 

--- a/indispensable-josef/src/jvmTest/kotlin/at/asitplus/signum/indispensable/josef/JwsJvmTest.kt
+++ b/indispensable-josef/src/jvmTest/kotlin/at/asitplus/signum/indispensable/josef/JwsJvmTest.kt
@@ -1,0 +1,120 @@
+package at.asitplus.signum.indispensable.josef
+
+import at.asitplus.signum.indispensable.ECCurve
+import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
+import at.asitplus.signum.indispensable.toJcaPublicKey
+import at.asitplus.signum.supreme.sign.Signer
+import at.asitplus.signum.supreme.signature
+import at.asitplus.testballoon.invoke
+import at.asitplus.testballoon.withFixtureGenerator
+import com.nimbusds.jose.JWSObject
+import com.nimbusds.jose.JWSObjectJSON
+import com.nimbusds.jose.crypto.ECDSAVerifier
+import de.infix.testBalloon.framework.core.testSuite
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonPrimitive
+import java.security.interfaces.ECPublicKey
+
+val JwsJvmTest by testSuite {
+
+    class Context {
+        val payload = """{"iss":"https://issuer.example","sub":"alice"}""".encodeToByteArray()
+
+        val signer1 = Signer.Ephemeral {
+            ec { curve = ECCurve.SECP_256_R_1 }
+        }.getOrThrow()
+
+        val signer2 = Signer.Ephemeral {
+            ec { curve = ECCurve.SECP_256_R_1 }
+        }.getOrThrow()
+
+        val verifier1 = ECDSAVerifier(signer1.publicKey.toJcaPublicKey().getOrThrow() as ECPublicKey)
+        val verifier2 = ECDSAVerifier(signer2.publicKey.toJcaPublicKey().getOrThrow() as ECPublicKey)
+
+        fun signerFor(signer: Signer): (JwsAlgorithm, ByteArray) -> ByteArray = { _, input ->
+            runBlocking { signer.sign(input).signature.rawByteArray }
+        }
+    }
+
+    withFixtureGenerator(::Context) - {
+
+        "compact JWS can be encoded and verified by Nimbus" { it ->
+            val compact = JwsCompact.invoke(
+                protectedHeader = JwsHeader.Part(
+                    algorithm = it.signer1.signatureAlgorithm.toJwsAlgorithm().getOrThrow(),
+                    keyId = "kid-1",
+                    type = "application/example+jws",
+                ),
+                payload = it.payload,
+                signer = it.signerFor(it.signer1),
+            )
+
+            val serialized = compact.toString()
+            val parsed = JWSObject.parse(serialized)
+
+            parsed.verify(it.verifier1).shouldBeTrue()
+            parsed.header.keyID shouldBe "kid-1"
+            compact.jwsHeader shouldBe JwsHeader.fromParts(compact.plainProtectedHeader, null)
+        }
+
+        "flattened JWS can be serialized and verified by Nimbus" { it ->
+            val flattened = JwsFlattened.invoke(
+                protectedHeader = JwsHeader.Part(
+                    algorithm = it.signer1.signatureAlgorithm.toJwsAlgorithm().getOrThrow(),
+                    type = "application/example+jws",
+                ),
+                unprotectedHeader = JwsHeader.Part(keyId = "kid-1"),
+                payload = it.payload,
+                signer = it.signerFor(it.signer1),
+            )
+
+            val serialized = joseCompliantSerializer.encodeToString(JwsFlattened.serializer(), flattened)
+            val parsed = JWSObjectJSON.parse(serialized)
+
+            parsed.signatures.size shouldBe 1
+            parsed.signatures.single().verify(it.verifier1).shouldBeTrue()
+            parsed.signatures.single().header.keyID shouldBe null
+            parsed.signatures.single().unprotectedHeader.keyID shouldBe "kid-1"
+            flattened.jwsHeader shouldBe JwsHeader.fromParts(
+                flattened.plainProtectedHeader,
+                flattened.unprotectedHeader
+            )
+        }
+
+        "general JWS can be serialized and verified by Nimbus" { it ->
+            val flattened1 = JwsFlattened.invoke(
+                protectedHeader = JwsHeader.Part(
+                    algorithm = it.signer1.signatureAlgorithm.toJwsAlgorithm().getOrThrow(),
+                ),
+                unprotectedHeader = JwsHeader.Part(keyId = "kid-1"),
+                payload = it.payload,
+                signer = it.signerFor(it.signer1),
+            )
+            val flattened2 = JwsFlattened.invoke(
+                protectedHeader = JwsHeader.Part(
+                    algorithm = it.signer2.signatureAlgorithm.toJwsAlgorithm().getOrThrow(),
+                ),
+                unprotectedHeader = JwsHeader.Part(keyId = "kid-2"),
+                payload = it.payload,
+                signer = it.signerFor(it.signer2),
+            )
+
+            val general = JwsGeneral.invoke(listOf(flattened1, flattened2))
+            val serialized = joseCompliantSerializer.encodeToString(JwsGeneral.serializer(), general)
+            val parsed = JWSObjectJSON.parse(serialized)
+
+            parsed.signatures.size shouldBe 2
+            parsed.signatures[0].verify(it.verifier1).shouldBeTrue()
+            parsed.signatures[1].verify(it.verifier2).shouldBeTrue()
+            parsed.signatures[0].header.keyID shouldBe null
+            parsed.signatures[1].header.keyID shouldBe null
+            parsed.signatures[0].unprotectedHeader.keyID shouldBe "kid-1"
+            parsed.signatures[1].unprotectedHeader.keyID shouldBe "kid-2"
+            general.getHeaderAt(0) shouldBe flattened1.jwsHeader
+            general.getHeaderAt(1) shouldBe flattened2.jwsHeader
+        }
+    }
+}

--- a/indispensable-josef/src/jvmTest/kotlin/at/asitplus/signum/indispensable/josef/JwsJvmTest.kt
+++ b/indispensable-josef/src/jvmTest/kotlin/at/asitplus/signum/indispensable/josef/JwsJvmTest.kt
@@ -111,8 +111,8 @@ val JwsJvmTest by testSuite {
             parsed.signatures[1].header.keyID shouldBe null
             parsed.signatures[0].unprotectedHeader.keyID shouldBe "kid-1"
             parsed.signatures[1].unprotectedHeader.keyID shouldBe "kid-2"
-            general.getHeaderAt(0) shouldBe flattened1.jwsHeader
-            general.getHeaderAt(1) shouldBe flattened2.jwsHeader
+            general.jwsHeaders[0] shouldBe flattened1.jwsHeader
+            general.jwsHeaders[1] shouldBe flattened2.jwsHeader
         }
     }
 }

--- a/indispensable-josef/src/jvmTest/kotlin/at/asitplus/signum/indispensable/josef/JwsJvmTest.kt
+++ b/indispensable-josef/src/jvmTest/kotlin/at/asitplus/signum/indispensable/josef/JwsJvmTest.kt
@@ -14,8 +14,6 @@ import de.infix.testBalloon.framework.core.testSuite
 import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.runBlocking
-import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.JsonPrimitive
 import java.security.interfaces.ECPublicKey
 
 val JwsJvmTest by testSuite {
@@ -43,7 +41,7 @@ val JwsJvmTest by testSuite {
 
         "compact JWS can be encoded and verified by Nimbus" { it ->
             val compact = JwsCompact.invoke(
-                protectedHeader = JwsHeader.Part(
+                protectedHeader = JwsHeader(
                     algorithm = it.signer1.signatureAlgorithm.toJwsAlgorithm().getOrThrow(),
                     keyId = "kid-1",
                     type = "application/example+jws",

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/io/Encoding.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/io/Encoding.kt
@@ -65,35 +65,45 @@ open class TransformingSerializerTemplate<ValueT, EncodedT>
 }
 
 /** De-/serializes Base64 strings to/from [ByteArray] */
-object ByteArrayBase64Serializer: TransformingSerializerTemplate<ByteArray, String>(
+object ByteArrayBase64Serializer : TransformingSerializerTemplate<ByteArray, String>(
     parent = String.serializer(),
     encodeAs = { it.encodeToString(Base64Strict) },
     decodeAs = { it.decodeToByteArray(Base64Strict) }
 )
 
 /** De-/serializes Base64Url strings to/from [ByteArray] */
-object ByteArrayBase64UrlSerializer: TransformingSerializerTemplate<ByteArray, String>(
+object ByteArrayBase64UrlSerializer : TransformingSerializerTemplate<ByteArray, String>(
     parent = String.serializer(),
     encodeAs = { it.encodeToString(Base64UrlStrict) },
     decodeAs = { it.decodeToByteArray(Base64UrlStrict) }
 )
 
+/** De-/serializes Base64Url strings to/from [ByteArray] rejecting padded strings for protocols that require unpadded Base64Url such as RFC7515 */
+object ByteArrayBase64UrlNoPaddingSerializer : TransformingSerializerTemplate<ByteArray, String>(
+    parent = String.serializer(),
+    encodeAs = { it.encodeToString(Base64UrlStrict) },
+    decodeAs = {
+        require(!it.contains("=")) { "Trailing = are not supported" }
+        it.decodeToByteArray(Base64UrlStrict)
+    }
+)
+
 /** De-/serializes X509Certificate as Base64Url-encoded String */
-object X509CertificateBase64UrlSerializer: TransformingSerializerTemplate<X509Certificate, ByteArray>(
+object X509CertificateBase64UrlSerializer : TransformingSerializerTemplate<X509Certificate, ByteArray>(
     parent = ByteArrayBase64UrlSerializer,
     encodeAs = X509Certificate::encodeToDer,
     decodeAs = { X509Certificate.decodeFromDer(it) } // workaround iOS compilation bug KT-71498
 )
 
 /** De-/serializes X509Certificate as Base64-encoded String */
-object X509CertificateBase64Serializer: TransformingSerializerTemplate<X509Certificate, ByteArray>(
+object X509CertificateBase64Serializer : TransformingSerializerTemplate<X509Certificate, ByteArray>(
     parent = ByteArrayBase64Serializer,
     encodeAs = X509Certificate::encodeToDer,
     decodeAs = { X509Certificate.decodeFromDer(it) } // workaround iOS compilation bug KT-71498
 )
 
 /** De-/serializes a public key as a Base64Url-encoded IOS encoding public key */
-object IosPublicKeySerializer: TransformingSerializerTemplate<CryptoPublicKey, ByteArray>(
+object IosPublicKeySerializer : TransformingSerializerTemplate<CryptoPublicKey, ByteArray>(
     parent = ByteArrayBase64UrlSerializer,
     encodeAs = CryptoPublicKey::iosEncoded,
     decodeAs = CryptoPublicKey::fromIosEncoded)
@@ -115,9 +125,9 @@ sealed class ListSerializerTemplate<ValueT>(
 }
 
 /** De-/serializes X509Certificate as collection of Base64Url-encoded Strings */
-object CertificateChainBase64UrlSerializer: ListSerializerTemplate<X509Certificate>(
+object CertificateChainBase64UrlSerializer : ListSerializerTemplate<X509Certificate>(
     using = X509CertificateBase64UrlSerializer)
 
 /** De-/serializes X509Certificate as collection of Base64-encoded Strings */
-object CertificateChainBase64Serializer: ListSerializerTemplate<X509Certificate>(
+object CertificateChainBase64Serializer : ListSerializerTemplate<X509Certificate>(
     using = X509CertificateBase64Serializer)

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/io/Encoding.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/io/Encoding.kt
@@ -78,13 +78,6 @@ object ByteArrayBase64UrlSerializer: TransformingSerializerTemplate<ByteArray, S
     decodeAs = { it.decodeToByteArray(Base64UrlStrict) }
 )
 
-/** De-/serializes UTF-8 strings to/from [ByteArray] without additional encoding. */
-object ByteArrayUtf8Serializer: TransformingSerializerTemplate<ByteArray, String>(
-    parent = String.serializer(),
-    encodeAs = ByteArray::decodeToString,
-    decodeAs = String::encodeToByteArray,
-)
-
 /** De-/serializes X509Certificate as Base64Url-encoded String */
 object X509CertificateBase64UrlSerializer: TransformingSerializerTemplate<X509Certificate, ByteArray>(
     parent = ByteArrayBase64UrlSerializer,

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/io/Encoding.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/io/Encoding.kt
@@ -78,6 +78,13 @@ object ByteArrayBase64UrlSerializer: TransformingSerializerTemplate<ByteArray, S
     decodeAs = { it.decodeToByteArray(Base64UrlStrict) }
 )
 
+/** De-/serializes UTF-8 strings to/from [ByteArray] without additional encoding. */
+object ByteArrayUtf8Serializer: TransformingSerializerTemplate<ByteArray, String>(
+    parent = String.serializer(),
+    encodeAs = ByteArray::decodeToString,
+    decodeAs = String::encodeToByteArray,
+)
+
 /** De-/serializes X509Certificate as Base64Url-encoded String */
 object X509CertificateBase64UrlSerializer: TransformingSerializerTemplate<X509Certificate, ByteArray>(
     parent = ByteArrayBase64UrlSerializer,


### PR DESCRIPTION
Implements three new classes `JwsCompact`, `JwsFlattened` and `JwsGeneral` to implement RFC 7515 Section 3.1, 7.2.1 and 7.2.2 respectively.

Removed generic parameter as present in `JwsSigned` which will be deprecated. Payload can still be serialized into a specific structure at runtime. Serialization stability is now guaranteed by handling all signature related parameters as bytearrays and deserializing into transient properties only. 