### PR TITLE
Add typed JWS wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
     * Represent protected and unprotected header fragments explicitly via `JwsHeader.Part`, merging them into a `JwsHeader` only when the combined header is valid
     * Parse `JwsHeader.attestationJwt` and `JwsHeader.keyAttestation` as `JwsCompact` instead of raw strings
     * Deprecate `JwsSigned` in favor of `JwsCompact`
+    * Typed payloads remain supported via `JwsTyped`
 
 ## 3.19.3 / Supreme 0.11.3
 * Support CURSED X.509 Certificate extensions that encode critical=false instead of omitting it

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/Jws.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/Jws.kt
@@ -20,6 +20,8 @@ import kotlinx.serialization.json.JsonPrimitive
 
 /**
  * Wrapper for all JWS formats.
+ *
+ * If [plainPayload] data structure is defined as part of the contact consider [JwsTyped]
  */
 @Serializable(with = JWS.JwsSerializer::class)
 sealed class JWS {

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsCompact.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsCompact.kt
@@ -27,6 +27,8 @@ import kotlinx.serialization.encoding.Encoder
  * a JSON document.
  *
  * For a standalone compact JWS string, use [toString] and [JwsCompact.invoke].
+ *
+ * If [plainPayload] data structure is defined as part of the contact consider [JwsCompactTyped]
  */
 @ConsistentCopyVisibility
 data class JwsCompact internal constructor(

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsFlattened.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsFlattened.kt
@@ -18,6 +18,9 @@ import kotlinx.serialization.Transient
  *
  * [plainPayload] stores the plain payload bytes. JSON serialization base64url-encodes those bytes for the `payload`
  * member, so callers should not pre-encode them.
+ *
+ *
+ * If [plainPayload] data structure is defined as part of the contact consider [JwsFlattenedTyped]
  */
 @ConsistentCopyVisibility
 @Serializable

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsGeneral.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsGeneral.kt
@@ -9,7 +9,7 @@ import kotlinx.serialization.Transient
 /**
  * General JSON JWS.
  *
- * A general JWS carries one payload and one or more [signatureElements]. Each [SignatureElement] contains the header
+ * A general JWS carries one payload and one or more [SignatureElement]s. Each [SignatureElement] contains the header
  * fragments for one signature and exposes its merged effective [JwsHeader]. All signatures in a [JwsGeneral] share
  * the same payload.
  *

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsGeneral.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsGeneral.kt
@@ -15,6 +15,8 @@ import kotlinx.serialization.Transient
  *
  * [plainPayload] stores the plain payload bytes. JSON serialization base64url-encodes those bytes for the `payload`
  * member, so callers should not pre-encode them.
+ *
+ * If [plainPayload] data structure is defined as part of the contact consider [JwsGeneralTyped]
  */
 @ConsistentCopyVisibility
 @Serializable

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsHeader.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsHeader.kt
@@ -5,6 +5,7 @@ import at.asitplus.signum.indispensable.CryptoPublicKey
 import at.asitplus.signum.indispensable.io.ByteArrayBase64UrlSerializer
 import at.asitplus.signum.indispensable.io.CertificateChainBase64Serializer
 import at.asitplus.signum.indispensable.josef.JwsHeader.Companion.fromParts
+import at.asitplus.signum.indispensable.josef.JwsTyped.Companion.invoke
 import at.asitplus.signum.indispensable.josef.io.InstantLongSerializer
 import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
 import at.asitplus.signum.indispensable.pki.CertificateChain
@@ -410,16 +411,8 @@ data class JwsHeader(
             ?: certificateChain?.leaf?.decodedPublicKey?.getOrNull()
     }
 
-    @Deprecated("Use [keyAttestation] directly", replaceWith = ReplaceWith("keyAttestation"))
-    val keyAttestationParsed: JwsSigned<KeyAttestationJwt>? by lazy {
-        keyAttestation?.let {
-            JwsSigned.deserialize<KeyAttestationJwt>(
-                KeyAttestationJwt.serializer(),
-                it.toString(),
-                joseCompliantSerializer
-            )
-                .getOrNull()
-        }
+    val keyAttestationParsed: JwsCompactTyped<KeyAttestationJwt>? by lazy {
+        keyAttestation?.let { invoke(it) }
     }
 
     object SerialNames {

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsHeader.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsHeader.kt
@@ -412,7 +412,7 @@ data class JwsHeader(
     }
 
     val keyAttestationParsed: JwsCompactTyped<KeyAttestationJwt>? by lazy {
-        keyAttestation?.let { invoke(it) }
+        keyAttestation?.typed()
     }
 
     object SerialNames {

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsSigned.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsSigned.kt
@@ -20,7 +20,7 @@ import kotlinx.serialization.json.Json
  *
  * See [RFC 7515](https://datatracker.ietf.org/doc/html/rfc7515)
  */
-@Deprecated("Replaced by JwsCompact", level = DeprecationLevel.WARNING, replaceWith = ReplaceWith("JwsCompact"))
+@Deprecated("Replaced by JwsCompactTyped", level = DeprecationLevel.WARNING, replaceWith = ReplaceWith("JwsCompactTyped"))
 data class JwsSigned<out P : Any>(
     val header: JwsHeader,
     val payload: P,

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsTyped.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsTyped.kt
@@ -1,5 +1,6 @@
 package at.asitplus.signum.indispensable.josef
 
+import at.asitplus.signum.indispensable.josef.JwsTyped.Companion.invoke
 import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
 import kotlinx.serialization.serializer
 
@@ -10,6 +11,9 @@ typealias JwsGeneralTyped<P> = JwsTyped<JwsGeneral, P>
 fun <P> JwsCompactTyped<P>.toJwsFlattenedTyped() = JwsFlattenedTyped(this.jws.toJwsFlattened(), this.payload)
 fun <P> JwsFlattenedTyped<P>.toJwsCompactTyped() = JwsCompactTyped(this.jws.toJwsCompact(), this.payload)
 fun <P> JwsGeneralTyped<P>.toJwsFlattenedTyped() = this.jws.toJwsFlattened().map { JwsFlattenedTyped(it, this.payload) }
+
+inline fun <reified P, J : JWS> J.typed(): JwsTyped<J, P> =
+    JwsTyped(this, getPayload<P>().getOrThrow())
 
 /**
  * Wrapper for [at.asitplus.signum.indispensable.josef.JWS]. Useful when [payload] type is known as part of the contract.
@@ -23,16 +27,12 @@ data class JwsTyped<out J : JWS, out P>(
 ) {
     override fun toString() = jws.toString()
 
-
     companion object {
-        inline operator fun <reified P, J : JWS> invoke(jws: J) =
-            JwsTyped(jws, jws.getPayload<P>().getOrThrow())
-
         inline operator fun <reified P> invoke(base64UrlString: String) =
             JwsCompact.parse<P>(base64UrlString).getOrThrow().let { (jws, payload) -> JwsTyped(jws, payload) }
 
         inline operator fun <reified P> invoke(jwsFlattened: List<JwsFlattened>): JwsTyped<JwsGeneral, P> =
-            JwsTyped(jwsFlattened.toJwsGeneral())
+            jwsFlattened.toJwsGeneral().typed()
 
         /**
          * Creates [JwsCompact]. [protectedHeader] must form a valid [JwsHeader].

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsTyped.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsTyped.kt
@@ -1,0 +1,71 @@
+package at.asitplus.signum.indispensable.josef
+
+import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
+import kotlinx.serialization.serializer
+
+typealias JwsCompactTyped<P> = JwsTyped<JwsCompact, P>
+typealias JwsFlattenedTyped<P> = JwsTyped<JwsFlattened, P>
+typealias JwsGeneralTyped<P> = JwsTyped<JwsGeneral, P>
+
+fun <P> JwsCompactTyped<P>.toJwsFlattenedTyped() = JwsFlattenedTyped(this.jws.toJwsFlattened(), this.payload)
+fun <P> JwsFlattenedTyped<P>.toJwsCompactTyped() = JwsCompactTyped(this.jws.toJwsCompact(), this.payload)
+fun <P> JwsGeneralTyped<P>.toJwsFlattenedTyped() = this.jws.toJwsFlattened().map { JwsFlattenedTyped(it, this.payload) }
+
+/**
+ * Wrapper for [at.asitplus.signum.indispensable.josef.JWS]. Useful when [payload] type is known as part of the contract.
+ * All communication over the wire should use [jws] only!
+ *
+ * While the constructor can be used the different [invoke]s are recommended.
+ * For convenience also see the typealiases
+ */
+data class JwsTyped<out J : JWS, out P>(
+    val jws: J, val payload: P
+) {
+    override fun toString() = jws.toString()
+
+
+    companion object {
+        inline operator fun <reified P, J : JWS> invoke(jws: J) =
+            JwsTyped(jws, jws.getPayload<P>().getOrThrow())
+
+        inline operator fun <reified P> invoke(base64UrlString: String) =
+            JwsCompact.parse<P>(base64UrlString).getOrThrow().let { (jws, payload) -> JwsTyped(jws, payload) }
+
+        inline operator fun <reified P> invoke(jwsFlattened: List<JwsFlattened>): JwsTyped<JwsGeneral, P> =
+            JwsTyped(jwsFlattened.toJwsGeneral())
+
+        /**
+         * Creates [JwsCompact]. [protectedHeader] must form a valid [JwsHeader].
+         */
+        suspend inline operator fun <reified P> invoke(
+            protectedHeader: JwsHeader, payload: P, noinline signer: suspend (ByteArray) -> ByteArray
+        ): JwsCompactTyped<P> {
+            val plainPayload = joseCompliantSerializer.encodeToString(
+                joseCompliantSerializer.serializersModule.serializer(), payload
+            ).encodeToByteArray()
+            return JwsCompactTyped(
+                JwsCompact.invoke(protectedHeader = protectedHeader, payload = plainPayload, signer = signer), payload
+            )
+        }
+
+        /**
+         * Creates a flattened JWS from protected and unprotected header fragments.
+         * The fragments may be partial, but their merged content must form a valid [JwsHeader].
+         */
+        suspend inline operator fun <reified P> invoke(
+            protectedHeader: JwsHeader.Part?,
+            unprotectedHeader: JwsHeader.Part?,
+            payload: P,
+            noinline signer: suspend (ByteArray) -> ByteArray
+        ): JwsFlattenedTyped<P> {
+            val plainPayload = joseCompliantSerializer.encodeToString(
+                joseCompliantSerializer.serializersModule.serializer(), payload
+            ).encodeToByteArray()
+            return JwsFlattenedTyped(
+                JwsFlattened(
+                    protectedHeader, unprotectedHeader, plainPayload, signer = signer
+                ), payload
+            )
+        }
+    }
+}

--- a/indispensable-josef/src/commonTest/kotlin/at/asitplus/signum/indispensable/josef/JwsTypedTest.kt
+++ b/indispensable-josef/src/commonTest/kotlin/at/asitplus/signum/indispensable/josef/JwsTypedTest.kt
@@ -1,0 +1,127 @@
+package at.asitplus.signum.indispensable.josef
+
+import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
+import at.asitplus.testballoon.invoke
+import de.infix.testBalloon.framework.core.testSuite
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+
+val payload = JsonObject(
+    content = mapOf(
+        "issuer" to JsonPrimitive("https://issuer.example"),
+        "subject" to JsonPrimitive("alice"),
+        "admin" to JsonPrimitive(true),
+    )
+)
+
+val JwsTypedTest by testSuite {
+    "compact typed wrappers can be built from payloads and reopened from compact JWS" {
+        val header = JwsHeader(
+            algorithm = JwsAlgorithm.Signature.RS256,
+            type = "application/example+jws",
+            keyId = "kid-compact",
+        )
+        val expectedPayload = joseCompliantSerializer.encodeToString<JsonObject>(payload).encodeToByteArray()
+        val expectedProtectedHeader = JwsProtectedHeaderSerializer.encodeToByteArray(header.toPart())
+        var capturedSignatureInput: ByteArray? = null
+
+        val typedCompact: JwsCompactTyped<JsonObject> = JwsTyped(
+            protectedHeader = header,
+            payload = payload,
+        ) { signatureInput ->
+            capturedSignatureInput = signatureInput
+            byteArrayOf(1, 2, 3, 4)
+        }
+
+        typedCompact.payload shouldBe payload
+        typedCompact.jws.plainPayload shouldBe expectedPayload
+        capturedSignatureInput shouldBe JWS.getSignatureInput(expectedProtectedHeader, expectedPayload)
+        typedCompact.toString() shouldBe typedCompact.jws.toString()
+
+        JwsTyped<JsonObject, JwsCompact>(typedCompact.jws) shouldBe typedCompact
+        JwsTyped<JsonObject>(typedCompact.toString()) shouldBe typedCompact
+    }
+
+    "compact and flattened typed wrappers convert without changing the payload view" {
+        val typedCompact: JwsCompactTyped<JsonObject> = JwsTyped(
+            protectedHeader = JwsHeader(
+                algorithm = JwsAlgorithm.Signature.RS256,
+                keyId = "kid-roundtrip",
+            ),
+            payload = payload,
+        ) {
+            byteArrayOf(9, 8, 7, 6)
+        }
+
+        val typedFlattened = typedCompact.toJwsFlattenedTyped()
+        val reparsedCompact = typedFlattened.toJwsCompactTyped()
+
+        typedFlattened.payload shouldBe payload
+        typedFlattened.jws shouldBe typedCompact.jws.toJwsFlattened()
+        reparsedCompact shouldBe typedCompact
+    }
+
+    "flattened typed wrappers can be created from header fragments and existing flattened JWS" {
+        val protectedHeader = JwsHeader.Part(
+            algorithm = JwsAlgorithm.Signature.RS256,
+            type = "application/example+jws",
+        )
+        val unprotectedHeader = JwsHeader.Part(
+            keyId = "kid-flattened",
+            contentType = "application/example+json",
+        )
+        val expectedPayload = joseCompliantSerializer.encodeToString<JsonObject>(payload).encodeToByteArray()
+        val expectedProtectedHeader = JwsProtectedHeaderSerializer.encodeToByteArrayOrNull(protectedHeader)
+        var capturedSignatureInput: ByteArray? = null
+
+        val typedFlattened: JwsFlattenedTyped<JsonObject> = JwsTyped(
+            protectedHeader = protectedHeader,
+            unprotectedHeader = unprotectedHeader,
+            payload = payload,
+        ) { signatureInput ->
+            capturedSignatureInput = signatureInput
+            byteArrayOf(4, 3, 2, 1)
+        }
+
+        typedFlattened.payload shouldBe payload
+        typedFlattened.jws.plainPayload shouldBe expectedPayload
+        typedFlattened.jws.unprotectedHeader shouldBe unprotectedHeader
+        capturedSignatureInput shouldBe JWS.getSignatureInput(expectedProtectedHeader, expectedPayload)
+        typedFlattened.toString() shouldBe typedFlattened.jws.toString()
+
+        JwsTyped<JsonObject, JwsFlattened>(typedFlattened.jws) shouldBe typedFlattened
+    }
+
+    "general typed wrappers can be assembled from flattened signatures and expanded again" {
+        val first: JwsFlattenedTyped<JsonObject> = JwsTyped(
+            protectedHeader = JwsHeader.Part(
+                algorithm = JwsAlgorithm.Signature.RS256,
+                type = "application/example+jws",
+            ),
+            unprotectedHeader = JwsHeader.Part(keyId = "kid-1"),
+            payload = payload,
+        ) {
+            byteArrayOf(1, 1, 1, 1)
+        }
+        val second: JwsFlattenedTyped<JsonObject> = JwsTyped(
+            protectedHeader = JwsHeader.Part(
+                algorithm = JwsAlgorithm.Signature.RS256,
+                type = "application/example+jws",
+            ),
+            unprotectedHeader = JwsHeader.Part(keyId = "kid-2"),
+            payload = payload,
+        ) {
+            byteArrayOf(2, 2, 2, 2)
+        }
+
+        val typedGeneral: JwsGeneralTyped<JsonObject> = JwsTyped(listOf(first.jws, second.jws))
+
+        typedGeneral.payload shouldBe payload
+        typedGeneral.jws shouldBe listOf(first.jws, second.jws).toJwsGeneral()
+        typedGeneral.toString() shouldBe typedGeneral.jws.toString()
+        typedGeneral.toJwsFlattenedTyped() shouldBe listOf(first, second)
+
+        JwsTyped<JsonObject, JwsGeneral>(typedGeneral.jws) shouldBe typedGeneral
+    }
+}

--- a/indispensable-josef/src/commonTest/kotlin/at/asitplus/signum/indispensable/josef/JwsTypedTest.kt
+++ b/indispensable-josef/src/commonTest/kotlin/at/asitplus/signum/indispensable/josef/JwsTypedTest.kt
@@ -1,6 +1,7 @@
 package at.asitplus.signum.indispensable.josef
 
 import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
+import at.asitplus.signum.indispensable.josef.typed
 import at.asitplus.testballoon.invoke
 import de.infix.testBalloon.framework.core.testSuite
 import io.kotest.matchers.shouldBe
@@ -39,7 +40,7 @@ val JwsTypedTest by testSuite {
         capturedSignatureInput shouldBe JWS.getSignatureInput(expectedProtectedHeader, expectedPayload)
         typedCompact.toString() shouldBe typedCompact.jws.toString()
 
-        JwsTyped<JsonObject, JwsCompact>(typedCompact.jws) shouldBe typedCompact
+        typedCompact.jws.typed<JsonObject, JwsCompact>() shouldBe typedCompact
         JwsTyped<JsonObject>(typedCompact.toString()) shouldBe typedCompact
     }
 
@@ -90,7 +91,7 @@ val JwsTypedTest by testSuite {
         capturedSignatureInput shouldBe JWS.getSignatureInput(expectedProtectedHeader, expectedPayload)
         typedFlattened.toString() shouldBe typedFlattened.jws.toString()
 
-        JwsTyped<JsonObject, JwsFlattened>(typedFlattened.jws) shouldBe typedFlattened
+        typedFlattened.jws.typed<JsonObject, JwsFlattened>() shouldBe typedFlattened
     }
 
     "general typed wrappers can be assembled from flattened signatures and expanded again" {
@@ -122,6 +123,6 @@ val JwsTypedTest by testSuite {
         typedGeneral.toString() shouldBe typedGeneral.jws.toString()
         typedGeneral.toJwsFlattenedTyped() shouldBe listOf(first, second)
 
-        JwsTyped<JsonObject, JwsGeneral>(typedGeneral.jws) shouldBe typedGeneral
+        typedGeneral.jws.typed<JsonObject, JwsGeneral>() shouldBe typedGeneral
     }
 }


### PR DESCRIPTION
Adds thin wrapper when payload of JWS is known as part of the contract.
Delegates all logic to underlying JWS classes
For use-case example see JwsHeader `keyAttestationParsed`