### PR TITLE
Implement cancellation handling for signing operations in Android, iOS key and JVM providers

### DIFF
--- a/supreme/src/androidMain/kotlin/at/asitplus/signum/supreme/os/AndroidKeyStoreProvider.kt
+++ b/supreme/src/androidMain/kotlin/at/asitplus/signum/supreme/os/AndroidKeyStoreProvider.kt
@@ -39,6 +39,7 @@ import at.asitplus.signum.supreme.sign.Signer as SignerI
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.asCoroutineDispatcher
+import kotlin.coroutines.resumeWithException
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext

--- a/supreme/src/androidMain/kotlin/at/asitplus/signum/supreme/os/AndroidKeyStoreProvider.kt
+++ b/supreme/src/androidMain/kotlin/at/asitplus/signum/supreme/os/AndroidKeyStoreProvider.kt
@@ -39,8 +39,8 @@ import at.asitplus.signum.supreme.sign.Signer as SignerI
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.asCoroutineDispatcher
-import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
 import java.security.KeyFactory
 import java.security.KeyPairGenerator
@@ -303,13 +303,7 @@ sealed class AndroidKeystoreSigner private constructor(
 
     final override val mayRequireUserUnlock: Boolean get() = this.needsAuthentication
 
-    private sealed interface AuthResult {
-        @JvmInline value class Success(val result: AuthenticationResult): AuthResult
-        data class Error(val code: Int, val message: String): AuthResult
-    }
-
     protected suspend fun attemptBiometry(config: DSL.ConfigStack<AndroidUnlockPromptConfiguration>, forSpecificKey: CryptoObject?) {
-        val channel = Channel<AuthResult>(capacity = Channel.RENDEZVOUS)
         val effectiveContext = config.getProperty(AndroidUnlockPromptConfiguration::explicitContext,
             checker = AndroidUnlockPromptConfiguration::hasExplicitContext, default = {
                 (AppLifecycleMonitor.currentActivity as? FragmentActivity)?.let(FragmentContext::OfActivity)
@@ -320,43 +314,41 @@ sealed class AndroidKeystoreSigner private constructor(
             is FragmentContext.OfActivity -> ContextCompat.getMainExecutor(effectiveContext.activity)
             is FragmentContext.OfFragment -> ContextCompat.getMainExecutor(effectiveContext.fragment.context)
         }
-        executor.asCoroutineDispatcher().let(::CoroutineScope).launch {
-            val promptInfo = BiometricPrompt.PromptInfo.Builder().apply {
-                setTitle(config.getProperty(AndroidUnlockPromptConfiguration::_message,
-                    default = UnlockPromptConfiguration.defaultMessage))
-                setNegativeButtonText(config.getProperty(AndroidUnlockPromptConfiguration::_cancelText,
-                    default = UnlockPromptConfiguration.defaultCancelText))
-                config.getProperty(AndroidUnlockPromptConfiguration::_subtitle,null)?.let(this::setSubtitle)
-                config.getProperty(AndroidUnlockPromptConfiguration::_description,null)?.let(this::setDescription)
-                config.getProperty(AndroidUnlockPromptConfiguration::_allowedAuthenticators,null)?.let(this::setAllowedAuthenticators)
-                config.getProperty(AndroidUnlockPromptConfiguration::_confirmationRequired,null)?.let(this::setConfirmationRequired)
-            }.build()
-            val siphon = object: BiometricPrompt.AuthenticationCallback() {
-                private fun send(v: AuthResult) {
-                    executor.asCoroutineDispatcher().let(::CoroutineScope).launch { channel.send(v) }
+        suspendCancellableCoroutine { cont ->
+            executor.asCoroutineDispatcher().let(::CoroutineScope).launch {
+                val promptInfo = BiometricPrompt.PromptInfo.Builder().apply {
+                    setTitle(config.getProperty(AndroidUnlockPromptConfiguration::_message,
+                        default = UnlockPromptConfiguration.defaultMessage))
+                    setNegativeButtonText(config.getProperty(AndroidUnlockPromptConfiguration::_cancelText,
+                        default = UnlockPromptConfiguration.defaultCancelText))
+                    config.getProperty(AndroidUnlockPromptConfiguration::_subtitle,null)?.let(this::setSubtitle)
+                    config.getProperty(AndroidUnlockPromptConfiguration::_description,null)?.let(this::setDescription)
+                    config.getProperty(AndroidUnlockPromptConfiguration::_allowedAuthenticators,null)?.let(this::setAllowedAuthenticators)
+                    config.getProperty(AndroidUnlockPromptConfiguration::_confirmationRequired,null)?.let(this::setConfirmationRequired)
+                }.build()
+                val siphon = object: BiometricPrompt.AuthenticationCallback() {
+                    override fun onAuthenticationSucceeded(result: AuthenticationResult) {
+                        if (cont.isActive) cont.resume(Unit) {}
+                    }
+                    override fun onAuthenticationError(errorCode: Int, errString: CharSequence) {
+                        if (cont.isActive) cont.resumeWithException(UnlockFailed("$errString (code $errorCode)"))
+                    }
+                    override fun onAuthenticationFailed() {
+                        config.forEach { it.invalidBiometryCallback?.invoke() }
+                    }
                 }
-                override fun onAuthenticationSucceeded(result: AuthenticationResult) {
-                    send(AuthResult.Success(result))
+                val prompt = when (effectiveContext) {
+                    is FragmentContext.OfActivity -> BiometricPrompt(effectiveContext.activity, executor, siphon)
+                    is FragmentContext.OfFragment -> BiometricPrompt(effectiveContext.fragment, executor, siphon)
                 }
-                override fun onAuthenticationError(errorCode: Int, errString: CharSequence) {
-                    send(AuthResult.Error(errorCode, errString.toString()))
+                cont.invokeOnCancellation {
+                    prompt.cancelAuthentication()
                 }
-                override fun onAuthenticationFailed() {
-                    config.forEach { it.invalidBiometryCallback?.invoke() }
+                when (forSpecificKey) {
+                    null -> prompt.authenticate(promptInfo)
+                    else -> prompt.authenticate(promptInfo, forSpecificKey)
                 }
             }
-            val prompt = when (effectiveContext) {
-                is FragmentContext.OfActivity -> BiometricPrompt(effectiveContext.activity, executor, siphon)
-                is FragmentContext.OfFragment -> BiometricPrompt(effectiveContext.fragment, executor, siphon)
-            }
-            when (forSpecificKey) {
-                null -> prompt.authenticate(promptInfo)
-                else -> prompt.authenticate(promptInfo, forSpecificKey)
-            }
-        }
-        when (val result = channel.receive()) {
-            is AuthResult.Success -> return
-            is AuthResult.Error -> throw UnlockFailed("${result.message} (code ${result.code})")
         }
     }
 

--- a/supreme/src/commonMain/kotlin/at/asitplus/signum/supreme/SignatureResult.kt
+++ b/supreme/src/commonMain/kotlin/at/asitplus/signum/supreme/SignatureResult.kt
@@ -3,7 +3,9 @@ package at.asitplus.signum.supreme
 import at.asitplus.KmmResult
 import at.asitplus.catching
 import at.asitplus.signum.indispensable.CryptoSignature
+import kotlin.coroutines.coroutineContext
 import kotlin.jvm.JvmInline
+import kotlinx.coroutines.ensureActive
 
 /** These map to SignatureResult.Failure instead of SignatureResult.Error */
 sealed class UserInitiatedCancellationReason(message: String?, cause: Throwable?): Throwable(message, cause)
@@ -56,8 +58,15 @@ inline fun <T: CryptoSignature.RawByteEncodable, S: CryptoSignature.RawByteEncod
         onFailure = { SignatureResult.FromException(it) })
 
 /** Runs the block, catches exceptions, and maps to [SignatureResult].
+ * Respects coroutine cancellation: checks [ensureActive] before executing and
+ * re-throws [CancellationException] so that structured concurrency is preserved.
  * @see SignatureResult.FromException */
-internal inline fun signCatching(fn: ()->CryptoSignature.RawByteEncodable): SignatureResult<*> =
-    catching { fn() }.fold(
+internal suspend inline fun signCatching(fn: ()->CryptoSignature.RawByteEncodable): SignatureResult<*> {
+    coroutineContext.ensureActive()
+    return catching { fn() }.fold(
         onSuccess = { SignatureResult.Success(it) },
-        onFailure = { SignatureResult.FromException(it) })
+        onFailure = {
+            coroutineContext.ensureActive()
+            SignatureResult.FromException(it)
+        })
+}

--- a/supreme/src/commonMain/kotlin/at/asitplus/signum/supreme/SignatureResult.kt
+++ b/supreme/src/commonMain/kotlin/at/asitplus/signum/supreme/SignatureResult.kt
@@ -62,7 +62,7 @@ inline fun <T: CryptoSignature.RawByteEncodable, S: CryptoSignature.RawByteEncod
  * Respects coroutine cancellation: checks [ensureActive] before executing and
  * re-throws [CancellationException] so that structured concurrency is preserved.
  * @see SignatureResult.FromException */
-internal suspend inline fun signCatching(fn: suspend ()->CryptoSignature.RawByteEncodable): SignatureResult<*> {
+internal suspend inline fun signCatching(fn: ()->CryptoSignature.RawByteEncodable): SignatureResult<*> {
     coroutineContext.ensureActive()
     return try {
         val result = fn()

--- a/supreme/src/commonMain/kotlin/at/asitplus/signum/supreme/SignatureResult.kt
+++ b/supreme/src/commonMain/kotlin/at/asitplus/signum/supreme/SignatureResult.kt
@@ -5,6 +5,7 @@ import at.asitplus.catching
 import at.asitplus.signum.indispensable.CryptoSignature
 import kotlin.coroutines.coroutineContext
 import kotlin.jvm.JvmInline
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.ensureActive
 
 /** These map to SignatureResult.Failure instead of SignatureResult.Error */
@@ -61,12 +62,16 @@ inline fun <T: CryptoSignature.RawByteEncodable, S: CryptoSignature.RawByteEncod
  * Respects coroutine cancellation: checks [ensureActive] before executing and
  * re-throws [CancellationException] so that structured concurrency is preserved.
  * @see SignatureResult.FromException */
-internal suspend inline fun signCatching(fn: ()->CryptoSignature.RawByteEncodable): SignatureResult<*> {
+internal suspend inline fun signCatching(fn: suspend ()->CryptoSignature.RawByteEncodable): SignatureResult<*> {
     coroutineContext.ensureActive()
-    return catching { fn() }.fold(
-        onSuccess = { SignatureResult.Success(it) },
-        onFailure = {
-            coroutineContext.ensureActive()
-            SignatureResult.FromException(it)
-        })
+    return try {
+        val result = fn()
+        coroutineContext.ensureActive()
+        SignatureResult.Success(result)
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Throwable) {
+        coroutineContext.ensureActive()
+        SignatureResult.FromException(e)
+    }
 }

--- a/supreme/src/commonTest/kotlin/at/asitplus/signum/supreme/sign/SignCancellationTests.kt
+++ b/supreme/src/commonTest/kotlin/at/asitplus/signum/supreme/sign/SignCancellationTests.kt
@@ -9,7 +9,6 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeout
 import kotlin.random.Random
 
@@ -27,10 +26,8 @@ val SignCancellationTests by matrixSuite {
         val data = Random.Default.nextBytes(64)
         shouldThrow<CancellationException> {
             coroutineScope {
-                launch {
-                    cancel()
-                    signer.sign(data)
-                }
+                cancel()
+                signer.sign(data)
             }
         }
     }

--- a/supreme/src/commonTest/kotlin/at/asitplus/signum/supreme/sign/SignCancellationTests.kt
+++ b/supreme/src/commonTest/kotlin/at/asitplus/signum/supreme/sign/SignCancellationTests.kt
@@ -1,0 +1,58 @@
+package at.asitplus.signum.supreme.sign
+
+import at.asitplus.signum.supreme.isSuccess
+import at.asitplus.signum.supreme.signature
+import at.asitplus.testballoon.matrix.matrixSuite
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeout
+import kotlin.random.Random
+
+val SignCancellationTests by matrixSuite {
+
+    "sign completes normally without cancellation" {
+        val signer = Signer.Ephemeral {}.getOrThrow()
+        val data = Random.Default.nextBytes(64)
+        val result = signer.sign(data)
+        result.isSuccess shouldBe true
+    }
+
+    "sign respects coroutine cancellation" {
+        val signer = Signer.Ephemeral {}.getOrThrow()
+        val data = Random.Default.nextBytes(64)
+        shouldThrow<CancellationException> {
+            coroutineScope {
+                launch {
+                    cancel()
+                    signer.sign(data)
+                }
+            }
+        }
+    }
+
+    "sign works within withTimeout" {
+        val signer = Signer.Ephemeral {}.getOrThrow()
+        val data = Random.Default.nextBytes(64)
+        val result = withTimeout(5000) {
+            signer.sign(data)
+        }
+        result.isSuccess shouldBe true
+    }
+
+    "sign propagates CancellationException instead of wrapping it" {
+        val signer = Signer.Ephemeral {}.getOrThrow()
+        val data = Random.Default.nextBytes(64)
+        val parentJob = Job()
+        parentJob.cancel()
+        shouldThrow<CancellationException> {
+            kotlinx.coroutines.withContext(parentJob) {
+                signer.sign(data)
+            }
+        }
+    }
+}

--- a/supreme/src/iosMain/kotlin/at/asitplus/signum/supreme/os/IosKeychainProvider.kt
+++ b/supreme/src/iosMain/kotlin/at/asitplus/signum/supreme/os/IosKeychainProvider.kt
@@ -18,7 +18,9 @@ import kotlinx.cinterop.*
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.withContext
+import kotlin.coroutines.coroutineContext
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
@@ -134,6 +136,13 @@ sealed class IosSigner(final override val alias: String,
     val needsAuthenticationForEveryUse get() = metadata.needsUnlock && (metadata.unlockTimeout == Duration.ZERO)
     override val attestation get() = metadata.attestation
 
+    /** Tracks the active [LAContext] during biometric authentication for cancellation support. */
+    internal var activeLAContext: LAContext? = null
+
+    internal fun cancelAuthentication() {
+        activeLAContext?.invalidate()
+    }
+
     internal interface PrivateKeyManager { fun get(signingConfig: IosSignerSigningConfiguration): AutofreeVariable<SecKeyRef> }
     internal val privateKeyManager = object : PrivateKeyManager {
         private var storedKey: AutofreeVariable<SecKeyRef>? = null
@@ -165,6 +174,7 @@ sealed class IosSigner(final override val alias: String,
                     localizedCancelTitle = stack.getProperty(UnlockPromptConfiguration::_cancelText,
                         default = UnlockPromptConfiguration.defaultCancelText)
                 }
+                activeLAContext = ctx
             } else {
                 recordable = false
                 ctx = null
@@ -225,6 +235,7 @@ sealed class IosSigner(final override val alias: String,
                     authnContext = ctx, authnTime = TimeSource.Monotonic.markNow())
                 Napier.v { "Successfully recorded LAContext for future re-use" }
             }
+            activeLAContext = null
             if (!needsAuthenticationForEveryUse) {
                 storedKey = newPrivateKey
             }
@@ -232,39 +243,59 @@ sealed class IosSigner(final override val alias: String,
         }
     }
 
-    final override suspend fun trySetupUninterruptedSigning(configure: DSLConfigureFn<IosSignerSigningConfiguration>): KmmResult<Unit> =
-    withContext(dispatcher) { catching {
-        if (needsAuthentication && !needsAuthenticationForEveryUse) {
-            val config = DSL.resolve(::IosSignerSigningConfiguration, configure)
-            privateKeyManager.get(config)
+    final override suspend fun trySetupUninterruptedSigning(configure: DSLConfigureFn<IosSignerSigningConfiguration>): KmmResult<Unit> {
+        val cancellationHandle = if (needsAuthentication) {
+            coroutineContext[Job]?.invokeOnCompletion { cause ->
+                if (cause != null) cancelAuthentication()
+            }
+        } else null
+        return try {
+            withContext(dispatcher) { catching {
+                if (needsAuthentication && !needsAuthenticationForEveryUse) {
+                    val config = DSL.resolve(::IosSignerSigningConfiguration, configure)
+                    privateKeyManager.get(config)
+                }
+            } }
+        } finally {
+            cancellationHandle?.dispose()
         }
-    } }
+    }
 
     protected abstract fun bytesToSignature(sigBytes: ByteArray): CryptoSignature.RawByteEncodable
-    final override suspend fun sign(data: SignatureInput, configure: DSLConfigureFn<IosSignerSigningConfiguration>): SignatureResult<*> =
-    withContext(dispatcher) { signCatching {
-        require(data.format == null) { "Pre-hashed data is unsupported on iOS" }
-        require(metadata.allowSigning) { "Signing key purpose not set! Signing disallowed!" }
-        val signingConfig = DSL.resolve(::IosSignerSigningConfiguration, configure)
-        val algorithm = signatureAlgorithm.secKeyAlgorithmPreHashed
-        val plaintext = data.convertTo(signatureAlgorithm.preHashedSignatureFormat).getOrThrow().data.first().toNSData()
-        val signatureBytes = try {
-            corecall {
-                SecKeyCreateSignature(privateKeyManager.get(signingConfig).value, algorithm, plaintext.let(::giveToCF), error)
-            }.takeFromCF<NSData>().toByteArray()
-        } catch (x: CoreFoundationException) { /* secure enclave failure */
-            if (x.nsError.domain == LAErrorDomain) when (x.nsError.code) {
-                LAErrorUserCancel, LAErrorAuthenticationFailed, LAErrorBiometryLockout -> throw UnlockFailed(x.nsError.localizedDescription, x)
-                else -> throw x
-            } else throw x
-        } catch (x: CFCryptoOperationFailed) { /* keychain failure */
-            when (x.osStatus) {
-                errSecUserCanceled, errSecAuthFailed -> throw UnlockFailed(x.message, x)
-                else -> throw x
+    final override suspend fun sign(data: SignatureInput, configure: DSLConfigureFn<IosSignerSigningConfiguration>): SignatureResult<*> {
+        val cancellationHandle = if (needsAuthentication) {
+            coroutineContext[Job]?.invokeOnCompletion { cause ->
+                if (cause != null) cancelAuthentication()
             }
+        } else null
+        return try {
+            withContext(dispatcher) { signCatching {
+                require(data.format == null) { "Pre-hashed data is unsupported on iOS" }
+                require(metadata.allowSigning) { "Signing key purpose not set! Signing disallowed!" }
+                val signingConfig = DSL.resolve(::IosSignerSigningConfiguration, configure)
+                val algorithm = signatureAlgorithm.secKeyAlgorithmPreHashed
+                val plaintext = data.convertTo(signatureAlgorithm.preHashedSignatureFormat).getOrThrow().data.first().toNSData()
+                val signatureBytes = try {
+                    corecall {
+                        SecKeyCreateSignature(privateKeyManager.get(signingConfig).value, algorithm, plaintext.let(::giveToCF), error)
+                    }.takeFromCF<NSData>().toByteArray()
+                } catch (x: CoreFoundationException) { /* secure enclave failure */
+                    if (x.nsError.domain == LAErrorDomain) when (x.nsError.code) {
+                        LAErrorUserCancel, LAErrorAuthenticationFailed, LAErrorBiometryLockout -> throw UnlockFailed(x.nsError.localizedDescription, x)
+                        else -> throw x
+                    } else throw x
+                } catch (x: CFCryptoOperationFailed) { /* keychain failure */
+                    when (x.osStatus) {
+                        errSecUserCanceled, errSecAuthFailed -> throw UnlockFailed(x.message, x)
+                        else -> throw x
+                    }
+                }
+                return@signCatching bytesToSignature(signatureBytes)
+            }}
+        } finally {
+            cancellationHandle?.dispose()
         }
-        return@signCatching bytesToSignature(signatureBytes)
-    }}
+    }
 
     class ECDSA internal constructor
         (alias: String, override val publicKey: CryptoPublicKey.EC, metadata: IosKeyMetadata, config: IosSignerConfiguration)
@@ -289,10 +320,21 @@ sealed class IosSigner(final override val alias: String,
         final override suspend fun keyAgreement(
             publicValue: KeyAgreementPublicValue.ECDH,
             configure: DSLConfigureFn<IosSignerSigningConfiguration>
-        ) = catching {
-            require(metadata.allowKeyAgreement) { "Key agreement purpose not set! Key agreement disallowed!" }
-            val config = DSL.resolve(::IosSignerSigningConfiguration, configure)
-            performKeyAgreement(privateKeyManager.get(config).value, publicValue)
+        ): KmmResult<ByteArray> {
+            val cancellationHandle = if (needsAuthentication) {
+                coroutineContext[Job]?.invokeOnCompletion { cause ->
+                    if (cause != null) cancelAuthentication()
+                }
+            } else null
+            return try {
+                catching {
+                    require(metadata.allowKeyAgreement) { "Key agreement purpose not set! Key agreement disallowed!" }
+                    val config = DSL.resolve(::IosSignerSigningConfiguration, configure)
+                    performKeyAgreement(privateKeyManager.get(config).value, publicValue)
+                }
+            } finally {
+                cancellationHandle?.dispose()
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Adds coroutine cancellation support to signing operations across Android and iOS.
* Propagates coroutine cancellation instead of wrapping it as a signing error.
* Cancels active biometric authentication when the coroutine is cancelled.
* Adds tests covering cancellation and timeout scenarios.


(This PR has been assisted by AI)

## Reasoning

The old implementation did not allow an application to cancel a `.sign()` call when it involved **biometric authentication**.

Depending on the use case and the device, it can be useful to cancel the suspended function for example, when a timeout is reached or the user navigates away from the current screen.

## Example

The signing operation can now be cancelled using the standard coroutine timeout mechanism:

```kotlin
val result = withTimeout(5.seconds) {
    signer.sign(data)
}
```

It can also be wrapped in a `Flow` and combined with the existing `timeout` operator:

```kotlin
flow {
    emit(signer.sign(data))
}
    .timeout(5.seconds)
    .collect { result ->
        // Handle signature result
    }
```
