### PR TITLE
JWS: Add convenience protectedHeader parameter

### DIFF
--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsFlattened.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsFlattened.kt
@@ -43,9 +43,6 @@ data class JwsFlattened internal constructor(
     }
 
     @Transient
-    val protectedHeader: JwsHeader.Part? = plainProtectedHeader?.let(JwsProtectedHeaderSerializer::decodeFromByteArray)
-
-    @Transient
     val jwsHeader = JwsHeader.fromParts(protectedHeader, unprotectedHeader)
 
     @Transient
@@ -100,6 +97,9 @@ data class JwsFlattened internal constructor(
         }
     }
 }
+
+val JwsFlattened.protectedHeader: JwsHeader.Part?
+        get() = plainProtectedHeader?.let(JwsProtectedHeaderSerializer::decodeFromByteArray)
 
 /**
  * Converts flattened JSON serialization to compact serialization.

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsFlattened.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsFlattened.kt
@@ -43,7 +43,10 @@ data class JwsFlattened internal constructor(
     }
 
     @Transient
-    val jwsHeader = JwsHeader.fromParts(plainProtectedHeader, unprotectedHeader)
+    val protectedHeader: JwsHeader.Part? = plainProtectedHeader?.let(JwsProtectedHeaderSerializer::decodeFromByteArray)
+
+    @Transient
+    val jwsHeader = JwsHeader.fromParts(protectedHeader, unprotectedHeader)
 
     @Transient
     val signature = getSignature(jwsHeader.algorithm, plainSignature)
@@ -107,7 +110,7 @@ data class JwsFlattened internal constructor(
 fun JwsFlattened.toJwsCompact(): JwsCompact {
     require(unprotectedHeader == null) { "Compact Serialization does not support unprotected header" }
     requireNotNull(plainProtectedHeader)
-    runCatching { JwsHeader.fromParts(plainProtectedHeader) }.getOrElse { throw IllegalArgumentException("Compact JWS requires protected header to be a valid JwsHeader") }
+    runCatching { JwsHeader.fromParts(protectedHeader) }.getOrElse { throw IllegalArgumentException("Compact JWS requires protected header to be a valid JwsHeader") }
     return JwsCompact(
         plainProtectedHeader = plainProtectedHeader,
         plainPayload = plainPayload,

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsGeneral.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsGeneral.kt
@@ -34,8 +34,6 @@ data class JwsGeneral internal constructor(
     }
 
     @Transient
-    val protectedHeaders: List<JwsHeader.Part?> = signatureElements.map { it.protectedHeader }
-    @Transient
     val jwsHeaders: List<JwsHeader> = signatureElements.map { it.jwsHeader }
 
     @Transient
@@ -83,6 +81,9 @@ data class JwsGeneral internal constructor(
         operator fun invoke(jwsFlattened: List<JwsFlattened>): JwsGeneral = jwsFlattened.toJwsGeneral()
     }
 }
+
+val JwsGeneral.protectedHeaders: List<JwsHeader.Part?>
+    get() = signatureElements.map { it.protectedHeader }
 
 /**
  * Expands general JSON JWS representation into one flattened JWS per signature.

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsGeneral.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsGeneral.kt
@@ -34,6 +34,8 @@ data class JwsGeneral internal constructor(
     }
 
     @Transient
+    val protectedHeaders: List<JwsHeader.Part?> = signatureElements.map { it.protectedHeader }
+    @Transient
     val jwsHeaders: List<JwsHeader> = signatureElements.map { it.jwsHeader }
 
     @Transient

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsHeader.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsHeader.kt
@@ -6,8 +6,6 @@ import at.asitplus.signum.indispensable.io.ByteArrayBase64UrlSerializer
 import at.asitplus.signum.indispensable.io.CertificateChainBase64Serializer
 import at.asitplus.signum.indispensable.io.InstantLongSerializer
 import at.asitplus.signum.indispensable.josef.JwsHeader.Companion.fromParts
-import at.asitplus.signum.indispensable.josef.io.JwsCertificateSerializer
-import at.asitplus.signum.indispensable.josef.JwsTyped.Companion.invoke
 import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
 import at.asitplus.signum.indispensable.pki.CertificateChain
 import at.asitplus.signum.indispensable.pki.leaf

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/SignatureElement.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/SignatureElement.kt
@@ -47,9 +47,6 @@ data class SignatureElement internal constructor(
     init {
         JwsProtectedHeaderSerializer.requireAbsentIfEmpty(plainProtectedHeader)
     }
-
-    @Transient
-    val protectedHeader: JwsHeader.Part? = plainProtectedHeader?.let(JwsProtectedHeaderSerializer::decodeFromByteArray)
     @Transient
     val jwsHeader: JwsHeader = JwsHeader.fromParts(protectedHeader, unprotectedHeader)
     @Transient
@@ -74,3 +71,6 @@ data class SignatureElement internal constructor(
         return result
     }
 }
+
+val SignatureElement.protectedHeader: JwsHeader.Part?
+    get() = plainProtectedHeader?.let(JwsProtectedHeaderSerializer::decodeFromByteArray)

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/SignatureElement.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/SignatureElement.kt
@@ -49,7 +49,9 @@ data class SignatureElement internal constructor(
     }
 
     @Transient
-    val jwsHeader: JwsHeader = JwsHeader.fromParts(plainProtectedHeader, unprotectedHeader)
+    val protectedHeader: JwsHeader.Part? = plainProtectedHeader?.let(JwsProtectedHeaderSerializer::decodeFromByteArray)
+    @Transient
+    val jwsHeader: JwsHeader = JwsHeader.fromParts(protectedHeader, unprotectedHeader)
     @Transient
     val signature = getSignature(jwsHeader.algorithm, plainSignature)
 


### PR DESCRIPTION
Useful since many standards require specific parameters to be part of the protected header specifically. Uniqueness of parameter already enforced via `.strictUnion` in eager `jwsHeader` parsing.

Cannot be parameter of `JWS` itself since `JwsGeneral` defines list of headers
