### PR TITLE
Feature/jws typed serializer

### DIFF
--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/Jws.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/Jws.kt
@@ -44,7 +44,6 @@ sealed class JWS {
     /**
      * Find correct serializer at compile time
      */
-    @Suppress("unused")
     inline fun <reified P> getPayload(serialFormat: SerialFormat = joseCompliantSerializer): KmmResult<P> =
         getPayload(serialFormat.serializersModule.serializer(), serialFormat)
 

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsTyped.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsTyped.kt
@@ -1,13 +1,26 @@
 package at.asitplus.signum.indispensable.josef
 
+import at.asitplus.signum.indispensable.io.TransformingSerializerTemplate
 import at.asitplus.signum.indispensable.josef.JwsTyped.Companion.invoke
 import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
+import kotlinx.serialization.KSerializer
 import kotlinx.serialization.serializer
 
 typealias JwsCompactTyped<P> = JwsTyped<JwsCompact, P>
 typealias JwsFlattenedTyped<P> = JwsTyped<JwsFlattened, P>
 typealias JwsGeneralTyped<P> = JwsTyped<JwsGeneral, P>
 
+/**
+ * Convenience Serializer Template which only serializes [JwsTyped.jws]
+ */
+class JwsTypedSerializerTemplate<J : JWS, P>(
+    jwsSerializer: KSerializer<J>,
+    private val payloadSerializer: KSerializer<P>,
+) : TransformingSerializerTemplate<JwsTyped<J, P>, J>(
+    parent = jwsSerializer,
+    encodeAs = { it.jws },
+    decodeAs = { jws -> JwsTyped(jws, jws.getPayload(payloadSerializer).getOrThrow()) }
+)
 
 fun <P> JwsCompactTyped<P>.toJwsFlattenedTyped() = JwsFlattenedTyped(this.jws.toJwsFlattened(), this.payload)
 fun <P> JwsFlattenedTyped<P>.toJwsCompactTyped() = JwsCompactTyped(this.jws.toJwsCompact(), this.payload)
@@ -19,6 +32,7 @@ inline fun <J : JWS, reified P> J.typed(): JwsTyped<J, P> =
 /**
  * Wrapper for [at.asitplus.signum.indispensable.josef.JWS]. Useful when [payload] type is known as part of the contract.
  * All communication over the wire should use [jws] only!
+ * Serialization is not recommended but does work. See [JwsTypedSerializerTemplate]
  *
  * While the constructor can be used the different [invoke]s are recommended.
  * For convenience also see the typealiases

--- a/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsTyped.kt
+++ b/indispensable-josef/src/commonMain/kotlin/at/asitplus/signum/indispensable/josef/JwsTyped.kt
@@ -8,11 +8,12 @@ typealias JwsCompactTyped<P> = JwsTyped<JwsCompact, P>
 typealias JwsFlattenedTyped<P> = JwsTyped<JwsFlattened, P>
 typealias JwsGeneralTyped<P> = JwsTyped<JwsGeneral, P>
 
+
 fun <P> JwsCompactTyped<P>.toJwsFlattenedTyped() = JwsFlattenedTyped(this.jws.toJwsFlattened(), this.payload)
 fun <P> JwsFlattenedTyped<P>.toJwsCompactTyped() = JwsCompactTyped(this.jws.toJwsCompact(), this.payload)
 fun <P> JwsGeneralTyped<P>.toJwsFlattenedTyped() = this.jws.toJwsFlattened().map { JwsFlattenedTyped(it, this.payload) }
 
-inline fun <reified P, J : JWS> J.typed(): JwsTyped<J, P> =
+inline fun <J : JWS, reified P> J.typed(): JwsTyped<J, P> =
     JwsTyped(this, getPayload<P>().getOrThrow())
 
 /**

--- a/indispensable-josef/src/commonTest/kotlin/at/asitplus/signum/indispensable/josef/JwsTypedTest.kt
+++ b/indispensable-josef/src/commonTest/kotlin/at/asitplus/signum/indispensable/josef/JwsTypedTest.kt
@@ -63,6 +63,28 @@ val JwsTypedTest by testSuite {
         reparsedCompact shouldBe typedCompact
     }
 
+    "typed serializer template roundtrips compact JWS with typed payload" {
+        val serializer = JwsTypedSerializerTemplate(
+            JwsCompactStringSerializer,
+            JsonObject.serializer(),
+        )
+        val typedCompact: JwsCompactTyped<JsonObject> = JwsTyped(
+            protectedHeader = JwsHeader(
+                algorithm = JwsAlgorithm.Signature.RS256,
+                keyId = "kid-serializer",
+            ),
+            payload = payload,
+        ) {
+            byteArrayOf(5, 6, 7, 8)
+        }
+
+        val serialized = joseCompliantSerializer.encodeToString(serializer, typedCompact)
+        val reparsed = joseCompliantSerializer.decodeFromString(serializer, serialized)
+
+        reparsed shouldBe typedCompact
+        reparsed.payload shouldBe payload
+    }
+
     "flattened typed wrappers can be created from header fragments and existing flattened JWS" {
         val protectedHeader = JwsHeader.Part(
             algorithm = JwsAlgorithm.Signature.RS256,

--- a/indispensable-josef/src/commonTest/kotlin/at/asitplus/signum/indispensable/josef/JwsTypedTest.kt
+++ b/indispensable-josef/src/commonTest/kotlin/at/asitplus/signum/indispensable/josef/JwsTypedTest.kt
@@ -40,7 +40,7 @@ val JwsTypedTest by testSuite {
         capturedSignatureInput shouldBe JWS.getSignatureInput(expectedProtectedHeader, expectedPayload)
         typedCompact.toString() shouldBe typedCompact.jws.toString()
 
-        typedCompact.jws.typed<JsonObject, JwsCompact>() shouldBe typedCompact
+        typedCompact.jws.typed<JwsCompact, JsonObject>() shouldBe typedCompact
         JwsTyped<JsonObject>(typedCompact.toString()) shouldBe typedCompact
     }
 
@@ -91,7 +91,7 @@ val JwsTypedTest by testSuite {
         capturedSignatureInput shouldBe JWS.getSignatureInput(expectedProtectedHeader, expectedPayload)
         typedFlattened.toString() shouldBe typedFlattened.jws.toString()
 
-        typedFlattened.jws.typed<JsonObject, JwsFlattened>() shouldBe typedFlattened
+        typedFlattened.jws.typed<JwsFlattened, JsonObject>() shouldBe typedFlattened
     }
 
     "general typed wrappers can be assembled from flattened signatures and expanded again" {
@@ -123,6 +123,6 @@ val JwsTypedTest by testSuite {
         typedGeneral.toString() shouldBe typedGeneral.jws.toString()
         typedGeneral.toJwsFlattenedTyped() shouldBe listOf(first, second)
 
-        typedGeneral.jws.typed<JsonObject, JwsGeneral>() shouldBe typedGeneral
+        typedGeneral.jws.typed<JwsGeneral, JsonObject>() shouldBe typedGeneral
     }
 }


### PR DESCRIPTION
The desire-path strikes again.

Thin serializer template that goes through JwsTyped to the over-the-wire format JWS for correct serialization. Might actually be more performant than normal usage because types and serializers need to be known at compile time? (P no longer reified)


Edit: I am very sorry for the generics re-ordering