### PR TITLE
Expose iOS authentication timeout

### DIFF
--- a/supreme/src/iosMain/kotlin/at/asitplus/signum/supreme/os/IosKeychainProvider.kt
+++ b/supreme/src/iosMain/kotlin/at/asitplus/signum/supreme/os/IosKeychainProvider.kt
@@ -130,8 +130,24 @@ sealed class IosSigner(final override val alias: String,
     override suspend fun exportPrivateKey(): KmmResult<Nothing> = KmmResult.failure(IllegalStateException("Non-Exportable key"))
 
     override val mayRequireUserUnlock get() = needsAuthentication
-    val needsAuthentication get() = metadata.needsUnlock
-    val needsAuthenticationForEveryUse get() = metadata.needsUnlock && (metadata.unlockTimeout == Duration.ZERO)
+
+    /** Whether this key requires user authentication before use. */
+    val needsAuthentication get() = authenticationTimeout != null
+
+    /** Whether this key requires a fresh user authentication for every use. */
+    val needsAuthenticationForEveryUse get() = authenticationTimeout == Duration.ZERO
+
+    /**
+     * The effective Signum reuse window for successful user authentication.
+     *
+     * `null` means that the key does not require user authentication, [Duration.ZERO] means that every use requires
+     * authentication, and a positive duration is the time for which Signum may reuse authentication in the provider
+     * process.
+     *
+     * This value is restored from Signum's stored key metadata. It is not an independent readback of an iOS Keychain
+     * access-control attribute.
+     */
+    val authenticationTimeout: Duration? get() = metadata.authenticationTimeout
     override val attestation get() = metadata.attestation
 
     internal interface PrivateKeyManager { fun get(signingConfig: IosSignerSigningConfiguration): AutofreeVariable<SecKeyRef> }
@@ -344,6 +360,7 @@ internal data class IosKeyMetadata(
     init {
         require(!(allowSigning && allowEncryption)) //TODO is this really always illegal?
     }
+    val authenticationTimeout inline get() = rawUnlockTimeout
     val needsUnlock inline get() = (rawUnlockTimeout != null)
     val unlockTimeout inline get() = rawUnlockTimeout ?: Duration.INFINITE
 }

--- a/supreme/src/iosTest/kotlin/at/asitplus/signum/supreme/os/IosKeychainProviderTest.kt
+++ b/supreme/src/iosTest/kotlin/at/asitplus/signum/supreme/os/IosKeychainProviderTest.kt
@@ -1,13 +1,45 @@
 package at.asitplus.signum.supreme.os
 
 import at.asitplus.shouldSucceed
+import at.asitplus.signum.indispensable.CryptoPublicKey
+import at.asitplus.signum.indispensable.Digest
+import at.asitplus.signum.indispensable.ECCurve
 import at.asitplus.signum.supreme.azString
-import at.asitplus.testballoon.matrix.matrixSuite
+import at.asitplus.testballoon.matrix.*
 import io.kotest.matchers.shouldBe
+import kotlinx.serialization.json.Json
 import kotlin.random.Random
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
 
 
 val IosKeychainProviderTest by matrixSuite {
+    "Authentication timeout readback" - {
+        data(
+            listOf(null, Duration.ZERO, 10.seconds),
+            nameFn = { it?.toString() ?: "no authentication" },
+        ) test { authenticationTimeout ->
+            val metadata = IosKeyMetadata(
+                attestation = null,
+                rawUnlockTimeout = authenticationTimeout,
+                algSpecific = IosKeyAlgSpecificMetadata.ECDSA(setOf(Digest.SHA256)),
+            ).let { Json.decodeFromString<IosKeyMetadata>(Json.encodeToString(it)) }
+            val publicKey = with(CryptoPublicKey.EC) {
+                ECCurve.SECP_256_R_1.generator.asPublicKey()
+            }
+            val signer = IosSigner.ECDSA(
+                alias = "restored-key",
+                publicKey = publicKey,
+                metadata = metadata,
+                config = IosSignerConfiguration(),
+            )
+
+            signer.authenticationTimeout shouldBe authenticationTimeout
+            signer.needsAuthentication shouldBe (authenticationTimeout != null)
+            signer.needsAuthenticationForEveryUse shouldBe (authenticationTimeout == Duration.ZERO)
+        }
+    }
+
     "Creating a key with an alias that already exists" - {
 
         "fails but leaves the existing key untouched when the new config is broken" {


### PR DESCRIPTION
## Summary

Expose `IosSigner.authenticationTimeout` so callers can distinguish keys that require no authentication, authentication for every use, or authentication with a positive reuse window—even after signer restoration.

The value comes from Signum's stored key metadata. It does not change authentication enforcement or caching and does not claim independent iOS Keychain access-control readback. The existing authentication booleans now derive from the same property.

Closes #472.

## Tests

- `:supreme:iosSimulatorArm64Test`
- `:supreme:compileKotlinIosArm64`
