### PR TITLE
Feature/unknown keys wrapper

### DIFF
--- a/.github/config/test-strategy-matrix.json
+++ b/.github/config/test-strategy-matrix.json
@@ -22,6 +22,11 @@
       "testCommand": "./gradlew jsTest --scan"
     },
     {
+      "os": "ubuntu-latest",
+      "name": "wasmJsRunner",
+      "testCommand": "./gradlew wasmJsTest --scan"
+    },
+    {
       "os": "windows-latest",
       "name": "mingwRunner",
       "testCommand": "./gradlew mingwX64Test --scan"
@@ -34,12 +39,12 @@
     {
       "os": "macos-latest",
       "name": "appleOtherRunner",
-      "testCommand": "./gradlew iosArm64MainKlibrary iosSimulatorArm64MainKlibrary tvosSimulatorArm64Test watchosSimulatorArm64Test macosArm64Test --scan"
+      "testCommand": "./gradlew iosArm64MainKlibrary iosSimulatorArm64MainKlibrary tvosSimulatorArm64Test watchosSimulatorArm64Test --scan"
     },
     {
       "os": "macos-latest",
       "name": "macRunner",
-      "testCommand": "./gradlew allTests -x jvmTest -x jsTest --scan"
+      "testCommand": "./gradlew macosArm64Test --scan"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
 ## NEXT
+* Rework JWS support around explicit compact, flattened, and general representations
+    * Add sealed `JWS` support with dedicated `JwsCompact`, `JwsFlattened`, `JwsGeneral`
+    * Add conversions between compact, flattened, and general JWS representations
+    * Represent protected and unprotected header fragments explicitly via `JwsHeader.Part`, merging them into a `JwsHeader` only when the combined header is valid
+    * Parse `JwsHeader.attestationJwt` and `JwsHeader.keyAttestation` as `JwsCompact` instead of raw strings
+    * Deprecate `JwsSigned` in favor of `JwsCompact`
+    * Typed payloads remain supported via `JwsTyped`
 
 ## 3.21.0 / Supreme 0.13.0
 * Drop Apple X64 targets

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## NEXT
+
 ## 3.21.0 / Supreme 0.13.0
 * Drop Apple X64 targets
 * Move `InstantLongSerializer` from indispensable-josef/indispensable-cosef to indispensable

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,8 +3,8 @@ org.gradle.jvmargs=-Xmx10g -Dfile.encoding=UTF-8 -Xms200m
 kotlin.daemon.jvm.options=-Xmx10G -Xms200m
 kotlin.daemon.jvmargs=-Didea.max.content.load.filesize=50000000 -Didea.max.intellisense.filesize=50000000 -Xmx10g -Xms200m
 
-indispensableVersion=3.21.0
-supremeVersion=0.13.0
+indispensableVersion=3.22-SNAPSHOT
+supremeVersion=0.14-SNAPSHOT
 
 # This is not a well-defined property, the ASP convention plugin respects it, though
 jdk.version=17

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/Jws.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/Jws.kt
@@ -1,0 +1,154 @@
+package at.asitplus.signum.indispensable.josef
+
+import at.asitplus.KmmResult
+import at.asitplus.KmmResult.Companion.wrap
+import at.asitplus.signum.indispensable.CryptoSignature
+import at.asitplus.signum.indispensable.io.Base64UrlStrict
+import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
+import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
+import kotlinx.serialization.*
+import kotlinx.serialization.descriptors.PolymorphicKind
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.descriptors.buildSerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.JsonDecoder
+import kotlinx.serialization.json.JsonEncoder
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+
+
+/**
+ * Wrapper for all JWS formats.
+ *
+ * If [plainPayload] data structure is defined as part of the contact consider [JwsTyped]
+ */
+@Serializable(with = JWS.JwsSerializer::class)
+sealed class JWS {
+    /**
+     * Raw payload bytes.
+     *
+     * JWS serializers and signature-input construction base64url-encode these bytes where required.
+     * Callers should not pre-encode the payload.
+     */
+    abstract val plainPayload: ByteArray
+
+    fun <P> getPayload(serializer: KSerializer<P>, serialFormat: SerialFormat = joseCompliantSerializer): KmmResult<P> = runCatching {
+        when (serialFormat) {
+            is StringFormat -> serialFormat.decodeFromString(serializer, plainPayload.decodeToString())
+            is BinaryFormat -> serialFormat.decodeFromByteArray(serializer, plainPayload)
+            else -> throw NotImplementedError("Unknown serial format $serialFormat")
+        }
+    }.wrap()
+
+    /**
+     * Find correct serializer at compile time
+     */
+    @Suppress("unused")
+    inline fun <reified P> getPayload(serialFormat: SerialFormat = joseCompliantSerializer): KmmResult<P> =
+        getPayload(serialFormat.serializersModule.serializer(), serialFormat)
+
+    object SerialNames {
+        const val PROTECTED = "protected"
+        const val HEADER = "header"
+        const val SIGNATURE = "signature"
+        const val SIGNATURES = "signatures"
+        const val PAYLOAD = "payload"
+
+        /* Shapes */
+        const val COMPACT = "compact"
+        const val FLATTENED = "flattened"
+        const val GENERAL = "general"
+
+    }
+
+    companion object {
+        fun getSignature(algorithm: JwsAlgorithm, plainSignature: ByteArray): CryptoSignature.RawByteEncodable =
+            when (algorithm) {
+                is JwsAlgorithm.Signature.EC -> CryptoSignature.EC.fromRawBytes(algorithm.ecCurve, plainSignature)
+                is JwsAlgorithm.Signature.RSA -> CryptoSignature.RSA(plainSignature)
+                else -> throw SerializationException("Unsupported algorithm for JWS signature element: $algorithm")
+            }
+
+        fun getEncodedProtectedHeader(protectedHeader: ByteArray?): String =
+            protectedHeader?.encodeToString(Base64UrlStrict).orEmpty()
+
+        /**
+         * Builds the RFC 7515 signing input from raw protected-header bytes and raw payload bytes.
+         *
+         * [payload] must be plain payload bytes; this helper base64url-encodes it internally.
+         */
+        fun getSignatureInput(protectedHeader: ByteArray?, payload: ByteArray) =
+            "${getEncodedProtectedHeader(protectedHeader)}.${payload.encodeToString(Base64UrlStrict)}".encodeToByteArray()
+    }
+
+    object JwsSerializer: KSerializer<JWS> {
+        @OptIn(InternalSerializationApi::class)
+        override val descriptor: SerialDescriptor = buildSerialDescriptor("JWS", PolymorphicKind.SEALED) {
+            element(SerialNames.COMPACT, JwsCompactStringSerializer.descriptor)
+            element(SerialNames.FLATTENED, JwsFlattened.serializer().descriptor)
+            element(SerialNames.GENERAL, JwsGeneral.serializer().descriptor)
+        }
+
+        override fun serialize(
+            encoder: Encoder,
+            value: JWS
+        ) {
+            require(encoder is JsonEncoder) { "JWS serialization requires a JsonDecoder" }
+            when (value) {
+                is JwsCompact -> encoder.encodeSerializableValue(JwsCompactStringSerializer, value)
+                is JwsFlattened -> encoder.encodeSerializableValue(JwsFlattened.serializer(), value)
+                is JwsGeneral -> encoder.encodeSerializableValue(JwsGeneral.serializer(), value)
+            }
+        }
+
+        override fun deserialize(decoder: Decoder): JWS {
+            require(decoder is JsonDecoder) { "JWS deserialization requires a JsonDecoder" }
+            val jsonElement = decoder.decodeJsonElement()
+
+            return when (jsonElement) {
+                is JsonPrimitive -> decoder.json.decodeFromJsonElement(JwsCompactStringSerializer, jsonElement)
+                is JsonObject -> {
+                    val hasGeneralSignatures = SerialNames.SIGNATURES in jsonElement
+                    val hasFlattenedSignature = SerialNames.SIGNATURE in jsonElement
+
+                    when {
+                        hasGeneralSignatures && hasFlattenedSignature ->
+                            throw SerializationException(
+                                "Invalid JWS JSON serialization: object must not contain both " +
+                                    "'${SerialNames.SIGNATURE}' and '${SerialNames.SIGNATURES}'"
+                            )
+
+                        hasGeneralSignatures ->
+                            decoder.json.decodeFromJsonElement(JwsGeneral.serializer(), jsonElement)
+
+                        hasFlattenedSignature ->
+                            decoder.json.decodeFromJsonElement(JwsFlattened.serializer(), jsonElement)
+
+                        else ->
+                            throw SerializationException(
+                                "Invalid JWS JSON serialization: object must contain " +
+                                    "'${SerialNames.SIGNATURE}' or '${SerialNames.SIGNATURES}'"
+                            )
+                    }
+                }
+
+                else -> throw SerializationException(
+                    "Invalid JWS JSON serialization: expected a compact string or JSON object"
+                )
+            }
+        }
+    }
+}
+
+internal fun JsonObject?.strictUnion(other: JsonObject?): JsonObject {
+    if (this == null) return other ?: JsonObject(emptyMap())
+    if (other == null) return this
+
+    val duplicates = this.keys intersect other.keys
+    require(duplicates.isEmpty()) {
+        "Duplicate keys: ${duplicates.joinToString()}"
+    }
+
+    return JsonObject(this + other)
+}

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsCompact.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsCompact.kt
@@ -1,0 +1,155 @@
+package at.asitplus.signum.indispensable.josef
+
+import at.asitplus.KmmResult
+import at.asitplus.catching
+import at.asitplus.signum.indispensable.io.Base64UrlStrict
+import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArray
+import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.Transient
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+
+/**
+ * Implements compact serialization as defined in [RFC 7515](https://datatracker.ietf.org/doc/html/rfc7515)
+ *
+ * Serialized output is of the form
+ * BASE64URL(UTF8(HEADER)).BASE64URL(PAYLOAD).BASE64URL(SIGNATURE)
+ *
+ * This class does not support an unprotected header field!
+ *
+ * [JwsCompact] is intentionally *not* annotated with `@Serializable`: its JSON representation is only the compact
+ * JWS string, not a JSON object. Use [JwsCompactStringSerializer] explicitly when you want that string form inside
+ * a JSON document.
+ *
+ * For a standalone compact JWS string, use [toString] and [JwsCompact.invoke].
+ *
+ * If [plainPayload] data structure is defined as part of the contact consider [JwsCompactTyped]
+ */
+@ConsistentCopyVisibility
+data class JwsCompact internal constructor(
+    val plainProtectedHeader: ByteArray,
+    override val plainPayload: ByteArray,
+    val plainSignature: ByteArray,
+) : JWS() {
+
+    @Transient
+    val jwsHeader = JwsHeader.fromParts(plainProtectedHeader, null)
+
+    @Transient
+    val signature = getSignature(jwsHeader.algorithm, plainSignature)
+
+    @Transient
+    val signatureInput = getSignatureInput(plainProtectedHeader, plainPayload)
+
+    override fun toString() = "${signatureInput.decodeToString()}.${plainSignature.encodeToString(Base64UrlStrict)}"
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as JwsCompact
+
+        if (!plainProtectedHeader.contentEquals(other.plainProtectedHeader)) return false
+        if (!plainPayload.contentEquals(other.plainPayload)) return false
+        if (!plainSignature.contentEquals(other.plainSignature)) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = plainProtectedHeader.contentHashCode()
+        result = 31 * result + plainPayload.contentHashCode()
+        result = 31 * result + plainSignature.contentHashCode()
+        return result
+    }
+
+    companion object {
+
+        /**
+         * Build a [at.asitplus.signum.indispensable.josef.JwsCompact] received as string
+         * and immediately resolve the payload
+         */
+        inline fun <reified P> parse(base64UrlString: String): KmmResult<Pair<JwsCompact, P>> = catching{
+            val jws = JwsCompact(base64UrlString)
+            val payload = jws.getPayload<P>().getOrThrow()
+            jws to payload
+        }
+
+        /**
+         * Build a [at.asitplus.signum.indispensable.josef.JwsCompact] received as string
+         */
+        operator fun invoke(
+            base64UrlString: String,
+        ): JwsCompact {
+            require(!base64UrlString.contains("=")) { "Trailing = are not supported. See RFC 7515" }
+            val parts = base64UrlString.split('.')
+
+            if (parts.size != 3) {
+                throw SerializationException(
+                    "Invalid JWS compact serialization: expected 3 parts, got ${parts.size}"
+                )
+            }
+
+            return try {
+                JwsCompact(
+                    plainProtectedHeader = parts[0].decodeToByteArray(Base64UrlStrict),
+                    plainPayload = parts[1].decodeToByteArray(Base64UrlStrict),
+                    plainSignature = parts[2].decodeToByteArray(Base64UrlStrict),
+                )
+            } catch (e: Exception) {
+                throw SerializationException("Invalid base64url content in JWS compact serialization", e)
+            }
+        }
+
+        /**
+         * Build a new [at.asitplus.signum.indispensable.josef.JwsCompact]
+         * from components and immediately sign the correct representation.
+         *
+         * [payload] must be the plain payload bytes. Do not base64url-encode it before calling this overload;
+         * compact serialization and signing input construction apply base64url encoding internally.
+         */
+        suspend operator fun invoke(
+            protectedHeader: JwsHeader,
+            payload: ByteArray,
+            signer: suspend (ByteArray) -> ByteArray
+        ): JwsCompact {
+            val plainProtectedHeader = JwsProtectedHeaderSerializer.encodeToByteArray(protectedHeader.toPart())
+            return JwsCompact(
+                plainProtectedHeader = plainProtectedHeader,
+                plainPayload = payload,
+                plainSignature = signer(getSignatureInput(plainProtectedHeader, payload)),
+            )
+        }
+    }
+}
+
+/**
+ * Serializes a [JwsCompact] as its compact JWS string form inside JSON.
+ *
+ * This serializer must be opted into explicitly to avoid accidentally treating [JwsCompact] as a JSON object.
+ */
+object JwsCompactStringSerializer : KSerializer<JwsCompact> {
+    override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("JwsCompact", PrimitiveKind.STRING)
+
+    override fun serialize(encoder: Encoder, value: JwsCompact) = encoder.encodeString(value.toString())
+
+    override fun deserialize(decoder: Decoder): JwsCompact = JwsCompact(decoder.decodeString())
+}
+
+/**
+ * Converts compact serialization to the equivalent flattened JSON form.
+ *
+ * The protected header bytes are preserved and the unprotected header is absent, because compact serialization does
+ * not support unprotected header parameters.
+ */
+fun JwsCompact.toJwsFlattened(): JwsFlattened = JwsFlattened(
+    plainProtectedHeader = plainProtectedHeader,
+    unprotectedHeader = null,
+    plainPayload = plainPayload,
+    plainSignature = plainSignature,
+)

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsFlattened.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsFlattened.kt
@@ -1,0 +1,138 @@
+package at.asitplus.signum.indispensable.josef
+
+import at.asitplus.signum.indispensable.contentEqualsIfArray
+import at.asitplus.signum.indispensable.io.ByteArrayBase64UrlNoPaddingSerializer
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.Transient
+
+/**
+ * Flattened JSON JWS serialization.
+ *
+ * A flattened JWS carries one payload and one signature. The protected header is stored as encoded bytes in
+ * [plainProtectedHeader]; the optional unprotected header is represented as [JwsHeader.Part]. The effective
+ * [jwsHeader] is reconstructed by merging both fragments with [JwsHeader.fromParts].
+ *
+ * Either header fragment may be partial. Only the combination of protected and unprotected parameters must
+ * constitute a valid [JwsHeader].
+ *
+ * [plainPayload] stores the plain payload bytes. JSON serialization base64url-encodes those bytes for the `payload`
+ * member, so callers should not pre-encode them.
+ *
+ *
+ * If [plainPayload] data structure is defined as part of the contact consider [JwsFlattenedTyped]
+ */
+@ConsistentCopyVisibility
+@Serializable
+data class JwsFlattened internal constructor(
+    @Serializable(ByteArrayBase64UrlNoPaddingSerializer::class)
+    @SerialName(SerialNames.PROTECTED)
+    val plainProtectedHeader: ByteArray? = null,
+    @SerialName(SerialNames.HEADER)
+    val unprotectedHeader: JwsHeader.Part? = null,
+    @Serializable(ByteArrayBase64UrlNoPaddingSerializer::class)
+    @SerialName(SerialNames.PAYLOAD)
+    override val plainPayload: ByteArray,
+    @Serializable(ByteArrayBase64UrlNoPaddingSerializer::class)
+    @SerialName(SerialNames.SIGNATURE)
+    val plainSignature: ByteArray
+) : JWS() {
+
+    init {
+        JwsProtectedHeaderSerializer.requireAbsentIfEmpty(plainProtectedHeader)
+    }
+
+    @Transient
+    val jwsHeader = JwsHeader.fromParts(plainProtectedHeader, unprotectedHeader)
+
+    @Transient
+    val signature = getSignature(jwsHeader.algorithm, plainSignature)
+
+    @Transient
+    val signatureInput = getSignatureInput(plainProtectedHeader, plainPayload)
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as JwsFlattened
+
+        if (!plainProtectedHeader.contentEquals(other.plainProtectedHeader)) return false
+        if (unprotectedHeader != other.unprotectedHeader) return false
+        if (!plainPayload.contentEquals(other.plainPayload)) return false
+        if (!plainSignature.contentEquals(other.plainSignature)) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = plainProtectedHeader?.contentHashCode() ?: 0
+        result = 31 * result + (unprotectedHeader?.hashCode() ?: 0)
+        result = 31 * result + plainPayload.contentHashCode()
+        result = 31 * result + plainSignature.contentHashCode()
+        return result
+    }
+
+    companion object {
+        /**
+         * Creates a flattened JWS from protected and unprotected header fragments.
+         *
+         * The fragments may be partial, but their merged content must form a valid [JwsHeader].
+         * [payload] must be the plain payload bytes. Do not base64url-encode it before calling this overload;
+         * flattened JSON serialization and signing input construction apply base64url encoding internally.
+         */
+        suspend operator fun invoke(
+            protectedHeader: JwsHeader.Part?,
+            unprotectedHeader: JwsHeader.Part?,
+            payload: ByteArray,
+            signer: suspend (ByteArray) -> ByteArray
+        ): JwsFlattened {
+            val plainProtectedHeader = JwsProtectedHeaderSerializer.encodeToByteArrayOrNull(protectedHeader)
+            return JwsFlattened(
+                plainProtectedHeader,
+                unprotectedHeader,
+                payload,
+                signer(getSignatureInput(plainProtectedHeader, payload))
+            )
+        }
+    }
+}
+
+/**
+ * Converts flattened JSON serialization to compact serialization.
+ *
+ * This requires the absence of an unprotected header, because compact JWS can only carry protected parameters.
+ * The protected fragment must therefore represent a valid [JwsHeader] by itself.
+ */
+fun JwsFlattened.toJwsCompact(): JwsCompact {
+    require(unprotectedHeader == null) { "Compact Serialization does not support unprotected header" }
+    requireNotNull(plainProtectedHeader)
+    runCatching { JwsHeader.fromParts(plainProtectedHeader) }.getOrElse { throw IllegalArgumentException("Compact JWS requires protected header to be a valid JwsHeader") }
+    return JwsCompact(
+        plainProtectedHeader = plainProtectedHeader,
+        plainPayload = plainPayload,
+        plainSignature = plainSignature,
+    )
+}
+
+/**
+ * Converts multiple flattened JWS values with the same payload into general JSON JWS representation.
+ */
+fun List<JwsFlattened>.toJwsGeneral(): JwsGeneral {
+    require(isNotEmpty()) { "General JWS requires at least one signature" }
+    val payload = this[0].plainPayload
+    val signatures = this.map {
+        require(payload.contentEqualsIfArray(it.plainPayload)) {
+            "Additional signed JWS payload must match existing payload"
+        }
+        SignatureElement(
+            plainSignature = it.plainSignature,
+            plainProtectedHeader = it.plainProtectedHeader,
+            unprotectedHeader = it.unprotectedHeader,
+        )
+    }
+    return JwsGeneral(
+        plainPayload = payload,
+        signatureElements = signatures
+    )
+}

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsGeneral.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsGeneral.kt
@@ -1,0 +1,96 @@
+package at.asitplus.signum.indispensable.josef
+
+import at.asitplus.signum.indispensable.contentEqualsIfArray
+import at.asitplus.signum.indispensable.io.ByteArrayBase64UrlNoPaddingSerializer
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.Transient
+
+/**
+ * General JSON JWS.
+ *
+ * A general JWS carries one payload and one or more [SignatureElement]s. Each [SignatureElement] contains the header
+ * fragments for one signature and exposes its merged effective [JwsHeader]. All signatures in a [JwsGeneral] share
+ * the same payload.
+ *
+ * [plainPayload] stores the plain payload bytes. JSON serialization base64url-encodes those bytes for the `payload`
+ * member, so callers should not pre-encode them.
+ *
+ * If [plainPayload] data structure is defined as part of the contact consider [JwsGeneralTyped]
+ */
+@ConsistentCopyVisibility
+@Serializable
+data class JwsGeneral internal constructor(
+    @Serializable(ByteArrayBase64UrlNoPaddingSerializer::class)
+    @SerialName(SerialNames.PAYLOAD)
+    override val plainPayload: ByteArray,
+    @Serializable
+    @SerialName(SerialNames.SIGNATURES)
+    val signatureElements: List<SignatureElement>
+) : JWS() {
+
+    init {
+        require(signatureElements.isNotEmpty()) { "At least one signature is required" }
+    }
+
+    @Transient
+    val jwsHeaders: List<JwsHeader> = signatureElements.map { it.jwsHeader }
+
+    @Transient
+    val signatures = signatureElements.map { it.signature }
+
+    @Transient
+    val signatureInputs = signatureElements.map { getSignatureInput(it.plainProtectedHeader, plainPayload) }
+
+    /**
+     * Returns a new [JwsGeneral] with one additional signature over the same payload.
+     */
+    fun appendSignature(jwsFlattened: JwsFlattened): JwsGeneral {
+        require(plainPayload.contentEqualsIfArray(jwsFlattened.plainPayload)) {
+            "Additional signed JWS payload must match existing payload"
+        }
+
+        return copy(
+            signatureElements = signatureElements + SignatureElement(
+                plainSignature = jwsFlattened.plainSignature,
+                unprotectedHeader = jwsFlattened.unprotectedHeader,
+                plainProtectedHeader = jwsFlattened.plainProtectedHeader,
+            )
+        )
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as JwsGeneral
+
+        if (!plainPayload.contentEquals(other.plainPayload)) return false
+        if (signatureElements != other.signatureElements) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = plainPayload.contentHashCode()
+        result = 31 * result + signatureElements.hashCode()
+        return result
+    }
+
+    companion object {
+        operator fun invoke(jwsFlattened: List<JwsFlattened>): JwsGeneral = jwsFlattened.toJwsGeneral()
+    }
+}
+
+/**
+ * Expands general JSON JWS representation into one flattened JWS per signature.
+ */
+fun JwsGeneral.toJwsFlattened(): List<JwsFlattened> =
+    signatureElements.map {
+        JwsFlattened(
+            plainProtectedHeader = it.plainProtectedHeader,
+            unprotectedHeader = it.unprotectedHeader,
+            plainPayload = this.plainPayload,
+            plainSignature = it.plainSignature
+        )
+    }

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsHeader.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsHeader.kt
@@ -1,26 +1,35 @@
-@file:UseSerializers(ByteArrayBase64Serializer::class, JwsCertificateSerializer::class)
-
 package at.asitplus.signum.indispensable.josef
 
 import at.asitplus.catching
 import at.asitplus.signum.indispensable.CryptoPublicKey
-import at.asitplus.signum.indispensable.io.ByteArrayBase64Serializer
 import at.asitplus.signum.indispensable.io.ByteArrayBase64UrlSerializer
 import at.asitplus.signum.indispensable.io.CertificateChainBase64Serializer
 import at.asitplus.signum.indispensable.io.InstantLongSerializer
+import at.asitplus.signum.indispensable.josef.JwsHeader.Companion.fromParts
 import at.asitplus.signum.indispensable.josef.io.JwsCertificateSerializer
+import at.asitplus.signum.indispensable.josef.JwsTyped.Companion.invoke
 import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
 import at.asitplus.signum.indispensable.pki.CertificateChain
 import at.asitplus.signum.indispensable.pki.leaf
-import kotlin.time.Instant
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.UseSerializers
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.decodeFromJsonElement
+import kotlinx.serialization.json.jsonObject
+import kotlin.time.Instant
 
 /**
- * Header of a [JwsSigned].
+ * Effective JWS header as defined in [RFC 7515](https://datatracker.ietf.org/doc/html/rfc7515)
+ * after combining protected and unprotected header members.
  *
- * See [RFC 7515](https://datatracker.ietf.org/doc/html/rfc7515)
+ * [JwsCompact] carries this header entirely in the protected section. [JwsFlattened], [JwsGeneral], and
+ * [SignatureElement] represent the protected and unprotected fragments as [Part] and reconstruct the effective
+ * header with [fromParts].
+ *
+ * Individual fragments may be incomplete. Only the combination of protected and unprotected parameters must
+ * constitute a valid [JwsHeader].
+ *
+ * Private Header Parameters as specified in RFC 7515 4.3 are currently not implemented
  */
 @Serializable
 data class JwsHeader(
@@ -34,7 +43,7 @@ data class JwsHeader(
      * When used with a JWK, the "kid" value is used to match a JWK "kid"
      * parameter value.
      */
-    @SerialName("kid")
+    @SerialName(SerialNames.KEY_ID)
     val keyId: String? = null,
 
     /**
@@ -49,7 +58,7 @@ data class JwsHeader(
      * processing of this parameter is performed by the JWS application.
      * Use of this Header Parameter is OPTIONAL.
      */
-    @SerialName("typ")
+    @SerialName(SerialNames.TYPE)
     val type: String? = null,
 
     /**
@@ -65,7 +74,7 @@ data class JwsHeader(
      * Parameter MUST be present and MUST be understood and processed by
      * implementations.
      */
-    @SerialName("alg")
+    @SerialName(SerialNames.ALGORITHM)
     val algorithm: JwsAlgorithm,
 
     /**
@@ -80,7 +89,7 @@ data class JwsHeader(
      * parameter is performed by the JWS application.  Use of this Header
      * Parameter is OPTIONAL.
      */
-    @SerialName("cty")
+    @SerialName(SerialNames.CONTENT_TYPE)
     val contentType: String? = null,
 
     /**
@@ -99,7 +108,7 @@ data class JwsHeader(
      * the certificate or certificate chain to be invalid if any validation
      * failure occurs.  Use of this Header Parameter is OPTIONAL.
      */
-    @SerialName("x5c")
+    @SerialName(SerialNames.CERTIFICATE_CHAIN)
     @Serializable(with = CertificateChainBase64Serializer::class)
     val certificateChain: CertificateChain? = null,
 
@@ -112,7 +121,7 @@ data class JwsHeader(
      * account for clock skew.  Its value MUST be a number containing a
      * NumericDate value.  Use of this claim is OPTIONAL.
      */
-    @SerialName("nbf")
+    @SerialName(SerialNames.NOT_BEFORE)
     @Serializable(with = InstantLongSerializer::class)
     val notBefore: Instant? = null,
 
@@ -122,7 +131,7 @@ data class JwsHeader(
      * value MUST be a number containing a NumericDate value.  Use of this
      * claim is OPTIONAL.
      */
-    @SerialName("iat")
+    @SerialName(SerialNames.ISSUED_AT)
     @Serializable(with = InstantLongSerializer::class)
     val issuedAt: Instant? = null,
 
@@ -135,7 +144,7 @@ data class JwsHeader(
      * a few minutes, to account for clock skew.  Its value MUST be a number
      * containing a NumericDate value.  Use of this claim is OPTIONAL.
      */
-    @SerialName("exp")
+    @SerialName(SerialNames.EXPIRATION)
     @Serializable(with = InstantLongSerializer::class)
     val expiration: Instant? = null,
 
@@ -145,7 +154,7 @@ data class JwsHeader(
      * represented as a JSON Web Key (JWK).  Use of this Header Parameter is
      * OPTIONAL.
      */
-    @SerialName("jwk")
+    @SerialName(SerialNames.JSON_WEB_KEY)
     val jsonWebKey: JsonWebKey? = null,
 
     /**
@@ -160,7 +169,7 @@ data class JwsHeader(
      * Section 8 on TLS requirements.  Use of this Header Parameter is
      * OPTIONAL.
      */
-    @SerialName("jku")
+    @SerialName(SerialNames.JSON_WEB_KEY_SET_URL)
     val jsonWebKeySetUrl: String? = null,
 
     /**
@@ -181,7 +190,7 @@ data class JwsHeader(
      * Also, see Section 8 on TLS requirements.  Use of this Header
      * Parameter is OPTIONAL.
      */
-    @SerialName("x5u")
+    @SerialName(SerialNames.CERTIFICATE_URL)
     val certificateUrl: String? = null,
 
     /**
@@ -192,7 +201,7 @@ data class JwsHeader(
      * are also sometimes known as certificate fingerprints.  Use of this
      * Header Parameter is OPTIONAL.
      */
-    @SerialName("x5t")
+    @SerialName(SerialNames.CERTIFICATE_SHA1_THUMBPRINT)
     @Serializable(with = ByteArrayBase64UrlSerializer::class)
     val certificateSha1Thumbprint: ByteArray? = null,
 
@@ -204,23 +213,25 @@ data class JwsHeader(
      * thumbprints are also sometimes known as certificate fingerprints.
      * Use of this Header Parameter is OPTIONAL.
      */
-    @SerialName("x5t#S256")
+    @SerialName(SerialNames.CERTIFICATE_SHA256_THUMBPRINT)
     @Serializable(with = ByteArrayBase64UrlSerializer::class)
     val certificateSha256Thumbprint: ByteArray? = null,
 
     /**
      * OID4VP: Verifier Attestation JWT, used to authenticate a Verifier, by providing a JWT signed by a trusted
-     * third party. May be parsed as a [JwsSigned], with [JsonWebToken] as the payload.
+     * third party. May be parsed as a [JwsCompact], with [JsonWebToken] as the payload.
      */
-    @SerialName("jwt")
-    val attestationJwt: String? = null,
+    @SerialName(SerialNames.ATTESTATION_JWT)
+    @Serializable(with = JwsCompactStringSerializer::class)
+    val attestationJwt: JwsCompact? = null,
 
     /**
      * OpenID4VCI: Optional. JOSE Header containing a key attestation as described in Appendix D.
-     * See [keyAttestationParsed].
+     * Should be a [JwsCompact], with [JsonWebToken] as the payload
      */
-    @SerialName("key_attestation")
-    val keyAttestation: String? = null,
+    @SerialName(SerialNames.KEY_ATTESTATION)
+    @Serializable(with = JwsCompactStringSerializer::class)
+    val keyAttestation: JwsCompact? = null,
 
     /**
      * SD-JWT VC: Credentials MAY encode Type Metadata directly, providing it as "glue information"
@@ -231,12 +242,113 @@ data class JwsHeader(
      *
      * Defined as a [String] here, so client applications can parse to appropriate types.
      */
-    @SerialName("vctm")
+    @SerialName(SerialNames.VC_TYPE_METADATA)
     val vcTypeMetadata: Set<String>? = null,
 ) {
+    /**
+     * Typed representation of either the protected or unprotected JWS header fragment.
+     *
+     * A [Part] may be incomplete and does not have to be a valid [JwsHeader] on its own. Only the merged protected
+     * plus unprotected representation must decode to a valid [JwsHeader].
+     */
+    @Serializable
+    data class Part(
+        @SerialName(SerialNames.KEY_ID)
+        val keyId: String? = null,
+        @SerialName(SerialNames.TYPE)
+        val type: String? = null,
+        @SerialName(SerialNames.ALGORITHM)
+        val algorithm: JwsAlgorithm? = null,
+        @SerialName(SerialNames.CONTENT_TYPE)
+        val contentType: String? = null,
+        @SerialName(SerialNames.CERTIFICATE_CHAIN)
+        @Serializable(with = CertificateChainBase64Serializer::class)
+        val certificateChain: CertificateChain? = null,
+        @SerialName(SerialNames.NOT_BEFORE)
+        @Serializable(with = InstantLongSerializer::class)
+        val notBefore: Instant? = null,
+        @SerialName(SerialNames.ISSUED_AT)
+        @Serializable(with = InstantLongSerializer::class)
+        val issuedAt: Instant? = null,
+        @SerialName(SerialNames.EXPIRATION)
+        @Serializable(with = InstantLongSerializer::class)
+        val expiration: Instant? = null,
+        @SerialName(SerialNames.JSON_WEB_KEY)
+        val jsonWebKey: JsonWebKey? = null,
+        @SerialName(SerialNames.JSON_WEB_KEY_SET_URL)
+        val jsonWebKeySetUrl: String? = null,
+        @SerialName(SerialNames.CERTIFICATE_URL)
+        val certificateUrl: String? = null,
+        @SerialName(SerialNames.CERTIFICATE_SHA1_THUMBPRINT)
+        @Serializable(with = ByteArrayBase64UrlSerializer::class)
+        val certificateSha1Thumbprint: ByteArray? = null,
+        @SerialName(SerialNames.CERTIFICATE_SHA256_THUMBPRINT)
+        @Serializable(with = ByteArrayBase64UrlSerializer::class)
+        val certificateSha256Thumbprint: ByteArray? = null,
+        @SerialName(SerialNames.ATTESTATION_JWT)
+        @Serializable(with = JwsCompactStringSerializer::class)
+        val attestationJwt: JwsCompact? = null,
+        @SerialName(SerialNames.KEY_ATTESTATION)
+        @Serializable(with = JwsCompactStringSerializer::class)
+        val keyAttestation: JwsCompact? = null,
+        @SerialName(SerialNames.VC_TYPE_METADATA)
+        val vcTypeMetadata: Set<String>? = null,
+    ) {
+        fun toJsonObject(): JsonObject =
+            joseCompliantSerializer.encodeToJsonElement(serializer(), this).jsonObject
 
-    @Deprecated("To be removed in next release")
-    fun serialize() = joseCompliantSerializer.encodeToString(this)
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other == null || this::class != other::class) return false
+
+            other as Part
+
+            if (keyId != other.keyId) return false
+            if (type != other.type) return false
+            if (algorithm != other.algorithm) return false
+            if (contentType != other.contentType) return false
+            if (certificateChain != other.certificateChain) return false
+            if (notBefore != other.notBefore) return false
+            if (issuedAt != other.issuedAt) return false
+            if (expiration != other.expiration) return false
+            if (jsonWebKey != other.jsonWebKey) return false
+            if (jsonWebKeySetUrl != other.jsonWebKeySetUrl) return false
+            if (certificateUrl != other.certificateUrl) return false
+            if (certificateSha1Thumbprint != null) {
+                if (other.certificateSha1Thumbprint == null) return false
+                if (!certificateSha1Thumbprint.contentEquals(other.certificateSha1Thumbprint)) return false
+            } else if (other.certificateSha1Thumbprint != null) return false
+            if (certificateSha256Thumbprint != null) {
+                if (other.certificateSha256Thumbprint == null) return false
+                if (!certificateSha256Thumbprint.contentEquals(other.certificateSha256Thumbprint)) return false
+            } else if (other.certificateSha256Thumbprint != null) return false
+            if (attestationJwt != other.attestationJwt) return false
+            if (keyAttestation != other.keyAttestation) return false
+            if (vcTypeMetadata != other.vcTypeMetadata) return false
+
+            return true
+        }
+
+        override fun hashCode(): Int {
+            var result = keyId?.hashCode() ?: 0
+            result = 31 * result + (type?.hashCode() ?: 0)
+            result = 31 * result + (algorithm?.hashCode() ?: 0)
+            result = 31 * result + (contentType?.hashCode() ?: 0)
+            result = 31 * result + (certificateChain?.hashCode() ?: 0)
+            result = 31 * result + (notBefore?.hashCode() ?: 0)
+            result = 31 * result + (issuedAt?.hashCode() ?: 0)
+            result = 31 * result + (expiration?.hashCode() ?: 0)
+            result = 31 * result + (jsonWebKey?.hashCode() ?: 0)
+            result = 31 * result + (jsonWebKeySetUrl?.hashCode() ?: 0)
+            result = 31 * result + (certificateUrl?.hashCode() ?: 0)
+            result = 31 * result + (certificateSha1Thumbprint?.contentHashCode() ?: 0)
+            result = 31 * result + (certificateSha256Thumbprint?.contentHashCode() ?: 0)
+            result = 31 * result + (attestationJwt?.hashCode() ?: 0)
+            result = 31 * result + (keyAttestation?.hashCode() ?: 0)
+            result = 31 * result + (vcTypeMetadata?.hashCode() ?: 0)
+            return result
+        }
+    }
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -300,19 +412,86 @@ data class JwsHeader(
             ?: certificateChain?.leaf?.decodedPublicKey?.getOrNull()
     }
 
-    val keyAttestationParsed: JwsSigned<KeyAttestationJwt>? by lazy {
-        keyAttestation?.let {
-            JwsSigned.deserialize<KeyAttestationJwt>(KeyAttestationJwt.serializer(), it, joseCompliantSerializer)
-                .getOrNull()
-        }
+    val keyAttestationParsed: JwsCompactTyped<KeyAttestationJwt>? by lazy {
+        keyAttestation?.typed()
+    }
+
+    object SerialNames {
+        const val KEY_ID = "kid"
+        const val TYPE = "typ"
+        const val ALGORITHM = "alg"
+        const val CONTENT_TYPE = "cty"
+        const val CERTIFICATE_CHAIN = "x5c"
+        const val NOT_BEFORE = "nbf"
+        const val ISSUED_AT = "iat"
+        const val EXPIRATION = "exp"
+        const val JSON_WEB_KEY = "jwk"
+        const val JSON_WEB_KEY_SET_URL = "jku"
+        const val CERTIFICATE_URL = "x5u"
+        const val CERTIFICATE_SHA1_THUMBPRINT = "x5t"
+        const val CERTIFICATE_SHA256_THUMBPRINT = "x5t#S256"
+        const val ATTESTATION_JWT = "jwt"
+        const val KEY_ATTESTATION = "key_attestation"
+        const val VC_TYPE_METADATA = "vctm"
     }
 
     companion object {
-        // TODO usages!
-        @Deprecated("To be removed in next release")
-        fun deserialize(it: String) = catching {
-            joseCompliantSerializer.decodeFromString<JwsHeader>(it)
-        }
+        /**
+         * Merges protected and unprotected header fragments into the effective [JwsHeader].
+         *
+         * Either fragment may be partial, but their combined content must form a valid header.
+         */
+        fun fromParts(
+            protectedHeader: Part? = null,
+            unprotectedHeader: Part? = null,
+        ): JwsHeader = fromJsonObjects(
+            protectedHeader = protectedHeader?.toJsonObject(),
+            unprotectedHeader = unprotectedHeader?.toJsonObject(),
+        )
 
+        /**
+         * Decodes the protected fragment and merges it with the optional unprotected fragment.
+         *
+         * This is the form used when reading serialized JWS values such as [JwsCompact] or [JwsFlattened].
+         */
+        fun fromParts(
+            protectedHeader: ByteArray? = null,
+            unprotectedHeader: Part? = null,
+        ): JwsHeader = fromJsonObjects(
+            protectedHeader = protectedHeader?.let(JwsProtectedHeaderSerializer::decodeToJsonObject),
+            unprotectedHeader = unprotectedHeader?.toJsonObject(),
+        )
+
+        internal fun fromJsonObjects(
+            protectedHeader: JsonObject? = null,
+            unprotectedHeader: JsonObject? = null,
+        ): JwsHeader = joseCompliantSerializer.decodeFromJsonElement<JwsHeader>(
+            protectedHeader.strictUnion(unprotectedHeader)
+        )
     }
 }
+
+/**
+ * Converts the effective header into a single [JwsHeader.Part].
+ *
+ * Use this when one fragment should represent the whole header, for example the protected header in [JwsCompact].
+ * When protected and unprotected members differ, construct the two [JwsHeader.Part] values explicitly.
+ */
+fun JwsHeader.toPart(): JwsHeader.Part = JwsHeader.Part(
+    keyId = keyId,
+    type = type,
+    algorithm = algorithm,
+    contentType = contentType,
+    certificateChain = certificateChain,
+    notBefore = notBefore,
+    issuedAt = issuedAt,
+    expiration = expiration,
+    jsonWebKey = jsonWebKey,
+    jsonWebKeySetUrl = jsonWebKeySetUrl,
+    certificateUrl = certificateUrl,
+    certificateSha1Thumbprint = certificateSha1Thumbprint,
+    certificateSha256Thumbprint = certificateSha256Thumbprint,
+    attestationJwt = attestationJwt,
+    keyAttestation = keyAttestation,
+    vcTypeMetadata = vcTypeMetadata,
+)

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsProtectedHeaderSerializer.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsProtectedHeaderSerializer.kt
@@ -1,0 +1,49 @@
+package at.asitplus.signum.indispensable.josef
+
+import at.asitplus.signum.indispensable.io.ByteArrayBase64UrlSerializer
+import at.asitplus.signum.indispensable.io.TransformingSerializerTemplate
+import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
+import kotlinx.serialization.json.JsonObject
+
+private fun JwsHeader.Part.toProtectedHeaderBytes(): ByteArray =
+    joseCompliantSerializer.encodeToString(JwsHeader.Part.serializer(), this)
+        .encodeToByteArray()
+
+private fun ByteArray.toProtectedHeaderPart(): JwsHeader.Part =
+    joseCompliantSerializer.decodeFromString(
+        JwsHeader.Part.serializer(),
+        decodeToString(),
+    )
+
+private fun ByteArray.toProtectedHeaderJsonObject(): JsonObject =
+    joseCompliantSerializer.decodeFromString(decodeToString())
+
+object JwsProtectedHeaderSerializer : TransformingSerializerTemplate<JwsHeader.Part, ByteArray>(
+    parent = ByteArrayBase64UrlSerializer,
+    encodeAs = JwsHeader.Part::toProtectedHeaderBytes,
+    decodeAs = ByteArray::toProtectedHeaderPart,
+    serialName = "JwsProtectedHeader",
+) {
+    fun encodeToByteArray(header: JwsHeader.Part): ByteArray = header.toProtectedHeaderBytes()
+
+    /**
+     * RFC 7515 requires empty protected header values to be absent rather than encoded as `{}`.
+     */
+    fun encodeToByteArrayOrNull(header: JwsHeader.Part?): ByteArray? =
+        header
+            ?.takeUnless { it.toJsonObject().isEmpty() }
+            ?.toProtectedHeaderBytes()
+
+    /**
+     * RFC 7515 requires empty protected header values to be absent rather than encoded as `{}`.
+     */
+    internal fun requireAbsentIfEmpty(encodedHeader: ByteArray?) {
+        require(encodedHeader == null || decodeToJsonObject(encodedHeader).isNotEmpty()) {
+            "JWS protected header must be absent when it would otherwise be empty"
+        }
+    }
+
+    fun decodeFromByteArray(encodedHeader: ByteArray): JwsHeader.Part = encodedHeader.toProtectedHeaderPart()
+
+    fun decodeToJsonObject(encodedHeader: ByteArray): JsonObject = encodedHeader.toProtectedHeaderJsonObject()
+}

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsSigned.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsSigned.kt
@@ -20,6 +20,7 @@ import kotlinx.serialization.json.Json
  *
  * See [RFC 7515](https://datatracker.ietf.org/doc/html/rfc7515)
  */
+@Deprecated("Replaced by JwsCompactTyped", level = DeprecationLevel.WARNING, replaceWith = ReplaceWith("JwsCompactTyped"))
 data class JwsSigned<out P : Any>(
     val header: JwsHeader,
     val payload: P,

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsTyped.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsTyped.kt
@@ -1,0 +1,71 @@
+package at.asitplus.signum.indispensable.josef
+
+import at.asitplus.signum.indispensable.josef.JwsTyped.Companion.invoke
+import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
+import kotlinx.serialization.serializer
+
+typealias JwsCompactTyped<P> = JwsTyped<JwsCompact, P>
+typealias JwsFlattenedTyped<P> = JwsTyped<JwsFlattened, P>
+typealias JwsGeneralTyped<P> = JwsTyped<JwsGeneral, P>
+
+fun <P> JwsCompactTyped<P>.toJwsFlattenedTyped() = JwsFlattenedTyped(this.jws.toJwsFlattened(), this.payload)
+fun <P> JwsFlattenedTyped<P>.toJwsCompactTyped() = JwsCompactTyped(this.jws.toJwsCompact(), this.payload)
+fun <P> JwsGeneralTyped<P>.toJwsFlattenedTyped() = this.jws.toJwsFlattened().map { JwsFlattenedTyped(it, this.payload) }
+
+inline fun <reified P, J : JWS> J.typed(): JwsTyped<J, P> =
+    JwsTyped(this, getPayload<P>().getOrThrow())
+
+/**
+ * Wrapper for [at.asitplus.signum.indispensable.josef.JWS]. Useful when [payload] type is known as part of the contract.
+ * All communication over the wire should use [jws] only!
+ *
+ * While the constructor can be used the different [invoke]s are recommended.
+ * For convenience also see the typealiases
+ */
+data class JwsTyped<out J : JWS, out P>(
+    val jws: J, val payload: P
+) {
+    override fun toString() = jws.toString()
+
+    companion object {
+        inline operator fun <reified P> invoke(base64UrlString: String) =
+            JwsCompact.parse<P>(base64UrlString).getOrThrow().let { (jws, payload) -> JwsTyped(jws, payload) }
+
+        inline operator fun <reified P> invoke(jwsFlattened: List<JwsFlattened>): JwsTyped<JwsGeneral, P> =
+            jwsFlattened.toJwsGeneral().typed()
+
+        /**
+         * Creates [JwsCompact]. [protectedHeader] must form a valid [JwsHeader].
+         */
+        suspend inline operator fun <reified P> invoke(
+            protectedHeader: JwsHeader, payload: P, noinline signer: suspend (ByteArray) -> ByteArray
+        ): JwsCompactTyped<P> {
+            val plainPayload = joseCompliantSerializer.encodeToString(
+                joseCompliantSerializer.serializersModule.serializer(), payload
+            ).encodeToByteArray()
+            return JwsCompactTyped(
+                JwsCompact.invoke(protectedHeader = protectedHeader, payload = plainPayload, signer = signer), payload
+            )
+        }
+
+        /**
+         * Creates a flattened JWS from protected and unprotected header fragments.
+         * The fragments may be partial, but their merged content must form a valid [JwsHeader].
+         */
+        suspend inline operator fun <reified P> invoke(
+            protectedHeader: JwsHeader.Part?,
+            unprotectedHeader: JwsHeader.Part?,
+            payload: P,
+            noinline signer: suspend (ByteArray) -> ByteArray
+        ): JwsFlattenedTyped<P> {
+            val plainPayload = joseCompliantSerializer.encodeToString(
+                joseCompliantSerializer.serializersModule.serializer(), payload
+            ).encodeToByteArray()
+            return JwsFlattenedTyped(
+                JwsFlattened(
+                    protectedHeader, unprotectedHeader, plainPayload, signer = signer
+                ), payload
+            )
+        }
+    }
+}

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/KeyAttestationJwt.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/KeyAttestationJwt.kt
@@ -3,10 +3,62 @@ package at.asitplus.signum.indispensable.josef
 import at.asitplus.catching
 import at.asitplus.signum.indispensable.io.InstantLongSerializer
 import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
+import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonObject
 import kotlin.time.Instant
+
+@Serializable
+data class KeyAttestationElements(
+    /**
+     * Array of attested keys from the same key storage component using the syntax of JWK as defined in RFC7517.
+     */
+    @SerialName("attested_keys")
+    val attestedKeys: Collection<JsonWebKey>,
+
+    /**
+     * Optional. Array of case sensitive strings that assert the attack potential resistance of the key storage
+     * component and its keys attested in the attested_keys parameter. This specification defines initial values in
+     * Appendix D.2.
+     */
+    @SerialName("key_storage")
+    val keyStorage: Collection<String>? = null,
+
+    /**
+     * Optional. Array of case sensitive strings that assert the attack potential resistance of the user authentication
+     * methods allowed to access the private keys from the [attestedKeys] parameter.
+     * This specification defines initial values in Appendix D.2.
+     */
+    @SerialName("user_authentication")
+    val userAuthentication: Collection<String>? = null,
+
+    /**
+     * Optional. A String that contains a URL that links to the certification of the key storage component.
+     */
+    @SerialName("certification")
+    val certification: String? = null,
+
+    /**
+     * Optional. JSON Object representing the supported revocation check mechanisms, such as the one defined in
+     * ietf-oauth-status-list.
+     */
+    @SerialName("status")
+    val status: JsonObject? = null,
+)
+
+object ExperimentalKeyAttSerializer : KSerializer<ExperimentalKeyAtt> by UnknownKeyWrapperTransformingSerializer(
+    structSerializer = JsonWebToken.serializer(),
+    wrap = ::ExperimentalKeyAtt,
+)
+
+@Serializable(with=ExperimentalKeyAttSerializer::class)
+data class ExperimentalKeyAtt(
+    override val baseStructure: JsonWebToken,
+    override val unknownKeys: JsonObject
+): UnknownKeyWrapper<JsonWebToken> {
+    val keyAttestationElements: KeyAttestationElements = this.getDataClass<KeyAttestationElements>()
+}
 
 /**
  * Content of a Key Attestation in JWT format, according to

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/SignatureElement.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/SignatureElement.kt
@@ -1,0 +1,74 @@
+package at.asitplus.signum.indispensable.josef
+
+import at.asitplus.signum.indispensable.io.ByteArrayBase64UrlNoPaddingSerializer
+import at.asitplus.signum.indispensable.josef.JWS.Companion.getSignature
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.Transient
+
+/**
+ * One signature entry of general JSON JWS serialization.
+ *
+ * A [SignatureElement] contains the signature bytes plus the header fragments for that signature. The protected
+ * fragment is stored as encoded bytes in [plainProtectedHeader], while the optional unprotected fragment is
+ * represented as [JwsHeader.Part]. The effective [jwsHeader] is reconstructed by merging both fragments.
+ *
+ * Either header fragment may be partial. Only the combination of protected and unprotected parameters must
+ * constitute a valid [JwsHeader].
+ *
+ * See [RFC 7515 Sec 7.2.1](https://www.rfc-editor.org/rfc/rfc7515.html#section-7.2.1).
+ */
+@ConsistentCopyVisibility
+@Serializable
+data class SignatureElement internal constructor(
+    /**
+     * The [plainSignature] member MUST be present
+     *
+     * Serialization: BASE64URL(JWS Signature).
+     */
+    @SerialName(JWS.SerialNames.SIGNATURE)
+    @Serializable(ByteArrayBase64UrlNoPaddingSerializer::class)
+    val plainSignature: ByteArray,
+
+    /**
+     * The [plainProtectedHeader] member MUST be present ...when the JWS Protected
+     * Header value is non-empty; otherwise, it MUST be absent.  These
+     * Header Parameter values are integrity protected.
+     *
+     * Serialization: BASE64URL(UTF8(JWS Protected Header))
+     */
+    @SerialName(JWS.SerialNames.PROTECTED)
+    @Serializable(with = ByteArrayBase64UrlNoPaddingSerializer::class)
+    val plainProtectedHeader: ByteArray? = null,
+
+    @SerialName(JWS.SerialNames.HEADER)
+    val unprotectedHeader: JwsHeader.Part? = null
+) {
+    init {
+        JwsProtectedHeaderSerializer.requireAbsentIfEmpty(plainProtectedHeader)
+    }
+
+    @Transient
+    val jwsHeader: JwsHeader = JwsHeader.fromParts(plainProtectedHeader, unprotectedHeader)
+    @Transient
+    val signature = getSignature(jwsHeader.algorithm, plainSignature)
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as SignatureElement
+
+        if (!plainSignature.contentEquals(other.plainSignature)) return false
+        if (!plainProtectedHeader.contentEquals(other.plainProtectedHeader)) return false
+        if (unprotectedHeader != other.unprotectedHeader) return false
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = plainSignature.contentHashCode()
+        result = 31 * result + plainProtectedHeader.contentHashCode()
+        result = 31 * result + (unprotectedHeader?.hashCode() ?: 0)
+        return result
+    }
+}

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/UnknownKeyWrapper.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/UnknownKeyWrapper.kt
@@ -4,8 +4,6 @@ import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.decodeFromJsonElement
 import kotlinx.serialization.serializer
 
 interface UnknownKeyWrapper<T> {
@@ -16,7 +14,7 @@ interface UnknownKeyWrapper<T> {
             joseCompliantSerializer.decodeFromJsonElement(deserializer, it)
         }
 
-    fun <D> getDataClass(deserializer: KSerializer<D>): D? =
+    fun <D> getDataClass(deserializer: KSerializer<D>): D =
         joseCompliantSerializer.decodeFromJsonElement(deserializer, unknownKeys)
 }
 
@@ -46,5 +44,5 @@ object JsonWebTokenAllKeysSerializer : KSerializer<JsonWebTokenAllKeys> by Unkno
 inline fun <reified G> UnknownKeyWrapper<*>.getParameter(key: String): G? =
     getParameter(key, joseCompliantSerializer.serializersModule.serializer())
 
-inline fun <reified D> UnknownKeyWrapper<*>.getDataClass(): D? =
+inline fun <reified D> UnknownKeyWrapper<*>.getDataClass(): D =
     getDataClass(joseCompliantSerializer.serializersModule.serializer())

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/UnknownKeyWrapper.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/UnknownKeyWrapper.kt
@@ -1,12 +1,19 @@
 package at.asitplus.signum.indispensable.josef
 
+import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.decodeFromJsonElement
+import kotlinx.serialization.serializer
 
 interface UnknownKeyWrapper<T> {
     val baseStructure: T
     val unknownKeys: Map<String, JsonElement>
+    fun <G> getParameter(key: String, deserializer: KSerializer<G>): G? =
+        unknownKeys[key]?.let {
+            joseCompliantSerializer.decodeFromJsonElement(deserializer, it)
+        }
 }
 
 @Serializable(with = JwsHeaderAllKeysSerializer::class)
@@ -31,3 +38,6 @@ object JsonWebTokenAllKeysSerializer : KSerializer<JsonWebTokenAllKeys> by Unkno
     structSerializer = JsonWebToken.serializer(),
     wrap = ::JsonWebTokenAllKeys,
 )
+
+inline fun <reified G> UnknownKeyWrapper<*>.getParameter(key: String): G? =
+    getParameter(key, joseCompliantSerializer.serializersModule.serializer())

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/UnknownKeyWrapper.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/UnknownKeyWrapper.kt
@@ -3,30 +3,34 @@ package at.asitplus.signum.indispensable.josef
 import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.decodeFromJsonElement
 import kotlinx.serialization.serializer
 
 interface UnknownKeyWrapper<T> {
     val baseStructure: T
-    val unknownKeys: Map<String, JsonElement>
+    val unknownKeys: JsonObject
     fun <G> getParameter(key: String, deserializer: KSerializer<G>): G? =
         unknownKeys[key]?.let {
             joseCompliantSerializer.decodeFromJsonElement(deserializer, it)
         }
+
+    fun <D> getDataClass(deserializer: KSerializer<D>): D? =
+        joseCompliantSerializer.decodeFromJsonElement(deserializer, unknownKeys)
 }
 
 @Serializable(with = JwsHeaderAllKeysSerializer::class)
 data class JwsHeaderAllKeys(
     override val baseStructure: JwsHeader,
-    override val unknownKeys: Map<String, JsonElement> = emptyMap(),
+    override val unknownKeys: JsonObject = JsonObject(mapOf()),
 ) : UnknownKeyWrapper<JwsHeader>
 
 
 @Serializable(with = JsonWebTokenAllKeysSerializer::class)
 data class JsonWebTokenAllKeys(
     override val baseStructure: JsonWebToken,
-    override val unknownKeys: Map<String, JsonElement> = emptyMap(),
+    override val unknownKeys: JsonObject = JsonObject(mapOf()),
 ) : UnknownKeyWrapper<JsonWebToken>
 
 object JwsHeaderAllKeysSerializer : KSerializer<JwsHeaderAllKeys> by UnknownKeyWrapperTransformingSerializer(
@@ -41,3 +45,6 @@ object JsonWebTokenAllKeysSerializer : KSerializer<JsonWebTokenAllKeys> by Unkno
 
 inline fun <reified G> UnknownKeyWrapper<*>.getParameter(key: String): G? =
     getParameter(key, joseCompliantSerializer.serializersModule.serializer())
+
+inline fun <reified D> UnknownKeyWrapper<*>.getDataClass(): D? =
+    getDataClass(joseCompliantSerializer.serializersModule.serializer())

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/UnknownKeyWrapper.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/UnknownKeyWrapper.kt
@@ -1,0 +1,33 @@
+package at.asitplus.signum.indispensable.josef
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonElement
+
+interface UnknownKeyWrapper<T> {
+    val baseStructure: T
+    val unknownKeys: Map<String, JsonElement>
+}
+
+@Serializable(with = JwsHeaderAllKeysSerializer::class)
+data class JwsHeaderAllKeys(
+    override val baseStructure: JwsHeader,
+    override val unknownKeys: Map<String, JsonElement> = emptyMap(),
+) : UnknownKeyWrapper<JwsHeader>
+
+
+@Serializable(with = JsonWebTokenAllKeysSerializer::class)
+data class JsonWebTokenAllKeys(
+    override val baseStructure: JsonWebToken,
+    override val unknownKeys: Map<String, JsonElement> = emptyMap(),
+) : UnknownKeyWrapper<JsonWebToken>
+
+object JwsHeaderAllKeysSerializer : KSerializer<JwsHeaderAllKeys> by UnknownKeyWrapperTransformingSerializer(
+    structSerializer = JwsHeader.serializer(),
+    wrap = ::JwsHeaderAllKeys,
+)
+
+object JsonWebTokenAllKeysSerializer : KSerializer<JsonWebTokenAllKeys> by UnknownKeyWrapperTransformingSerializer(
+    structSerializer = JsonWebToken.serializer(),
+    wrap = ::JsonWebTokenAllKeys,
+)

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/UnknownKeyWrapperSerializer.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/UnknownKeyWrapperSerializer.kt
@@ -1,0 +1,42 @@
+package at.asitplus.signum.indispensable.josef
+
+import at.asitplus.signum.indispensable.io.TransformingSerializerTemplate
+import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlin.collections.component1
+import kotlin.collections.component2
+
+class UnknownKeyWrapperTransformingSerializer<T, U : UnknownKeyWrapper<T>>(
+    val structSerializer: KSerializer<T>,
+    private val wrap: (knownStructure: T, unknownKeys: Map<String, JsonElement>) -> U,
+    private val serialNames: Set<String> = structSerializer.topLevelSerialNames(),
+) : TransformingSerializerTemplate<U, JsonObject>(
+    parent = JsonObject.serializer(),
+    encodeAs = { value ->
+        val overlappingKeys = value.unknownKeys.keys.intersect(serialNames)
+        require(overlappingKeys.isEmpty()) {
+            "unknownKeys must not contain known keys: ${overlappingKeys.sorted().joinToString()}"
+        }
+
+        val knownKeys =
+            joseCompliantSerializer.encodeToJsonElement(structSerializer, value.baseStructure) as JsonObject
+        buildJsonObject {
+            value.unknownKeys.forEach { (key, jsonElement) -> put(key, jsonElement) }
+            knownKeys.forEach { (key, jsonElement) -> put(key, jsonElement) }
+        }
+    },
+    decodeAs = { jsonObject ->
+        val knownStructure = joseCompliantSerializer.decodeFromJsonElement(structSerializer, jsonObject)
+        val unknownKeys = jsonObject.filterKeys { it !in serialNames }
+        wrap(knownStructure, unknownKeys)
+    },
+    serialName = "${structSerializer.descriptor.serialName}AllKeys",
+)
+
+private fun KSerializer<*>.topLevelSerialNames(): Set<String> =
+    (0 until descriptor.elementsCount)
+        .map(descriptor::getElementName)
+        .toSet()

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/UnknownKeyWrapperSerializer.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/UnknownKeyWrapperSerializer.kt
@@ -4,9 +4,6 @@ import at.asitplus.signum.indispensable.io.TransformingSerializerTemplate
 import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.buildJsonObject
-import kotlin.collections.component1
-import kotlin.collections.component2
 
 class UnknownKeyWrapperTransformingSerializer<T, U : UnknownKeyWrapper<T>>(
     val structSerializer: KSerializer<T>,
@@ -15,17 +12,8 @@ class UnknownKeyWrapperTransformingSerializer<T, U : UnknownKeyWrapper<T>>(
 ) : TransformingSerializerTemplate<U, JsonObject>(
     parent = JsonObject.serializer(),
     encodeAs = { value ->
-        val overlappingKeys = value.unknownKeys.keys.intersect(serialNames)
-        require(overlappingKeys.isEmpty()) {
-            "unknownKeys must not contain known keys: ${overlappingKeys.sorted().joinToString()}"
-        }
-
-        val knownKeys =
-            joseCompliantSerializer.encodeToJsonElement(structSerializer, value.baseStructure) as JsonObject
-        buildJsonObject {
-            value.unknownKeys.forEach { (key, jsonElement) -> put(key, jsonElement) }
-            knownKeys.forEach { (key, jsonElement) -> put(key, jsonElement) }
-        }
+        val knownKeys = joseCompliantSerializer.encodeToJsonElement(structSerializer, value.baseStructure) as JsonObject
+        knownKeys.strictUnion(value.unknownKeys)
     },
     decodeAs = { jsonObject ->
         val knownStructure = joseCompliantSerializer.decodeFromJsonElement(structSerializer, jsonObject)

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/UnknownKeyWrapperSerializer.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/UnknownKeyWrapperSerializer.kt
@@ -19,8 +19,7 @@ class UnknownKeyWrapperTransformingSerializer<T, U : UnknownKeyWrapper<T>>(
         val knownStructure = joseCompliantSerializer.decodeFromJsonElement(structSerializer, jsonObject)
         val unknownKeys = JsonObject(jsonObject.filterKeys { it !in serialNames })
         wrap(knownStructure, unknownKeys)
-    },
-    serialName = "${structSerializer.descriptor.serialName}AllKeys",
+    }
 )
 
 private fun KSerializer<*>.topLevelSerialNames(): Set<String> =

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/UnknownKeyWrapperSerializer.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/UnknownKeyWrapperSerializer.kt
@@ -3,7 +3,6 @@ package at.asitplus.signum.indispensable.josef
 import at.asitplus.signum.indispensable.io.TransformingSerializerTemplate
 import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
 import kotlinx.serialization.KSerializer
-import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonObject
 import kotlin.collections.component1
@@ -11,7 +10,7 @@ import kotlin.collections.component2
 
 class UnknownKeyWrapperTransformingSerializer<T, U : UnknownKeyWrapper<T>>(
     val structSerializer: KSerializer<T>,
-    private val wrap: (knownStructure: T, unknownKeys: Map<String, JsonElement>) -> U,
+    private val wrap: (knownStructure: T, unknownKeys: JsonObject) -> U,
     private val serialNames: Set<String> = structSerializer.topLevelSerialNames(),
 ) : TransformingSerializerTemplate<U, JsonObject>(
     parent = JsonObject.serializer(),
@@ -30,7 +29,7 @@ class UnknownKeyWrapperTransformingSerializer<T, U : UnknownKeyWrapper<T>>(
     },
     decodeAs = { jsonObject ->
         val knownStructure = joseCompliantSerializer.decodeFromJsonElement(structSerializer, jsonObject)
-        val unknownKeys = jsonObject.filterKeys { it !in serialNames }
+        val unknownKeys = JsonObject(jsonObject.filterKeys { it !in serialNames })
         wrap(knownStructure, unknownKeys)
     },
     serialName = "${structSerializer.descriptor.serialName}AllKeys",

--- a/indispensable-josef/src/commonTest/kotlin/at/asitplus/signum/indispensable/josef/JwsHeaderPartsTest.kt
+++ b/indispensable-josef/src/commonTest/kotlin/at/asitplus/signum/indispensable/josef/JwsHeaderPartsTest.kt
@@ -1,0 +1,165 @@
+package at.asitplus.signum.indispensable.josef
+
+import at.asitplus.signum.indispensable.io.Base64UrlStrict
+import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
+import at.asitplus.testballoon.invoke
+import de.infix.testBalloon.framework.core.testSuite
+import io.kotest.matchers.result.shouldBeFailure
+import io.kotest.matchers.shouldBe
+import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArray
+
+val JwsHeaderPartsTest by testSuite {
+    "full JWS header can be converted to a typed header part" {
+        val header = JwsHeader(
+            keyId = "did:example:signer",
+            type = "vc+sd-jwt",
+            algorithm = JwsAlgorithm.Signature.ES256,
+            contentType = "application/example+json",
+            certificateSha1Thumbprint = byteArrayOf(1, 2, 3),
+            certificateSha256Thumbprint = byteArrayOf(4, 5, 6),
+            vcTypeMetadata = setOf("bWV0YWRhdGE"),
+        )
+
+        val part = header.toPart()
+
+        part shouldBe JwsHeader.Part(
+            keyId = "did:example:signer",
+            type = "vc+sd-jwt",
+            algorithm = JwsAlgorithm.Signature.ES256,
+            contentType = "application/example+json",
+            certificateSha1Thumbprint = byteArrayOf(1, 2, 3),
+            certificateSha256Thumbprint = byteArrayOf(4, 5, 6),
+            vcTypeMetadata = setOf("bWV0YWRhdGE"),
+        )
+        JwsHeader.fromParts(protectedHeader = part) shouldBe header
+    }
+
+    "split headers combine into a valid JWS header" {
+        val protectedHeader = JwsHeader.Part(
+            algorithm = JwsAlgorithm.Signature.ES256,
+            type = "vc+sd-jwt",
+        )
+        val unprotectedHeader = JwsHeader.Part(
+            keyId = "did:example:signer",
+            vcTypeMetadata = setOf("bWV0YWRhdGE"),
+        )
+
+        val combined = JwsHeader.fromParts(
+            protectedHeader = protectedHeader,
+            unprotectedHeader = unprotectedHeader,
+        )
+
+        combined.algorithm shouldBe JwsAlgorithm.Signature.ES256
+        combined.type shouldBe "vc+sd-jwt"
+        combined.keyId shouldBe "did:example:signer"
+        combined.vcTypeMetadata shouldBe setOf("bWV0YWRhdGE")
+    }
+
+    "duplicate names across protected and unprotected headers are rejected" {
+        val exception = runCatching {
+            JwsHeader.fromParts(
+                protectedHeader = JwsHeader.Part(keyId = "protected"),
+                unprotectedHeader = JwsHeader.Part(keyId = "unprotected"),
+            )
+        }
+
+        exception.shouldBeFailure() shouldBe IllegalArgumentException("Duplicate keys: kid")
+    }
+
+    "encoded protected header bytes can be merged with unprotected fields" {
+        val protectedHeader = JwsHeader.Part(
+            algorithm = JwsAlgorithm.Signature.RS256,
+            type = "application/example+jws",
+        )
+        val unprotectedHeader = JwsHeader.Part(
+            keyId = "did:example:signer",
+            contentType = "application/example+json",
+        )
+
+        val combined = JwsHeader.fromParts(
+            protectedHeader = JwsProtectedHeaderSerializer.encodeToByteArray(protectedHeader),
+            unprotectedHeader = unprotectedHeader,
+        )
+
+        combined shouldBe JwsHeader.fromParts(protectedHeader, unprotectedHeader)
+    }
+
+    "duplicate names across encoded protected and unprotected headers are rejected" {
+        val protectedHeader = JwsProtectedHeaderSerializer.encodeToByteArray(
+            JwsHeader.Part(
+                algorithm = JwsAlgorithm.Signature.RS256,
+                keyId = "protected",
+            )
+        )
+
+        val exception = runCatching {
+            JwsHeader.fromParts(
+                protectedHeader = protectedHeader,
+                unprotectedHeader = JwsHeader.Part(keyId = "unprotected"),
+            )
+        }
+
+        exception.shouldBeFailure() shouldBe IllegalArgumentException("Duplicate keys: kid")
+    }
+
+    "flattened JWS accepts typed header parts" {
+        val protectedHeader = JwsHeader.Part(
+            algorithm = JwsAlgorithm.Signature.ES256,
+            type = "application/example+jwt",
+        )
+        val unprotectedHeader = JwsHeader.Part(
+            vcTypeMetadata = setOf("bWV0YWRhdGE"),
+        )
+        val payload = "payload".encodeToByteArray()
+
+        val flattened = JwsFlattened.invoke(
+            protectedHeader = protectedHeader,
+            unprotectedHeader = unprotectedHeader,
+            payload = payload,
+        ) {
+            validEs256SignatureFixture
+        }
+
+        flattened.jwsHeader shouldBe JwsHeader.fromParts(protectedHeader, unprotectedHeader)
+    }
+
+    "compact JWS accepts full headers and serializes their protected part" {
+        val header = JwsHeader(
+            algorithm = JwsAlgorithm.Signature.ES256,
+            type = "application/example+jwt",
+            keyId = "did:example:signer",
+            vcTypeMetadata = setOf("bWV0YWRhdGE"),
+        )
+        val payload = "payload".encodeToByteArray()
+
+        val compact = JwsCompact.invoke(
+            protectedHeader = header,
+            payload = payload,
+        ) {
+            validEs256SignatureFixture
+        }
+
+        compact.jwsHeader shouldBe header
+        compact.plainProtectedHeader shouldBe
+                JwsProtectedHeaderSerializer.encodeToByteArray(header.toPart())
+    }
+
+    "protected header bytes are raw header json bytes" {
+        val protectedHeader = JwsHeader.Part(
+            algorithm = JwsAlgorithm.Signature.ES256,
+            type = "application/example+jwt",
+        )
+
+        val encoded = JwsProtectedHeaderSerializer.encodeToByteArray(protectedHeader)
+        val expected = joseCompliantSerializer.encodeToString(JwsHeader.Part.serializer(), protectedHeader)
+            .encodeToByteArray()
+
+        encoded shouldBe expected
+        JwsProtectedHeaderSerializer.decodeFromByteArray(encoded) shouldBe protectedHeader
+    }
+}
+
+// RFC 7515 Appendix A.6 ES256 signature; reused so constructors get a parseable raw ES256 signature.
+private val validEs256SignatureFixture =
+    "DtEhU3ljbEg8L38VWAfUAqOyKAM6-Xx-F4GawxaepmXFCgfTjDxw5djxLa8ISlSApmWQxfKTUJqPP3-Kg6NU1Q"
+        .decodeToByteArray(Base64UrlStrict)

--- a/indispensable-josef/src/commonTest/kotlin/at/asitplus/signum/indispensable/josef/JwsSerializationTest.kt
+++ b/indispensable-josef/src/commonTest/kotlin/at/asitplus/signum/indispensable/josef/JwsSerializationTest.kt
@@ -1,0 +1,546 @@
+package at.asitplus.signum.indispensable.josef
+
+import at.asitplus.signum.indispensable.CryptoSignature
+import at.asitplus.signum.indispensable.io.Base64UrlStrict
+import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
+import at.asitplus.testballoon.invoke
+import de.infix.testBalloon.framework.core.TestCompartment
+import de.infix.testBalloon.framework.core.testSuite
+import io.kotest.matchers.result.shouldBeFailure
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArray
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+private val generalVectorJson = """
+    {
+      "payload": "eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFtcGxlLmNvbS9pc19yb290Ijp0cnVlfQ",
+      "signatures": [
+        {
+          "protected": "eyJhbGciOiJSUzI1NiJ9",
+          "signature": "cC4hiUPoj9Eetdgtv3hF80EGrhuB__dzERat0XF9g2VtQgr9PJbu3XOiZj5RZmh7AAuHIm4Bh-0Qc_lF5YKt_O8W2Fp5jujGbds9uJdbF9CUAr7t1dnZcAcQjbKBYNX4BAynRFdiuB--f_nZLgrnbyTyWzO75vRK5h6xBArLIARNPvkSjtQBMHlb1L07Qe7K0GarZRmB_eSN9383LcOLn6_dO--xi12jzDwusC-eOkHWEsqtFZESc6BfI7noOPqvhJ1phCnvWh6IeYI2w9QOYEUipUTI8np6LbgGY9Fs98rqVt5AXLIhWkWywlVmtVrBp0igcN_IoypGlUPQGe77Rw"
+        },
+        {
+          "protected": "eyJhbGciOiJFUzI1NiJ9",
+          "signature": "DtEhU3ljbEg8L38VWAfUAqOyKAM6-Xx-F4GawxaepmXFCgfTjDxw5djxLa8ISlSApmWQxfKTUJqPP3-Kg6NU1Q"
+        }
+      ]
+    }
+""".trimIndent()
+
+private val generalVectorSource = joseCompliantSerializer.decodeFromString(JsonObject.serializer(), generalVectorJson)
+private val generalVectorPayload = generalVectorSource[JWS.SerialNames.PAYLOAD]!!.jsonPrimitive.content
+private val generalVectorSignatures = generalVectorSource[JWS.SerialNames.SIGNATURES]!!.jsonArray
+
+val JwsSerializerTest by testSuite(compartment = { TestCompartment.Sequential }) {
+    "general JWS keeps vector bytes stable through serialization and flattening" {
+        val general = joseCompliantSerializer.decodeFromString<JwsGeneral>(generalVectorJson)
+
+        general.signatureElements.size shouldBe 2
+        general.jwsHeaders[0].algorithm shouldBe JwsAlgorithm.Signature.RS256
+        general.jwsHeaders[1].algorithm shouldBe JwsAlgorithm.Signature.ES256
+        general.signatures[0].shouldBeInstanceOf<CryptoSignature.RSA>()
+        general.signatures[1].shouldBeInstanceOf<CryptoSignature.EC.DefiniteLength>()
+
+        general.signatureElements.forEachIndexed { index, signatureElement ->
+            val sourceSignature = generalVectorSignatures[index].jsonObject
+            val protectedHeaderBase64 = sourceSignature[JWS.SerialNames.PROTECTED]!!.jsonPrimitive.content
+            val signatureBase64 = sourceSignature[JWS.SerialNames.SIGNATURE]!!.jsonPrimitive.content
+
+            signatureElement.plainProtectedHeader shouldBe protectedHeaderBase64.decodeToByteArray(Base64UrlStrict)
+            signatureElement.plainSignature shouldBe signatureBase64.decodeToByteArray(Base64UrlStrict)
+            general.signatureInputs[index].decodeToString() shouldBe "$protectedHeaderBase64.$generalVectorPayload"
+        }
+
+        val reserialized = joseCompliantSerializer.encodeToString(general)
+
+        joseCompliantSerializer.decodeFromString(JsonObject.serializer(), reserialized) shouldBe generalVectorSource
+        general.toJwsFlattened().toJwsGeneral() shouldBe general
+    }
+
+    "flattened JWS keeps unprotected headers stable through serialization and general conversion" {
+        val protectedHeader = JwsHeader.Part(
+            algorithm = JwsAlgorithm.Signature.RS256,
+            type = "application/example+jws",
+            keyId = "protected-kid",
+        )
+        val unprotectedHeader = JwsHeader.Part(
+            contentType = "application/example+json",
+            certificateUrl = "https://example.com/cert.pem",
+        )
+        val payload = """{"iss":"https://issuer.example","sub":"alice"}""".encodeToByteArray()
+        val plainProtectedHeader = JwsProtectedHeaderSerializer.encodeToByteArray(protectedHeader)
+        var capturedSignatureInput: ByteArray? = null
+
+        val flattened = JwsFlattened.invoke(
+            protectedHeader = protectedHeader,
+            unprotectedHeader = unprotectedHeader,
+            payload = payload,
+        ) { signatureInput ->
+            capturedSignatureInput = signatureInput
+            byteArrayOf(1, 2, 3, 4)
+        }
+
+        capturedSignatureInput shouldBe JWS.getSignatureInput(plainProtectedHeader, payload)
+
+        val serialized = joseCompliantSerializer.encodeToString(flattened)
+        val reparsed = joseCompliantSerializer.decodeFromString<JwsFlattened>(serialized)
+
+        reparsed shouldBe flattened
+        with(joseCompliantSerializer) {
+            decodeFromString<JsonObject>(serialized) shouldBe decodeFromString<JsonObject>(encodeToString(reparsed))
+        }
+        val general = listOf(flattened).toJwsGeneral()
+
+        general.plainPayload shouldBe payload
+        general.jwsHeaders[0] shouldBe flattened.jwsHeader
+        general.signatures[0] shouldBe flattened.signature
+        general.signatureInputs[0] shouldBe flattened.signatureInput
+        general.toJwsFlattened() shouldBe listOf(flattened)
+    }
+
+    "empty protected header part is omitted from flattened/general JWS and signing input" {
+        val payload = """{"iss":"https://issuer.example","sub":"alice"}""".encodeToByteArray()
+        val emptyProtectedHeader = JwsHeader.Part()
+        val unprotectedHeader = JwsHeader.Part(
+            algorithm = JwsAlgorithm.Signature.RS256,
+            keyId = "kid-1",
+        )
+        val conformantWithoutProtected = JwsFlattened(
+            plainProtectedHeader = null,
+            unprotectedHeader = unprotectedHeader,
+            plainPayload = payload,
+            plainSignature = byteArrayOf(1, 2, 3, 4),
+        )
+        var capturedSignatureInput: ByteArray? = null
+
+        val flattened = JwsFlattened(
+            protectedHeader = emptyProtectedHeader,
+            unprotectedHeader = unprotectedHeader,
+            payload = payload,
+        ) { signatureInput ->
+            capturedSignatureInput = signatureInput
+            byteArrayOf(1, 2, 3, 4)
+        }
+        val general = listOf(flattened).toJwsGeneral()
+
+        flattened shouldBe conformantWithoutProtected
+        flattened.plainProtectedHeader shouldBe null
+        capturedSignatureInput shouldBe JWS.getSignatureInput(null, payload)
+        flattened.signatureInput shouldBe capturedSignatureInput
+        flattened.signatureInput shouldBe conformantWithoutProtected.signatureInput
+
+        val flattenedJson = joseCompliantSerializer.decodeFromString<JsonObject>(
+            joseCompliantSerializer.encodeToString(flattened)
+        )
+        flattenedJson.shouldNotContainKey(JWS.SerialNames.PROTECTED)
+
+        general.signatureElements.single().plainProtectedHeader shouldBe null
+        general.signatureInputs.single() shouldBe conformantWithoutProtected.signatureInput
+
+        val generalJson = joseCompliantSerializer.decodeFromString<JsonObject>(
+            joseCompliantSerializer.encodeToString(general)
+        )
+        generalJson[JWS.SerialNames.SIGNATURES]!!
+            .jsonArray
+            .single()
+            .shouldNotContainKey(JWS.SerialNames.PROTECTED)
+    }
+
+    "compact JWS keeps its exact string form and round-trips through flattened" {
+        val compactString = compactSerializationAt(0)
+        val compact = JwsCompact(compactString)
+
+        compact.jwsHeader.algorithm shouldBe JwsAlgorithm.Signature.RS256
+        compact.signature.shouldBeInstanceOf<CryptoSignature.RSA>()
+        compact.toString() shouldBe compactString
+
+        val serialized = joseCompliantSerializer.encodeToString(JwsCompactStringSerializer, compact)
+
+        serialized shouldBe "\"$compactString\""
+        joseCompliantSerializer.decodeFromString(JwsCompactStringSerializer, serialized) shouldBe compact
+
+        val flattened = compact.toJwsFlattened()
+
+        flattened.signatureInput shouldBe compact.signatureInput
+        flattened.toJwsCompact() shouldBe compact
+    }
+
+    "compact JWS invoke methods round-trip as three base64url segments" {
+        val compactPattern = Regex("[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+")
+        val compact = JwsCompact.invoke(
+            protectedHeader = JwsHeader(
+                algorithm = JwsAlgorithm.Signature.RS256,
+                keyId = "kid-1",
+                type = "application/example+jws",
+            ),
+            payload = """{"iss":"https://issuer.example","sub":"alice"}""".encodeToByteArray(),
+        ) {
+            byteArrayOf(1, 2, 3, 4)
+        }
+
+        val serialized = compact.toString()
+        val reparsed = JwsCompact(serialized)
+
+        compactPattern.matches(serialized) shouldBe true
+        reparsed shouldBe compact
+        reparsed.toString() shouldBe serialized
+
+        val jsonString = joseCompliantSerializer.encodeToString(JwsCompactStringSerializer, compact)
+            .removeSurrounding("\"")
+        compactPattern.matches(jsonString) shouldBe true
+    }
+
+    "compact JWS rejects padded base64url segments" {
+        val canonical = JwsCompact.invoke(
+            protectedHeader = JwsHeader(
+                algorithm = JwsAlgorithm.Signature.RS256,
+                keyId = "kid-1",
+            ),
+            payload = "x".encodeToByteArray(),
+        ) {
+            byteArrayOf(1, 2, 3, 4)
+        }.toString()
+        val (protectedSegment, payloadSegment, signatureSegment) = canonical.split('.')
+        val nonCanonical = buildString {
+            append(protectedSegment)
+            append('.')
+            append(payloadSegment.toPaddedBase64UrlVariant())
+            append('.')
+            append(signatureSegment.toPaddedBase64UrlVariant())
+        }
+
+        nonCanonical shouldNotBe canonical
+
+        val result = runCatching { JwsCompact(nonCanonical) }
+
+        result.isSuccess shouldBe false
+        result.shouldBeFailure().message.shouldContain("Trailing = are not supported")
+    }
+
+    "flattened JSON JWS rejects padded base64url members" {
+        val paddedProtectedHeaderResult = runCatching {
+            joseCompliantSerializer.decodeFromString<JwsFlattened>(
+                flattenedJson(protectedHeaderBase64 = "eyJhbGciOiJSUzI1NiJ9".toPaddedBase64UrlVariant())
+            )
+        }
+        val paddedPayloadResult = runCatching {
+            joseCompliantSerializer.decodeFromString<JwsFlattened>(
+                flattenedJson(payloadBase64 = "e30".toPaddedBase64UrlVariant())
+            )
+        }
+        val paddedSignatureResult = runCatching {
+            joseCompliantSerializer.decodeFromString<JwsFlattened>(
+                flattenedJson(signatureBase64 = "AQ".toPaddedBase64UrlVariant())
+            )
+        }
+
+        paddedProtectedHeaderResult.shouldBeRejectedPaddedBase64Url()
+        paddedPayloadResult.shouldBeRejectedPaddedBase64Url()
+        paddedSignatureResult.shouldBeRejectedPaddedBase64Url()
+    }
+
+    "general JSON JWS rejects padded base64url members" {
+        val paddedPayloadResult = runCatching {
+            joseCompliantSerializer.decodeFromString<JwsGeneral>(
+                generalJson(payloadBase64 = "e30".toPaddedBase64UrlVariant())
+            )
+        }
+        val paddedProtectedHeaderResult = runCatching {
+            joseCompliantSerializer.decodeFromString<JwsGeneral>(
+                generalJson(protectedHeaderBase64 = "eyJhbGciOiJSUzI1NiJ9".toPaddedBase64UrlVariant())
+            )
+        }
+        val paddedSignatureResult = runCatching {
+            joseCompliantSerializer.decodeFromString<JwsGeneral>(
+                generalJson(signatureBase64 = "AQ".toPaddedBase64UrlVariant())
+            )
+        }
+
+        paddedPayloadResult.shouldBeRejectedPaddedBase64Url()
+        paddedProtectedHeaderResult.shouldBeRejectedPaddedBase64Url()
+        paddedSignatureResult.shouldBeRejectedPaddedBase64Url()
+    }
+
+    "flattened and general JSON JWS reject explicitly empty protected headers" {
+        val flattenedResult = runCatching {
+            joseCompliantSerializer.decodeFromString<JwsFlattened>(
+                flattenedJson(
+                    protectedHeaderBase64 = "e30",
+                    headerJson = """{"alg":"RS256","kid":"kid-1"}""",
+                )
+            )
+        }
+        val generalResult = runCatching {
+            joseCompliantSerializer.decodeFromString<JwsGeneral>(
+                generalJson(
+                    protectedHeaderBase64 = "e30",
+                    headerJson = """{"alg":"RS256","kid":"kid-1"}""",
+                )
+            )
+        }
+
+        flattenedResult.shouldBeRejectedEmptyProtectedHeader()
+        generalResult.shouldBeRejectedEmptyProtectedHeader()
+    }
+
+    "general to flattened to compact preserves each single-signature view" {
+        val general = joseCompliantSerializer.decodeFromString<JwsGeneral>(generalVectorJson)
+        val flattened = general.toJwsFlattened()
+
+        flattened.size shouldBe general.signatureElements.size
+        flattened.forEachIndexed { index, entry ->
+            entry.jwsHeader shouldBe general.jwsHeaders[index]
+            entry.signature shouldBe general.signatures[index]
+            entry.signatureInput shouldBe general.signatureInputs[index]
+            entry.toJwsCompact().toString() shouldBe compactSerializationAt(index)
+        }
+    }
+
+    "appendSignature matches list-to-general conversion" {
+        val payload = """{"nonce":"1234"}""".encodeToByteArray()
+        val first = flattenedSample(
+            protectedHeader = JwsHeader.Part(
+                algorithm = JwsAlgorithm.Signature.RS256,
+                keyId = "kid-1",
+            ),
+            payload = payload,
+            plainSignature = byteArrayOf(0x01),
+        )
+        val second = flattenedSample(
+            protectedHeader = JwsHeader.Part(
+                algorithm = JwsAlgorithm.Signature.ES256,
+                keyId = "kid-2",
+            ),
+            payload = payload,
+            plainSignature = ByteArray(64) { (it + 1).toByte() },
+        )
+
+        val appended = JwsGeneral(listOf(first)).appendSignature(second)
+
+        appended.toJwsFlattened() shouldBe listOf(first, second)
+        appended shouldBe listOf(first, second).toJwsGeneral()
+    }
+
+    "general conversions reject empty and mismatched flattened inputs" {
+        val first = flattenedSample(
+            protectedHeader = JwsHeader.Part(algorithm = JwsAlgorithm.Signature.RS256),
+            payload = "payload-1".encodeToByteArray(),
+            plainSignature = byteArrayOf(1),
+        )
+        val second = flattenedSample(
+            protectedHeader = JwsHeader.Part(algorithm = JwsAlgorithm.Signature.RS256),
+            payload = "payload-2".encodeToByteArray(),
+            plainSignature = byteArrayOf(2),
+        )
+
+        val emptyResult = runCatching { emptyList<JwsFlattened>().toJwsGeneral() }
+        val listMismatchResult = runCatching { listOf(first, second).toJwsGeneral() }
+        val appendMismatchResult = runCatching { JwsGeneral(listOf(first)).appendSignature(second) }
+
+        emptyResult.isSuccess shouldBe false
+        emptyResult.shouldBeFailure() shouldBe IllegalArgumentException("General JWS requires at least one signature")
+
+        listMismatchResult.isSuccess shouldBe false
+        listMismatchResult.shouldBeFailure() shouldBe
+                IllegalArgumentException("Additional signed JWS payload must match existing payload")
+
+        appendMismatchResult.isSuccess shouldBe false
+        appendMismatchResult.shouldBeFailure() shouldBe
+                IllegalArgumentException("Additional signed JWS payload must match existing payload")
+    }
+
+    "compact conversion rejects missing protected header and malformed compact strings" {
+        val missingProtectedHeader = JwsFlattened(
+            plainProtectedHeader = null,
+            unprotectedHeader = JwsHeader.Part(keyId = "kid-1", algorithm = JwsAlgorithm.Signature.RSA.RS256),
+            plainPayload = "payload".encodeToByteArray(),
+            plainSignature = byteArrayOf(1),
+        )
+
+        val missingHeaderResult = runCatching { missingProtectedHeader.toJwsCompact() }
+        val missingPartResult = runCatching { JwsCompact("a.b") }
+        val extraPartResult = runCatching { JwsCompact("a.b.c.d") }
+        val invalidBase64Result = runCatching { JwsCompact("!!.e30.AQ") }
+
+        missingHeaderResult.isSuccess shouldBe false
+        missingHeaderResult.shouldBeFailure().shouldBeInstanceOf<IllegalArgumentException>()
+
+        missingPartResult.isSuccess shouldBe false
+        missingPartResult.shouldBeFailure().message.shouldContain("expected 3 parts, got 2")
+
+        extraPartResult.isSuccess shouldBe false
+        extraPartResult.shouldBeFailure().message.shouldContain("expected 3 parts, got 4")
+
+        invalidBase64Result.isSuccess shouldBe false
+        invalidBase64Result.shouldBeFailure().message.shouldContain("Invalid base64url content")
+    }
+
+    "raw-signature decoding rejects MAC algorithms" {
+        val result = runCatching {
+            JWS.getSignature(JwsAlgorithm.MAC.HS256, byteArrayOf(1, 2, 3))
+        }
+
+        result.isSuccess shouldBe false
+        result.shouldBeFailure().message.shouldContain("Unsupported algorithm")
+    }
+
+    "signature and general equality include unprotected headers" {
+        val protectedHeader = JwsProtectedHeaderSerializer.encodeToByteArray(
+            JwsHeader.Part(algorithm = JwsAlgorithm.Signature.RS256)
+        )
+        val signatureA = SignatureElement(
+            plainSignature = byteArrayOf(1),
+            plainProtectedHeader = protectedHeader,
+            unprotectedHeader = JwsHeader.Part(keyId = "kid-a"),
+        )
+        val signatureB = SignatureElement(
+            plainSignature = byteArrayOf(1),
+            plainProtectedHeader = protectedHeader,
+            unprotectedHeader = JwsHeader.Part(keyId = "kid-b"),
+        )
+
+        signatureA shouldNotBe signatureB
+
+        val generalA = JwsGeneral(
+            plainPayload = "payload".encodeToByteArray(),
+            signatureElements = listOf(signatureA),
+        )
+        val generalB = JwsGeneral(
+            plainPayload = "payload".encodeToByteArray(),
+            signatureElements = listOf(signatureB),
+        )
+
+        generalA shouldNotBe generalB
+    }
+
+    "sealed JWS serializer preserves the concrete JWS form" {
+        val compactValue = JwsCompact(compactSerializationAt(1))
+        val flattenedValue = flattenedSample(
+            protectedHeader = JwsHeader.Part(
+                algorithm = JwsAlgorithm.Signature.RS256,
+                type = "application/example+jws",
+            ),
+            unprotectedHeader = JwsHeader.Part(contentType = "application/example+json"),
+            payload = """{"sub":"alice"}""".encodeToByteArray(),
+            plainSignature = byteArrayOf(9, 8, 7, 6),
+        )
+        val generalValue = listOf(flattenedValue).toJwsGeneral()
+
+        val compactSerialized = joseCompliantSerializer.encodeToString(JWS.serializer(), compactValue)
+        val flattenedSerialized = joseCompliantSerializer.encodeToString(JWS.serializer(), flattenedValue)
+        val generalSerialized = joseCompliantSerializer.encodeToString(JWS.serializer(), generalValue)
+
+        joseCompliantSerializer.decodeFromString<JsonElement>(compactSerialized).shouldNotContainKey("type")
+        joseCompliantSerializer.decodeFromString<JsonElement>(flattenedSerialized).shouldNotContainKey("type")
+        joseCompliantSerializer.decodeFromString<JsonElement>(generalSerialized).shouldNotContainKey("type")
+
+        val compactDecoded = joseCompliantSerializer.decodeFromString<JWS>(compactSerialized)
+            .shouldBeInstanceOf<JwsCompact>()
+        val flattenedDecoded = joseCompliantSerializer.decodeFromString<JWS>(flattenedSerialized)
+            .shouldBeInstanceOf<JwsFlattened>()
+        val generalDecoded = joseCompliantSerializer.decodeFromString<JWS>(generalSerialized)
+            .shouldBeInstanceOf<JwsGeneral>()
+
+        compactDecoded shouldBe compactValue
+        flattenedDecoded shouldBe flattenedValue
+        generalDecoded.toJwsFlattened() shouldBe listOf(flattenedValue)
+    }
+
+    "sealed JWS serializer rejects ambiguous and incomplete JSON objects" {
+        val ambiguousResult = runCatching {
+            joseCompliantSerializer.decodeFromString<JWS>(
+                """{"payload":"e30","signature":"AQ","signatures":[{"signature":"AQ"}]}"""
+            )
+        }
+        val incompleteResult = runCatching {
+            joseCompliantSerializer.decodeFromString<JWS>("""{"payload":"e30"}""")
+        }
+        val arrayResult = runCatching {
+            joseCompliantSerializer.decodeFromString<JWS>("""[1,2,3]""")
+        }
+
+        ambiguousResult.isSuccess shouldBe false
+        ambiguousResult.shouldBeFailure().message.shouldContain("must not contain both")
+
+        incompleteResult.isSuccess shouldBe false
+        incompleteResult.shouldBeFailure().message.shouldContain("must contain 'signature' or 'signatures'")
+
+        arrayResult.isSuccess shouldBe false
+        arrayResult.shouldBeFailure().message.shouldContain("expected a compact string or JSON object")
+    }
+}
+
+private fun compactSerializationAt(index: Int): String {
+    val sourceSignature = generalVectorSignatures[index].jsonObject
+    val protectedHeaderBase64 = sourceSignature[JWS.SerialNames.PROTECTED]!!.jsonPrimitive.content
+    val signatureBase64 = sourceSignature[JWS.SerialNames.SIGNATURE]!!.jsonPrimitive.content
+    return "$protectedHeaderBase64.$generalVectorPayload.$signatureBase64"
+}
+
+private fun flattenedJson(
+    protectedHeaderBase64: String = "eyJhbGciOiJSUzI1NiJ9",
+    payloadBase64: String = "e30",
+    signatureBase64: String = "AQ",
+    headerJson: String? = null,
+): String = """
+    {"protected":"$protectedHeaderBase64","payload":"$payloadBase64","signature":"$signatureBase64"${headerJson?.let { ""","header":$it""" }.orEmpty()}}
+""".trimIndent()
+
+private fun generalJson(
+    protectedHeaderBase64: String = "eyJhbGciOiJSUzI1NiJ9",
+    payloadBase64: String = "e30",
+    signatureBase64: String = "AQ",
+    headerJson: String? = null,
+): String = """
+    {"payload":"$payloadBase64","signatures":[{"protected":"$protectedHeaderBase64","signature":"$signatureBase64"${headerJson?.let { ""","header":$it""" }.orEmpty()}}]}
+""".trimIndent()
+
+private fun flattenedSample(
+    protectedHeader: JwsHeader.Part,
+    payload: ByteArray,
+    plainSignature: ByteArray,
+    unprotectedHeader: JwsHeader.Part? = null,
+): JwsFlattened = JwsFlattened(
+    plainProtectedHeader = JwsProtectedHeaderSerializer.encodeToByteArray(protectedHeader),
+    unprotectedHeader = unprotectedHeader,
+    plainPayload = payload,
+    plainSignature = plainSignature,
+)
+
+private fun String.toPaddedBase64UrlVariant(): String = when (length % 2) {
+    1 -> "${this}=="
+    else -> "${this}="
+}
+
+private fun Result<*>.shouldBeRejectedPaddedBase64Url() {
+    isSuccess shouldBe false
+    val failure = shouldBeFailure()
+    failure.message.orEmpty().shouldContain("Decoding failed")
+    failure.cause shouldNotBe null
+    failure.cause!!.message.orEmpty().shouldContain("Trailing = are not supported")
+}
+
+private fun Result<*>.shouldBeRejectedEmptyProtectedHeader() {
+    isSuccess shouldBe false
+    shouldBeFailure().message.orEmpty().shouldContain("must be absent when it would otherwise be empty")
+}
+
+private fun JsonElement.shouldNotContainKey(key: String) {
+    when (this) {
+        is JsonObject -> {
+            keys.contains(key) shouldBe false
+            values.forEach { it.shouldNotContainKey(key) }
+        }
+
+        is JsonArray -> forEach { it.shouldNotContainKey(key) }
+        else -> Unit
+    }
+}

--- a/indispensable-josef/src/commonTest/kotlin/at/asitplus/signum/indispensable/josef/JwsSignedRegressionTest.kt
+++ b/indispensable-josef/src/commonTest/kotlin/at/asitplus/signum/indispensable/josef/JwsSignedRegressionTest.kt
@@ -1,0 +1,205 @@
+@file:Suppress("DEPRECATION")
+
+package at.asitplus.signum.indispensable.josef
+
+import at.asitplus.signum.indispensable.CryptoSignature
+import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
+import at.asitplus.testballoon.invoke
+import de.infix.testBalloon.framework.core.testSuite
+import io.kotest.engine.runBlocking
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldEndWith
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+
+val JwsSignedRegressionTest by testSuite {
+    "JwsCompact.invoke signs the protected-header bytes derived from JwsHeader.toPart" {
+        val header = JwsHeader(
+            algorithm = JwsAlgorithm.Signature.RS256,
+            type = "application/example+jws",
+            keyId = "kid-1",
+        )
+        val payload = """{"iss":"https://issuer.example","sub":"alice"}""".encodeToByteArray()
+        var capturedInput: ByteArray? = null
+
+        val compact = JwsCompact.invoke(
+            protectedHeader = header,
+            payload = payload,
+        ) { signingInput ->
+            capturedInput = signingInput
+            byteArrayOf(1, 2, 3, 4)
+        }
+
+        val expectedProtectedHeader = JwsProtectedHeaderSerializer.encodeToByteArray(header.toPart())
+
+        compact.plainProtectedHeader shouldBe expectedProtectedHeader
+        capturedInput shouldBe JWS.getSignatureInput(expectedProtectedHeader, payload)
+        compact.signatureInput shouldBe capturedInput
+    }
+
+    "legacy compact serialization matches JwsCompact for RS256" {
+        val regressionCase = compactRegressionCase(
+            protectedHeader = JwsHeader.Part(
+                algorithm = JwsAlgorithm.Signature.RS256,
+                type = "JWT",
+                keyId = "kid-rs256",
+            ),
+            payload = """{"iss":"https://issuer.example","aud":"example"}""".encodeToByteArray(),
+            plainSignature = byteArrayOf(5, 4, 3, 2, 1),
+        )
+
+        regressionCase.legacy.header shouldBe regressionCase.compact.jwsHeader
+        regressionCase.legacy.signature shouldBe regressionCase.compact.signature
+        regressionCase.legacy.plainSignatureInput shouldBe regressionCase.compact.signatureInput
+
+        val compactJson = joseCompliantSerializer.encodeToString(JwsCompactStringSerializer, regressionCase.compact)
+
+        compactJson.removeSurrounding("\"") shouldBe regressionCase.legacy.serialize()
+        joseCompliantSerializer.decodeFromString(
+            JwsCompactStringSerializer,
+            compactJson
+        ) shouldBe regressionCase.compact
+        JwsSigned.deserialize(regressionCase.legacy.serialize()).getOrThrow() shouldBe regressionCase.legacy
+    }
+
+    "JwsCompact.parse decodes compact serialization and typed payload" {
+        val typedPayload = JsonObject(
+            mapOf(
+                "iss" to JsonPrimitive("https://issuer.example"),
+                "sub" to JsonPrimitive("alice"),
+            )
+        )
+        val regressionCase = compactRegressionCase(
+            protectedHeader = JwsHeader.Part(
+                algorithm = JwsAlgorithm.Signature.RS256,
+                type = "JWT",
+            ),
+            payload = joseCompliantSerializer.encodeToString(JsonObject.serializer(), typedPayload).encodeToByteArray(),
+            plainSignature = byteArrayOf(1, 2, 3, 4),
+        )
+
+        val (parsedCompact, parsedPayload) = JwsCompact.parse<JsonObject>(regressionCase.compact.toString())
+            .getOrThrow()
+
+        parsedCompact shouldBe regressionCase.compact
+        parsedCompact.jwsHeader shouldBe regressionCase.compact.jwsHeader
+        parsedPayload shouldBe typedPayload
+    }
+
+    "typed payload decoding matches between JwsSigned and JwsCompact" {
+        val typedPayload = JsonObject(
+            mapOf(
+                "iss" to JsonPrimitive("https://issuer.example"),
+                "sub" to JsonPrimitive("alice"),
+                "admin" to JsonPrimitive(true),
+            )
+        )
+        val payload = joseCompliantSerializer.encodeToString(JsonObject.serializer(), typedPayload).encodeToByteArray()
+        val regressionCase = compactRegressionCase(
+            protectedHeader = JwsHeader.Part(
+                algorithm = JwsAlgorithm.Signature.RS256,
+                type = "application/example+jwt",
+            ),
+            payload = payload,
+            plainSignature = byteArrayOf(9, 8, 7, 6),
+        )
+
+        val legacyTyped = JwsSigned.deserialize(
+            deserializationStrategy = JsonObject.serializer(),
+            it = regressionCase.legacy.serialize(),
+            json = joseCompliantSerializer,
+        ).getOrThrow()
+
+        legacyTyped.header shouldBe regressionCase.compact.jwsHeader
+        legacyTyped.payload shouldBe regressionCase.compact.getPayload(JsonObject.serializer()).getOrThrow()
+        legacyTyped.signature shouldBe regressionCase.compact.signature
+        legacyTyped.plainSignatureInput shouldBe regressionCase.compact.signatureInput
+    }
+
+    "single-signature conversion path preserves the JwsSigned view" {
+        val regressionCase = compactRegressionCase(
+            protectedHeader = JwsHeader.Part(
+                algorithm = JwsAlgorithm.Signature.RS256,
+                keyId = "kid-general",
+            ),
+            payload = """{"nonce":"1234"}""".encodeToByteArray(),
+            plainSignature = byteArrayOf(0x2a),
+        )
+
+        val flattened = regressionCase.compact.toJwsFlattened()
+        val general = listOf(flattened).toJwsGeneral()
+
+        flattened.jwsHeader shouldBe regressionCase.legacy.header
+        flattened.signature shouldBe regressionCase.legacy.signature
+        flattened.signatureInput shouldBe regressionCase.legacy.plainSignatureInput
+
+        general.jwsHeaders[0] shouldBe regressionCase.legacy.header
+        general.signatures[0] shouldBe regressionCase.legacy.signature
+        general.signatureInputs[0] shouldBe regressionCase.legacy.plainSignatureInput
+    }
+
+    "empty payload keeps the compact separator for both APIs" {
+        val regressionCase = compactRegressionCase(
+            protectedHeader = JwsHeader.Part(
+                algorithm = JwsAlgorithm.Signature.RS256,
+            ),
+            payload = byteArrayOf(),
+            plainSignature = byteArrayOf(1),
+        )
+
+        regressionCase.legacy.plainSignatureInput.decodeToString().shouldEndWith(".")
+        regressionCase.compact.signatureInput.decodeToString().shouldEndWith(".")
+        regressionCase.legacy.serialize() shouldBe regressionCase.compact.toString()
+
+        JwsSigned.deserialize(regressionCase.legacy.serialize()).getOrThrow().payload shouldBe byteArrayOf()
+    }
+
+    "ES256 compact signatures are decoded as EC signatures in both APIs" {
+        val plainSignature = ByteArray(64) { (it + 1).toByte() }
+        val regressionCase = compactRegressionCase(
+            protectedHeader = JwsHeader.Part(
+                algorithm = JwsAlgorithm.Signature.ES256,
+                type = "application/example+jws",
+            ),
+            payload = """{"sub":"alice"}""".encodeToByteArray(),
+            plainSignature = plainSignature,
+        )
+
+        val legacy = JwsSigned.deserialize(regressionCase.legacy.serialize()).getOrThrow()
+
+        legacy.header.algorithm shouldBe JwsAlgorithm.Signature.ES256
+        legacy.signature shouldBe regressionCase.compact.signature
+        legacy.signature.rawByteArray shouldBe plainSignature
+        legacy.signature.shouldBeInstanceOf<CryptoSignature.EC.DefiniteLength>()
+        regressionCase.compact.signature.shouldBeInstanceOf<CryptoSignature.EC.DefiniteLength>()
+    }
+}
+
+private data class CompactRegressionCase(
+    val legacy: JwsSigned<ByteArray>,
+    val compact: JwsCompact,
+)
+
+private fun compactRegressionCase(
+    protectedHeader: JwsHeader.Part,
+    payload: ByteArray,
+    plainSignature: ByteArray,
+): CompactRegressionCase {
+    val header = JwsHeader.fromParts(protectedHeader, null)
+    val compact = JwsCompact(
+        plainProtectedHeader = JwsProtectedHeaderSerializer.encodeToByteArray(protectedHeader),
+        plainPayload = payload,
+        plainSignature = plainSignature,
+    )
+
+    return CompactRegressionCase(
+        legacy = JwsSigned(
+            header = header,
+            payload = payload,
+            signature = JWS.getSignature(header.algorithm, plainSignature),
+            plainSignatureInput = JwsSigned.prepareJwsSignatureInput(header, payload),
+        ),
+        compact = compact,
+    )
+}

--- a/indispensable-josef/src/commonTest/kotlin/at/asitplus/signum/indispensable/josef/JwsTypedTest.kt
+++ b/indispensable-josef/src/commonTest/kotlin/at/asitplus/signum/indispensable/josef/JwsTypedTest.kt
@@ -1,0 +1,128 @@
+package at.asitplus.signum.indispensable.josef
+
+import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
+import at.asitplus.signum.indispensable.josef.typed
+import at.asitplus.testballoon.invoke
+import de.infix.testBalloon.framework.core.testSuite
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+
+val payload = JsonObject(
+    content = mapOf(
+        "issuer" to JsonPrimitive("https://issuer.example"),
+        "subject" to JsonPrimitive("alice"),
+        "admin" to JsonPrimitive(true),
+    )
+)
+
+val JwsTypedTest by testSuite {
+    "compact typed wrappers can be built from payloads and reopened from compact JWS" {
+        val header = JwsHeader(
+            algorithm = JwsAlgorithm.Signature.RS256,
+            type = "application/example+jws",
+            keyId = "kid-compact",
+        )
+        val expectedPayload = joseCompliantSerializer.encodeToString<JsonObject>(payload).encodeToByteArray()
+        val expectedProtectedHeader = JwsProtectedHeaderSerializer.encodeToByteArray(header.toPart())
+        var capturedSignatureInput: ByteArray? = null
+
+        val typedCompact: JwsCompactTyped<JsonObject> = JwsTyped(
+            protectedHeader = header,
+            payload = payload,
+        ) { signatureInput ->
+            capturedSignatureInput = signatureInput
+            byteArrayOf(1, 2, 3, 4)
+        }
+
+        typedCompact.payload shouldBe payload
+        typedCompact.jws.plainPayload shouldBe expectedPayload
+        capturedSignatureInput shouldBe JWS.getSignatureInput(expectedProtectedHeader, expectedPayload)
+        typedCompact.toString() shouldBe typedCompact.jws.toString()
+
+        typedCompact.jws.typed<JsonObject, JwsCompact>() shouldBe typedCompact
+        JwsTyped<JsonObject>(typedCompact.toString()) shouldBe typedCompact
+    }
+
+    "compact and flattened typed wrappers convert without changing the payload view" {
+        val typedCompact: JwsCompactTyped<JsonObject> = JwsTyped(
+            protectedHeader = JwsHeader(
+                algorithm = JwsAlgorithm.Signature.RS256,
+                keyId = "kid-roundtrip",
+            ),
+            payload = payload,
+        ) {
+            byteArrayOf(9, 8, 7, 6)
+        }
+
+        val typedFlattened = typedCompact.toJwsFlattenedTyped()
+        val reparsedCompact = typedFlattened.toJwsCompactTyped()
+
+        typedFlattened.payload shouldBe payload
+        typedFlattened.jws shouldBe typedCompact.jws.toJwsFlattened()
+        reparsedCompact shouldBe typedCompact
+    }
+
+    "flattened typed wrappers can be created from header fragments and existing flattened JWS" {
+        val protectedHeader = JwsHeader.Part(
+            algorithm = JwsAlgorithm.Signature.RS256,
+            type = "application/example+jws",
+        )
+        val unprotectedHeader = JwsHeader.Part(
+            keyId = "kid-flattened",
+            contentType = "application/example+json",
+        )
+        val expectedPayload = joseCompliantSerializer.encodeToString<JsonObject>(payload).encodeToByteArray()
+        val expectedProtectedHeader = JwsProtectedHeaderSerializer.encodeToByteArrayOrNull(protectedHeader)
+        var capturedSignatureInput: ByteArray? = null
+
+        val typedFlattened: JwsFlattenedTyped<JsonObject> = JwsTyped(
+            protectedHeader = protectedHeader,
+            unprotectedHeader = unprotectedHeader,
+            payload = payload,
+        ) { signatureInput ->
+            capturedSignatureInput = signatureInput
+            byteArrayOf(4, 3, 2, 1)
+        }
+
+        typedFlattened.payload shouldBe payload
+        typedFlattened.jws.plainPayload shouldBe expectedPayload
+        typedFlattened.jws.unprotectedHeader shouldBe unprotectedHeader
+        capturedSignatureInput shouldBe JWS.getSignatureInput(expectedProtectedHeader, expectedPayload)
+        typedFlattened.toString() shouldBe typedFlattened.jws.toString()
+
+        typedFlattened.jws.typed<JsonObject, JwsFlattened>() shouldBe typedFlattened
+    }
+
+    "general typed wrappers can be assembled from flattened signatures and expanded again" {
+        val first: JwsFlattenedTyped<JsonObject> = JwsTyped(
+            protectedHeader = JwsHeader.Part(
+                algorithm = JwsAlgorithm.Signature.RS256,
+                type = "application/example+jws",
+            ),
+            unprotectedHeader = JwsHeader.Part(keyId = "kid-1"),
+            payload = payload,
+        ) {
+            byteArrayOf(1, 1, 1, 1)
+        }
+        val second: JwsFlattenedTyped<JsonObject> = JwsTyped(
+            protectedHeader = JwsHeader.Part(
+                algorithm = JwsAlgorithm.Signature.RS256,
+                type = "application/example+jws",
+            ),
+            unprotectedHeader = JwsHeader.Part(keyId = "kid-2"),
+            payload = payload,
+        ) {
+            byteArrayOf(2, 2, 2, 2)
+        }
+
+        val typedGeneral: JwsGeneralTyped<JsonObject> = JwsTyped(listOf(first.jws, second.jws))
+
+        typedGeneral.payload shouldBe payload
+        typedGeneral.jws shouldBe listOf(first.jws, second.jws).toJwsGeneral()
+        typedGeneral.toString() shouldBe typedGeneral.jws.toString()
+        typedGeneral.toJwsFlattenedTyped() shouldBe listOf(first, second)
+
+        typedGeneral.jws.typed<JsonObject, JwsGeneral>() shouldBe typedGeneral
+    }
+}

--- a/indispensable-josef/src/commonTest/kotlin/at/asitplus/signum/indispensable/josef/KeyAttestationJwtTest.kt
+++ b/indispensable-josef/src/commonTest/kotlin/at/asitplus/signum/indispensable/josef/KeyAttestationJwtTest.kt
@@ -1,0 +1,37 @@
+package at.asitplus.signum.indispensable.josef
+
+import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
+import at.asitplus.testballoon.invoke
+import de.infix.testBalloon.framework.core.testSuite
+import io.kotest.matchers.shouldBe
+import kotlin.time.Instant
+
+val KeyAttestationJwtTest by testSuite {
+    "KeyAttestationJwt roundtrips through ExperimentalKeyAtt" {
+        val keyJson = """
+            {
+              "kty": "EC",
+              "use": "sig",
+              "crv": "P-256",
+              "x": "18wHLeIgW9wVN6VD1Txgpqy2LszYkMf6J8njVAibvhM",
+              "y": "-V4dS4UaLMgP_4fY4j8ir7cl1TXlFdAgcx55o7TkcSA"
+            }
+        """.trimIndent()
+        val original = KeyAttestationJwt(
+            issuer = "https://issuer.example.com",
+            subject = "wallet-instance",
+            issuedAt = Instant.fromEpochSeconds(1710000000),
+            attestedKeys = listOf(joseCompliantSerializer.decodeFromString(keyJson)),
+            keyStorage = listOf("secure_element"),
+            userAuthentication = listOf("local_user_authentication"),
+            certification = "https://example.com/certification",
+        )
+        val serialized = joseCompliantSerializer.encodeToString(original)
+        val experimental = joseCompliantSerializer.decodeFromString<ExperimentalKeyAtt>(serialized)
+        val roundTripped = joseCompliantSerializer.decodeFromString<KeyAttestationJwt>(
+            joseCompliantSerializer.encodeToString(experimental)
+        )
+
+        roundTripped shouldBe original
+    }
+}

--- a/indispensable-josef/src/commonTest/kotlin/at/asitplus/signum/indispensable/josef/UnknownKeyWrapperTest.kt
+++ b/indispensable-josef/src/commonTest/kotlin/at/asitplus/signum/indispensable/josef/UnknownKeyWrapperTest.kt
@@ -26,12 +26,12 @@ val UnknownKeyWrapperTest by testSuite {
                 issuer = "issuer",
                 subject = "subject",
             ),
-            unknownKeys = mapOf(
+            unknownKeys = JsonObject(mapOf(
                 "custom_string" to JsonPrimitive("custom"),
                 "custom_object" to buildJsonObject {
                     put("flag", true)
                 },
-            ),
+            )),
         )
 
         val encoded = joseCompliantSerializer.encodeToJsonElement(serializer, decoded)
@@ -59,7 +59,7 @@ val UnknownKeyWrapperTest by testSuite {
                 algorithm = JwsAlgorithm.Signature.ES256,
                 keyId = "did:example:signer",
             ),
-            unknownKeys = mapOf("private_claim" to JsonPrimitive("value")),
+            unknownKeys = JsonObject(mapOf("private_claim" to JsonPrimitive("value"))),
         )
     }
 
@@ -92,7 +92,7 @@ val UnknownKeyWrapperTest by testSuite {
                     baseStructure = JwsHeader(
                         algorithm = JwsAlgorithm.Signature.ES256,
                     ),
-                    unknownKeys = mapOf("alg" to JsonPrimitive("HS256")),
+                    unknownKeys = JsonObject(mapOf("alg" to JsonPrimitive("HS256"))),
                 ),
             )
         }.shouldBeFailure().message shouldBe "Encoding failed"

--- a/indispensable-josef/src/commonTest/kotlin/at/asitplus/signum/indispensable/josef/UnknownKeyWrapperTest.kt
+++ b/indispensable-josef/src/commonTest/kotlin/at/asitplus/signum/indispensable/josef/UnknownKeyWrapperTest.kt
@@ -63,6 +63,25 @@ val UnknownKeyWrapperTest by testSuite {
         )
     }
 
+    "getParameter decodes unknown keys as the requested type" {
+        val decoded = joseCompliantSerializer.decodeFromString(
+            JsonWebTokenAllKeys.serializer(),
+            """
+                {
+                  "iss": "issuer",
+                  "custom_string": "custom",
+                  "custom_object": { "flag": true }
+                }
+            """.trimIndent()
+        )
+
+        decoded.getParameter<String>("custom_string") shouldBe "custom"
+        decoded.getParameter<JsonObject>("custom_object") shouldBe buildJsonObject {
+            put("flag", true)
+        }
+        decoded.getParameter<String>("missing") shouldBe null
+    }
+
     "encoding rejects unknown keys that collide with known JOSE names" {
         val serializer = JwsHeaderAllKeysSerializer
 

--- a/indispensable-josef/src/commonTest/kotlin/at/asitplus/signum/indispensable/josef/UnknownKeyWrapperTest.kt
+++ b/indispensable-josef/src/commonTest/kotlin/at/asitplus/signum/indispensable/josef/UnknownKeyWrapperTest.kt
@@ -1,0 +1,81 @@
+package at.asitplus.signum.indispensable.josef
+
+import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
+import at.asitplus.testballoon.invoke
+import de.infix.testBalloon.framework.core.testSuite
+import io.kotest.matchers.result.shouldBeFailure
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.json.*
+
+val UnknownKeyWrapperTest by testSuite {
+    "generic wrapper serializer preserves unknown JWT claims" {
+        val serializer = JsonWebTokenAllKeysSerializer
+        val json = """
+            {
+              "iss": "issuer",
+              "sub": "subject",
+              "custom_string": "custom",
+              "custom_object": { "flag": true }
+            }
+        """.trimIndent()
+
+        val decoded = joseCompliantSerializer.decodeFromString(serializer, json)
+
+        decoded shouldBe JsonWebTokenAllKeys(
+            baseStructure = JsonWebToken(
+                issuer = "issuer",
+                subject = "subject",
+            ),
+            unknownKeys = mapOf(
+                "custom_string" to JsonPrimitive("custom"),
+                "custom_object" to buildJsonObject {
+                    put("flag", true)
+                },
+            ),
+        )
+
+        val encoded = joseCompliantSerializer.encodeToJsonElement(serializer, decoded)
+
+        joseCompliantSerializer.decodeFromJsonElement<JsonWebToken>(encoded) shouldBe decoded.baseStructure
+        encoded shouldBe joseCompliantSerializer.encodeToJsonElement(
+            mapOf(
+                "iss" to JsonPrimitive("issuer"),
+                "sub" to JsonPrimitive("subject"),
+                "custom_string" to JsonPrimitive("custom"),
+                "custom_object" to buildJsonObject {
+                    put("flag", true)
+                },
+            ),
+        )
+    }
+
+    "JwsHeaderAllKeys serializes with the concrete wrapper serializer" {
+        val json = """{"alg":"ES256","kid":"did:example:signer","private_claim":"value"}"""
+
+        val decoded = joseCompliantSerializer.decodeFromString(JwsHeaderAllKeys.serializer(), json)
+
+        decoded shouldBe JwsHeaderAllKeys(
+            baseStructure = JwsHeader(
+                algorithm = JwsAlgorithm.Signature.ES256,
+                keyId = "did:example:signer",
+            ),
+            unknownKeys = mapOf("private_claim" to JsonPrimitive("value")),
+        )
+    }
+
+    "encoding rejects unknown keys that collide with known JOSE names" {
+        val serializer = JwsHeaderAllKeysSerializer
+
+        runCatching {
+            joseCompliantSerializer.encodeToJsonElement(
+                serializer,
+                JwsHeaderAllKeys(
+                    baseStructure = JwsHeader(
+                        algorithm = JwsAlgorithm.Signature.ES256,
+                    ),
+                    unknownKeys = mapOf("alg" to JsonPrimitive("HS256")),
+                ),
+            )
+        }.shouldBeFailure().message shouldBe "Encoding failed"
+    }
+}

--- a/indispensable-josef/src/jvmTest/kotlin/at/asitplus/signum/indispensable/josef/JwsJvmTest.kt
+++ b/indispensable-josef/src/jvmTest/kotlin/at/asitplus/signum/indispensable/josef/JwsJvmTest.kt
@@ -1,0 +1,117 @@
+package at.asitplus.signum.indispensable.josef
+
+import at.asitplus.signum.indispensable.ECCurve
+import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
+import at.asitplus.signum.indispensable.toJcaPublicKey
+import at.asitplus.signum.supreme.sign.Signer
+import at.asitplus.signum.supreme.signature
+import at.asitplus.testballoon.invoke
+import at.asitplus.testballoon.withFixtureGenerator
+import com.nimbusds.jose.JWSObject
+import com.nimbusds.jose.JWSObjectJSON
+import com.nimbusds.jose.crypto.ECDSAVerifier
+import de.infix.testBalloon.framework.core.testSuite
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.shouldBe
+import java.security.interfaces.ECPublicKey
+
+val JwsJvmTest by testSuite {
+
+    class Context {
+        val payload = """{"iss":"https://issuer.example","sub":"alice"}""".encodeToByteArray()
+
+        val signer1 = Signer.Ephemeral {
+            ec { curve = ECCurve.SECP_256_R_1 }
+        }.getOrThrow()
+
+        val signer2 = Signer.Ephemeral {
+            ec { curve = ECCurve.SECP_256_R_1 }
+        }.getOrThrow()
+
+        val verifier1 = ECDSAVerifier(signer1.publicKey.toJcaPublicKey().getOrThrow() as ECPublicKey)
+        val verifier2 = ECDSAVerifier(signer2.publicKey.toJcaPublicKey().getOrThrow() as ECPublicKey)
+
+        fun signerFor(signer: Signer): suspend (ByteArray) -> ByteArray = { input ->
+            signer.sign(input).signature.rawByteArray
+        }
+    }
+
+    withFixtureGenerator(::Context) - {
+
+        "compact JWS can be encoded and verified by Nimbus" { it ->
+            val compact = JwsCompact.invoke(
+                protectedHeader = JwsHeader(
+                    algorithm = it.signer1.signatureAlgorithm.toJwsAlgorithm().getOrThrow(),
+                    keyId = "kid-1",
+                    type = "application/example+jws",
+                ),
+                payload = it.payload,
+                signer = it.signerFor(it.signer1),
+            )
+
+            val serialized = compact.toString()
+            val parsed = JWSObject.parse(serialized)
+
+            parsed.verify(it.verifier1).shouldBeTrue()
+            parsed.header.keyID shouldBe "kid-1"
+            compact.jwsHeader shouldBe JwsHeader.fromParts(compact.plainProtectedHeader, null)
+        }
+
+        "flattened JWS can be serialized and verified by Nimbus" { it ->
+            val flattened = JwsFlattened.invoke(
+                protectedHeader = JwsHeader.Part(
+                    algorithm = it.signer1.signatureAlgorithm.toJwsAlgorithm().getOrThrow(),
+                    type = "application/example+jws",
+                ),
+                unprotectedHeader = JwsHeader.Part(keyId = "kid-1"),
+                payload = it.payload,
+                signer = it.signerFor(it.signer1),
+            )
+
+            val serialized = joseCompliantSerializer.encodeToString(JwsFlattened.serializer(), flattened)
+            val parsed = JWSObjectJSON.parse(serialized)
+
+            parsed.signatures.size shouldBe 1
+            parsed.signatures.single().verify(it.verifier1).shouldBeTrue()
+            parsed.signatures.single().header.keyID shouldBe null
+            parsed.signatures.single().unprotectedHeader.keyID shouldBe "kid-1"
+            flattened.jwsHeader shouldBe JwsHeader.fromParts(
+                flattened.plainProtectedHeader,
+                flattened.unprotectedHeader
+            )
+        }
+
+        "general JWS can be serialized and verified by Nimbus" { it ->
+            val flattened1 = JwsFlattened.invoke(
+                protectedHeader = JwsHeader.Part(
+                    algorithm = it.signer1.signatureAlgorithm.toJwsAlgorithm().getOrThrow(),
+                ),
+                unprotectedHeader = JwsHeader.Part(keyId = "kid-1"),
+                payload = it.payload,
+                signer = it.signerFor(it.signer1),
+            )
+            val flattened2 = JwsFlattened.invoke(
+                protectedHeader = JwsHeader.Part(
+                    algorithm = it.signer2.signatureAlgorithm.toJwsAlgorithm().getOrThrow(),
+                ),
+                unprotectedHeader = JwsHeader.Part(keyId = "kid-2"),
+                payload = it.payload,
+                signer = it.signerFor(it.signer2),
+            )
+
+            val general = JwsGeneral.invoke(listOf(flattened1, flattened2))
+            val serialized = joseCompliantSerializer.encodeToString(JwsGeneral.serializer(), general)
+            val parsed = JWSObjectJSON.parse(serialized)
+
+            parsed.signatures.size shouldBe 2
+            parsed.signatures[0].verify(it.verifier1).shouldBeTrue()
+            parsed.signatures[1].verify(it.verifier2).shouldBeTrue()
+            parsed.signatures[0].header.keyID shouldBe null
+            parsed.signatures[1].header.keyID shouldBe null
+            parsed.signatures[0].unprotectedHeader.keyID shouldBe "kid-1"
+            parsed.signatures[1].unprotectedHeader.keyID shouldBe "kid-2"
+            general.jwsHeaders[0] shouldBe flattened1.jwsHeader
+            general.jwsHeaders[1] shouldBe flattened2.jwsHeader
+        }
+    }
+}

--- a/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/io/Encoding.kt
+++ b/indispensable/src/commonMain/kotlin/at/asitplus/signum/indispensable/io/Encoding.kt
@@ -65,35 +65,45 @@ open class TransformingSerializerTemplate<ValueT, EncodedT>
 }
 
 /** De-/serializes Base64 strings to/from [ByteArray] */
-object ByteArrayBase64Serializer: TransformingSerializerTemplate<ByteArray, String>(
+object ByteArrayBase64Serializer : TransformingSerializerTemplate<ByteArray, String>(
     parent = String.serializer(),
     encodeAs = { it.encodeToString(Base64Strict) },
     decodeAs = { it.decodeToByteArray(Base64Strict) }
 )
 
 /** De-/serializes Base64Url strings to/from [ByteArray] */
-object ByteArrayBase64UrlSerializer: TransformingSerializerTemplate<ByteArray, String>(
+object ByteArrayBase64UrlSerializer : TransformingSerializerTemplate<ByteArray, String>(
     parent = String.serializer(),
     encodeAs = { it.encodeToString(Base64UrlStrict) },
     decodeAs = { it.decodeToByteArray(Base64UrlStrict) }
 )
 
+/** De-/serializes Base64Url strings to/from [ByteArray] rejecting padded strings for protocols that require unpadded Base64Url such as RFC7515 */
+object ByteArrayBase64UrlNoPaddingSerializer : TransformingSerializerTemplate<ByteArray, String>(
+    parent = String.serializer(),
+    encodeAs = { it.encodeToString(Base64UrlStrict) },
+    decodeAs = {
+        require(!it.contains("=")) { "Trailing = are not supported" }
+        it.decodeToByteArray(Base64UrlStrict)
+    }
+)
+
 /** De-/serializes X509Certificate as Base64Url-encoded String */
-object X509CertificateBase64UrlSerializer: TransformingSerializerTemplate<X509Certificate, ByteArray>(
+object X509CertificateBase64UrlSerializer : TransformingSerializerTemplate<X509Certificate, ByteArray>(
     parent = ByteArrayBase64UrlSerializer,
     encodeAs = X509Certificate::encodeToDer,
     decodeAs = { X509Certificate.decodeFromDer(it) } // workaround iOS compilation bug KT-71498
 )
 
 /** De-/serializes X509Certificate as Base64-encoded String */
-object X509CertificateBase64Serializer: TransformingSerializerTemplate<X509Certificate, ByteArray>(
+object X509CertificateBase64Serializer : TransformingSerializerTemplate<X509Certificate, ByteArray>(
     parent = ByteArrayBase64Serializer,
     encodeAs = X509Certificate::encodeToDer,
     decodeAs = { X509Certificate.decodeFromDer(it) } // workaround iOS compilation bug KT-71498
 )
 
 /** De-/serializes a public key as a Base64Url-encoded IOS encoding public key */
-object IosPublicKeySerializer: TransformingSerializerTemplate<CryptoPublicKey, ByteArray>(
+object IosPublicKeySerializer : TransformingSerializerTemplate<CryptoPublicKey, ByteArray>(
     parent = ByteArrayBase64UrlSerializer,
     encodeAs = CryptoPublicKey::iosEncoded,
     decodeAs = CryptoPublicKey::fromIosEncoded)
@@ -115,9 +125,9 @@ sealed class ListSerializerTemplate<ValueT>(
 }
 
 /** De-/serializes X509Certificate as collection of Base64Url-encoded Strings */
-object CertificateChainBase64UrlSerializer: ListSerializerTemplate<X509Certificate>(
+object CertificateChainBase64UrlSerializer : ListSerializerTemplate<X509Certificate>(
     using = X509CertificateBase64UrlSerializer)
 
 /** De-/serializes X509Certificate as collection of Base64-encoded Strings */
-object CertificateChainBase64Serializer: ListSerializerTemplate<X509Certificate>(
+object CertificateChainBase64Serializer : ListSerializerTemplate<X509Certificate>(
     using = X509CertificateBase64Serializer)


### PR DESCRIPTION
Adds generic wrapper to handle unknown keys which may be present in all json structures as 'private parameters' ([JWS for example](https://www.rfc-editor.org/rfc/rfc7515.html#section-4.3))
and an at-runtime get function.

Added `JwsHeader` and `JsonWebToken` as example usecases. Also looking for better names.
Might also be able to replace/move out domain specific parameters in the base classes which would allow null-checks on init where applicable. See `KeyAttestationJwt`